### PR TITLE
Add .gitattributes that disables text processing on localization files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/Northstar.Client/mod/resource/* -text


### PR DESCRIPTION
This should stop Github from brutally maiming the localization files, with any luck. I did a couple of test edits on the localization files (force pushed away from my branch now so as not to taint commit history) and it seems to have worked.