### PR TITLE
Resets killstreak first before calculating kills.

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_score.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_score.nut
@@ -148,6 +148,11 @@ void function ScoreEvent_PlayerKilled( entity victim, entity attacker, var damag
 	if ( attacker.p.playerKillStreaks[ victim ] == DOMINATING_KILL_REQUIREMENT )
 		AddPlayerScore( attacker, "Dominating" )
 	
+	if ( Time() - attacker.s.lastKillTime > CASCADINGKILL_REQUIREMENT_TIME )
+	{
+		attacker.s.currentTimedKillstreak = 0 // reset first before kill
+		attacker.s.lastKillTime = Time()
+	}
 	
 	// timed killstreaks
 	if ( Time() - attacker.s.lastKillTime <= CASCADINGKILL_REQUIREMENT_TIME )
@@ -161,8 +166,6 @@ void function ScoreEvent_PlayerKilled( entity victim, entity attacker, var damag
 		else if ( attacker.s.currentTimedKillstreak == MEGAKILL_REQUIREMENT_KILLS )
 			AddPlayerScore( attacker, "MegaKill" )
 	}
-	else
-		attacker.s.currentTimedKillstreak = 0 // reset if a kill took too long
 	
 	attacker.s.lastKillTime = Time()
 }


### PR DESCRIPTION
The previous version doesn't calculate killstreaks correctly.

Previously:
1) First kill, timer exceeds killstreak requirement, resets killstreak
2) Second kill, timer doesn't exceed killstreak requirement, however it is not counted as a Double Kill
3) Third kill, this time does the game only consider this to be the Double Kill.
4) Fourth kill, this is considered to be the Triple Kill.

Now:
1) Check if killstreaks timer has exceeded, if so, resets the killstreak.
2) First kill
3) Second kill, now properly determined as a Double Kill.
4) Third kill, now Triple Kill, so on and so forth.