### PR TITLE
Added a pro screen check to titan to pilot loadout retrieval.

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_titan_transfer.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_titan_transfer.nut
@@ -175,7 +175,8 @@ void function GiveWeaponsFromStoredArray( entity player, array<StoredWeapon> sto
 				if ( storedWeapon.isProScreenOwner )
 				{
 					weapon.SetProScreenOwner( player )
-					UpdateProScreen( player, weapon )
+					if ( weapon.HasMod( "pro_screen" ) )
+						UpdateProScreen( player, weapon )
 				}
 
 				string weaponCategory = ""


### PR DESCRIPTION
Just like the normal loadout "giver", prevents an error when a weapon is not properly setup to use the proscreen, but has been given as part of a loadout.