### PR TITLE
fix incorrectly formatted JSON

### DIFF
--- a/Northstar.Client/mod.json
+++ b/Northstar.Client/mod.json
@@ -25,14 +25,13 @@
 			"DefaultValue": "0"
 		}
 	],
-	// ui inits need to happen before so our init callbacks get called
 	"Scripts": [
 		{
 			"Path": "ui/menu_ns_modmenu.nut",
 			"RunOn": "UI",
 			"UICallback": {
 				"Before": "AddNorthstarModMenu", 
-				"After": "AddNorthstarModMenu_MainMenuFooter" // need to do this after, so we add footer after mainmenu init
+				"After": "AddNorthstarModMenu_MainMenuFooter"
 			}
 		},
 		

--- a/Northstar.Coop/mod.json
+++ b/Northstar.Coop/mod.json
@@ -20,6 +20,6 @@
 			"ServerCallback": {
 				"After": "SingleplayerCoopLobby_Init"
 			}
-		},
-	],
+		}
+	]
 }

--- a/Northstar.Custom/mod.json
+++ b/Northstar.Custom/mod.json
@@ -38,10 +38,9 @@
 		
 		{
 			"Path": "weapons/mp_weapon_peacekraber.nut",
-			"RunOn": "( CLIENT || SERVER ) && MP",
+			"RunOn": "( CLIENT || SERVER ) && MP"
 		},
 		
-		// fortwar
 		{
 			"Path": "gamemodes/sh_gamemode_fw_custom.nut",
 			"RunOn": "( CLIENT || SERVER ) && MP",
@@ -62,7 +61,6 @@
 			"RunOn": "CLIENT && MP"
 		},
 		
-		// gungame
 		{
 			"Path": "gamemodes/sh_gamemode_gg.gnut",
 			"RunOn": "( CLIENT || SERVER ) && MP",
@@ -83,7 +81,6 @@
 			"RunOn": "CLIENT && MP"
 		},
 		
-		// titan tag
 		{
 			"Path": "gamemodes/sh_gamemode_tt.gnut",
 			"RunOn": "( CLIENT || SERVER ) && MP",
@@ -104,12 +101,11 @@
 			"RunOn": "CLIENT && MP"
 		},
 		
-		// infection
 		{
 			"Path": "gamemodes/sh_gamemode_inf.gnut",
 			"RunOn": "( CLIENT || SERVER ) && MP",
 			"ClientCallback": {
-				"Before": "Sh_GamemodeInfection_Init",
+				"Before": "Sh_GamemodeInfection_Init"
 			},
 			
 			"ServerCallback": {
@@ -125,7 +121,6 @@
 			"RunOn": "CLIENT && MP"
 		},
 		
-		// arena
 		{
 			"Path": "_droppod_spawn.gnut",
 			"RunOn": "SERVER && MP",
@@ -169,7 +164,6 @@
 			"RunOn": "CLIENT && MP"
 		},
 		
-		// amped killrace
 		{
 			"Path": "gamemodes/sh_gamemode_kr.gnut",
 			"RunOn": "( CLIENT || SERVER ) && MP",
@@ -190,7 +184,6 @@
 			"RunOn": "CLIENT && MP"
 		},
 		
-		// fastball
 		{
 			"Path": "gamemodes/sh_gamemode_fastball.gnut",
 			"RunOn": "( CLIENT || SERVER ) && MP",
@@ -215,7 +208,6 @@
 			"RunOn": "CLIENT && MP"
 		},
 		
-		// hide and seek
 		{
 			"Path": "gamemodes/sh_gamemode_hs.gnut",
 			"RunOn": "( CLIENT || SERVER ) && MP",
@@ -236,7 +228,6 @@
 			"RunOn": "CLIENT && MP"
 		},
 		
-		// ctf comp
 		{
 			"Path": "gamemodes/sh_gamemode_ctf_comp.gnut",
 			"RunOn": "( CLIENT || SERVER ) && MP",
@@ -263,7 +254,6 @@
 			}
 		},
 		
-		// riffs, playlist vars etc
 		{
 			"Path": "gamemodes/sh_riff_instagib.gnut",
 			"RunOn": "( CLIENT || SERVER ) && MP",
@@ -347,7 +337,6 @@
 		}
 	],
 	
-	// todo this bit of the format
 	"Maps": [
 		{
 			"Name": "mp_skyway_v1",

--- a/Northstar.CustomServers/mod.json
+++ b/Northstar.CustomServers/mod.json
@@ -116,7 +116,7 @@
 		
 		{
 			"Path": "lobby/sh_private_lobby_modes_init.gnut",
-			"RunOn": "( SERVER || CLIENT ) && MP",
+			"RunOn": "( SERVER || CLIENT ) && MP"
 		}
 	]
 }

--- a/Northstar.CustomServers/mod.json
+++ b/Northstar.CustomServers/mod.json
@@ -13,7 +13,7 @@
 		{
 			"Name": "ns_is_modded_server",
 			"DefaultValue": "1",
-			"Flags": 8192 // FCVAR_REPLICATED
+			"Flags": 8192
 		},
 		
 		{
@@ -60,20 +60,20 @@
 	"Scripts": [
 		{
 			"Path": "_misc_stubs.gnut",
-			"RunOn": "SERVER && MP",
+			"RunOn": "SERVER && MP"
 		},
 		{
 			"Path": "_store.gnut",
-			"RunOn": "SERVER && MP",
+			"RunOn": "SERVER && MP"
 		},
 		{
 			"Path": "_script_movers.gnut",
-			"RunOn": "SERVER && MP",
+			"RunOn": "SERVER && MP"
 		},
 		
 		{
 			"Path": "sh_northstar_utils.gnut",
-			"RunOn": "CLIENT || SERVER || UI",
+			"RunOn": "CLIENT || SERVER || UI"
 		},
 		
 		{
@@ -99,7 +99,7 @@
 		
 		{
 			"Path": "mp/_classic_mp_dropship_intro.gnut",
-			"RunOn": "SERVER && MP",
+			"RunOn": "SERVER && MP"
 		},
 		{
 			"Path": "mp/_classic_mp_no_intro.gnut",
@@ -117,6 +117,6 @@
 		{
 			"Path": "lobby/sh_private_lobby_modes_init.gnut",
 			"RunOn": "( SERVER || CLIENT ) && MP",
-		},
+		}
 	]
 }


### PR DESCRIPTION
Having the JSON not being properly formatted makes parsing it a pain. Comments aren't natively supported in JSON, instead using an extra `"comment": "<comment>"` is recommended (I don't think this is a good thing but that's the spec)

JSON also doesn't allow commas on the last element in an Array or Object. Not following that spec can cause (and has caused) errors for parsers.