### PR TITLE
Hide death from scoreboard when playerDeathHidden is true

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
@@ -261,7 +261,7 @@ void function PostDeathThread_MP( entity player, var damageInfo ) // based on ga
 	player.SetNoTargetSmartAmmo( false )
 	player.ClearExtraWeaponMods()
 	
-	player.AddToPlayerGameStat( PGS_DEATHS, 1 )
+
 	
 	if ( player.IsTitan() )
 		SoulDies( player.GetTitanSoul(), damageInfo ) // cleanup some titan stuff, no idea where else to put this
@@ -303,7 +303,10 @@ void function PostDeathThread_MP( entity player, var damageInfo ) // based on ga
 		player.SetObserverTarget( null )
 	
 	if ( !file.playerDeathsHidden )
+	{
+		player.AddToPlayerGameStat( PGS_DEATHS, 1 )
 		Remote_CallFunction_NonReplay( player, "ServerCallback_YouDied", attacker.GetEncodedEHandle(), GetHealthFrac( attacker ), methodOfDeath )
+	}
 
 	float deathcamLength = GetDeathCamLength( player )
 	wait deathcamLength


### PR DESCRIPTION
This fixes the scoreboard showing a death when player survived a round in roundbased gamemodes