### PR TITLE
fix end of game replay perspective in gun game

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
@@ -64,6 +64,10 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 			AddTeamScore( attacker.GetTeam(), 1 )
 			attacker.AddToPlayerGameStat( PGS_ASSAULT_SCORE, 1 )
 			UpdateLoadout( attacker )
+
+			//last kill of the match (usually the winning kill) will be the replay, prevents
+			//black screen if the game ends in a draw			
+			SetRoundWinningKillReplayAttacker(attacker)
 		}
 		
 		if ( DamageInfo_GetDamageSourceIdentifier( damageInfo ) == eDamageSourceId.human_execution )


### PR DESCRIPTION
fixes end of game replays to use the final kill, or use the last kill in the case of a draw. Addresses part of #33.