### PR TITLE
fix end of game replay perspective and repsawns during replays in infection

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
@@ -30,7 +30,7 @@ void function InfectionInitPlayer( entity player )
 	if ( GetGameState() < eGameState.Playing )
 		SetTeam( player, INFECTION_TEAM_SURVIVOR )
 	else
-		InfectPlayer( player )
+		InfectPlayer( player, player )
 }
 
 void function SelectFirstInfected()
@@ -45,23 +45,23 @@ void function SelectFirstInfectedDelayed()
 	array<entity> players = GetPlayerArray()
 	entity infected = players[ RandomInt( players.len() ) ]
 	
-	InfectPlayer( infected )
+	InfectPlayer( infected, infected )
 	RespawnInfected( infected )
 }
 
 void function InfectionOnPlayerKilled( entity victim, entity attacker, var damageInfo )
 {
-	if ( !victim.IsPlayer() || GetGameState() != eGameState.Playing )
+	if ( !victim.IsPlayer() || !attacker.IsPlayer() || GetGameState() != eGameState.Playing )
 		return
 		
 	if ( victim.GetTeam() == INFECTION_TEAM_SURVIVOR )
-		InfectPlayer( victim )
+		InfectPlayer( victim, attacker )
 	
 	if ( attacker.IsPlayer() )
 		attacker.SetPlayerGameStat( PGS_ASSAULT_SCORE, attacker.GetPlayerGameStat( PGS_ASSAULT_SCORE ) + 1 )
 }
 
-void function InfectPlayer( entity player )
+void function InfectPlayer( entity player, entity attacker )
 {
 	SetTeam( player, INFECTION_TEAM_INFECTED )
 	player.SetPlayerGameStat( PGS_ASSAULT_SCORE, 0 ) // reset kills
@@ -70,7 +70,12 @@ void function InfectPlayer( entity player )
 	// check how many survivors there are
 	array<entity> survivors = GetPlayerArrayOfTeam( INFECTION_TEAM_SURVIVOR )
 	if ( survivors.len() == 0 )
+	{
+		SetRespawnsEnabled( false )
+		SetKillcamsEnabled( false )
+		SetRoundWinningKillReplayAttacker(attacker)
 		SetWinner( INFECTION_TEAM_INFECTED )
+	}
 	else if ( survivors.len() == 1 && !file.hasHadLastInfection )
 		SetLastSurvivor( survivors[ 0 ] )
 		
@@ -183,8 +188,14 @@ void function SetLastSurvivor( entity player )
 
 int function TimeoutCheckSurvivors()
 {
-	if ( GetPlayerArrayOfTeam( INFECTION_TEAM_SURVIVOR ).len() > 0 )
+	array<entity> survivors = GetPlayerArrayOfTeam( INFECTION_TEAM_SURVIVOR )
+	if ( survivors.len() > 0 )
+	{
+		SetRespawnsEnabled( false )
+		SetKillcamsEnabled( false )
+		SetRoundWinningKillReplayAttacker(survivors[ 0 ])
 		return INFECTION_TEAM_SURVIVOR
+	}
 		
 	return INFECTION_TEAM_INFECTED
 }


### PR DESCRIPTION
properly sets the end of game replay to use the appropriate player, and prevents respawns during end of game replays. Addresses part of #33.