### PR TITLE
Boost Fixes Redux

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/burnmeter/sh_burnmeter.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/burnmeter/sh_burnmeter.gnut
@@ -1,4 +1,6 @@
 global function ShBurnMeter_Init
+global function BurnMeter_SetNoTitansReplacement
+global function BurnMeter_GetNoTitansReplacement
 global function BurnReward_GetById
 global function BurnReward_GetByRef
 global function BurnReward_GetRandom
@@ -67,9 +69,8 @@ global table< string, bool functionref( entity ) >  burnMeterCanUseFuncTable
 
 struct
 {
-
 	bool shouldCycleOnRelease = false
-
+	table<string, string> noTitansReplacements
 } file
 
 array<string> turretBurnCards = [
@@ -131,6 +132,24 @@ void function ShBurnMeter_Init()
 
 		RegisterConCommandTriggeredCallback( "-offhand4", CycleOnRelease )
 	#endif
+
+	BurnMeter_SetNoTitansReplacement( "burnmeter_emergency_battery", "burnmeter_amped_weapons" )
+	BurnMeter_SetNoTitansReplacement( "burnmeter_at_turret_weapon", "burnmeter_amped_weapons" )
+	BurnMeter_SetNoTitansReplacement( "burnmeter_rodeo_grenade", "burnmeter_amped_weapons" )
+	BurnMeter_SetNoTitansReplacement( "burnmeter_nuke_titan", "burnmeter_amped_weapons" )
+}
+
+void function BurnMeter_SetNoTitansReplacement( string original, string noTitansReplacement )
+{
+	file.noTitansReplacements[original] <- noTitansReplacement
+}
+
+string function BurnMeter_GetNoTitansReplacement( string burnRef )
+{
+	if ( burnRef in file.noTitansReplacements )
+		return file.noTitansReplacements[burnRef]
+
+	return burnRef
 }
 
 #if SERVER || CLIENT
@@ -164,10 +183,20 @@ int function GetBoostSkin( string ref )
 	return reward.skinIndex
 }
 
-
 BurnReward function BurnReward_GetRandom()
 {
-	return burn.allowedCards.getrandom()
+	string ref = burn.allowedCards.getrandom().ref
+
+	#if SERVER || CLIENT
+	if ( !EarnMeterMP_IsTitanEarnGametype() )
+		ref = BurnMeter_GetNoTitansReplacement( ref )
+
+	if ( GetCurrentPlaylistVarInt( "featured_mode_all_ticks", 0 ) >= 1 )
+		if ( ref == "burnmeter_ticks" || ref == "burnmeter_random_foil"  )
+			ref = "burnmeter_amped_weapons"
+	#endif
+
+	return BurnReward_GetByRef( ref )
 }
 
 string function GetSelectedBurnCardRef( entity player )
@@ -182,19 +211,12 @@ string function GetSelectedBurnCardRef( entity player )
 	#endif
 
 	#if SERVER || CLIENT
-
-	if ( Riff_TitanAvailability() == eTitanAvailability.Never )
-	{
-		//JFS: Batteries and Titan turrets are useless in PvP, turn them into amped weapons instead. Not an elegant solution at all. Fix next game. (Make boosts editable mid-match? )
-		if ( ref == "burnmeter_emergency_battery" || ref == "burnmeter_at_turret_weapon"  )
-			ref = "burnmeter_amped_weapons"
-	}
+	if ( !EarnMeterMP_IsTitanEarnGametype() )
+		ref = BurnMeter_GetNoTitansReplacement( ref )
 
 	if ( GetCurrentPlaylistVarInt( "featured_mode_all_ticks", 0 ) >= 1 )
-	{
 		if ( ref == "burnmeter_ticks" || ref == "burnmeter_random_foil"  )
 			ref = "burnmeter_amped_weapons"
-	}
 	#endif
 
 	return ref

--- a/Northstar.CustomServers/mod/scripts/vscripts/burnmeter/_burnmeter.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/burnmeter/_burnmeter.gnut
@@ -2,7 +2,8 @@ untyped
 
 global function BurnMeter_Init
 global function BurnMeter_SetBoostLimit
-global function BurnMeter_CheckBoostLimit
+global function BurnMeter_SetBoostRewardCount
+global function BurnMeter_GetLimitedRewardCount
 global function ForceSetGlobalBurncardOverride
 global function GetSelectedBurncardRefFromWeaponOrPlayer
 global function RunBurnCardUseFunc
@@ -22,8 +23,10 @@ const float AMPED_WEAPONS_LENGTH = 30.0
 const int MAPHACK_PULSE_COUNT = 4
 const float MAPHACK_PULSE_DELAY = 2.0
 
-struct {
+struct
+{
 	string forcedGlobalBurncardOverride = ""
+	table<string, int> boostRewardCount
 	table<string, int> boostLimits
 } file
 
@@ -49,6 +52,8 @@ void function BurnMeter_Init()
 	BurnReward_GetByRef( "burnmeter_rodeo_grenade" ).rewardAvailableCallback = PlayerUsesRodeoGrenadeBurncard
 	BurnReward_GetByRef( "burnmeter_nuke_titan" ).rewardAvailableCallback = PlayerUsesNukeTitanBurncard // unused in vanilla, fun though
 
+	BurnMeter_SetBoostRewardCount( "burnmeter_ticks", 2 )
+
 	BurnMeter_SetBoostLimit( "burnmeter_ticks", 6 )
 	BurnMeter_SetBoostLimit( "burnmeter_ap_turret_weapon", 3 )
 	BurnMeter_SetBoostLimit( "burnmeter_at_turret_weapon", 3 )
@@ -70,24 +75,35 @@ void function BurnMeter_SetBoostLimit( string burnRef, int limit )
 	file.boostLimits[burnRef] <- limit
 }
 
-bool function BurnMeter_CheckBoostLimit( entity player )
+
+void function BurnMeter_SetBoostRewardCount( string burnRef, int rewardCount )
+{
+	file.boostRewardCount[burnRef] <- rewardCount
+}
+
+int function BurnMeter_GetLimitedRewardCount( entity player )
 {
 	EarnObject earnObject = PlayerEarnMeter_GetReward( player )
 	string burnRef = earnObject.ref
 	int limit = -1
+	int rewardCount = 1
 
 	if ( burnRef in file.boostLimits )
 		limit = file.boostLimits[burnRef]
 
+	if ( burnRef in file.boostRewardCount )
+		rewardCount = file.boostRewardCount[burnRef]
+
 	if ( limit < 0 )
-		return false
+		return rewardCount
 
 	int current = PlayerInventory_CountBurnRef( player, burnRef )
+	int delta = limit - current
 
-	if ( current < limit )
-		return false
+	if ( delta <= 0 )
+		return 0
 
-	return true
+	return int( min( delta, rewardCount ) )
 }
 
 void function ForceSetGlobalBurncardOverride( string ref )

--- a/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
@@ -153,9 +153,8 @@ void function EarnMeterMP_BoostEarned( entity player )
 	while ( burncard.ref == "burnmeter_random_foil" )
 		burncard = BurnReward_GetRandom()
 
-	if ( !BurnMeter_CheckBoostLimit( player ) ) {
+	for ( int i = 0; i < BurnMeter_GetLimitedRewardCount( player ); i++ )
 		BurnMeter_GiveRewardDirect( player, burncard.ref )
-	}
 
 	PlayerEarnMeter_DisableReward( player )
 }


### PR DESCRIPTION
- Fixed Dice Roll still picking "titan only" boosts.
- Added a more flexible way to set replacements for "non-titan" modes. `BurnMeter_SetNoTitansReplacement( string original, string replacement)`
- Fixed ticks not being rewarded in pairs.
- Added support for multiple boost rewards. `BurnMeter_SetBoostRewardCount( string burnRef, int count )`