### PR TITLE
Add Fastball spawns for Crash Site and Rise

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
@@ -102,7 +102,7 @@ void function GamemodeFastball_Init()
 	FastballAddBuddySpawnForLevel( "mp_crashsite3", TEAM_IMC, < -2455.29, 821.52, 539.21>, <0, -179.21, 0> )
 	FastballAddPanelSpawnsForLevel( "mp_crashsite3", [
 		< -672.27, -2786, 931.17 >, < 0, -45, 0 >,
-		< -3967.45, -1616.51, 1255.15 >, < 1.43, 80, 21.5 >,
+		< -3770, -990, 985 >, < 10, 80.00, 20 >,
 		< -6190.25, 1658.51, 1400.03 >, < 0, 144, 0 >  
 	])
 	

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
@@ -109,9 +109,9 @@ void function GamemodeFastball_Init()
 	FastballAddBuddySpawnForLevel( "mp_rise", TEAM_MILITIA, < -3885.97, 35.11, 704.03>, <0, 11.86, 0> ) 
 	FastballAddBuddySpawnForLevel( "mp_rise", TEAM_IMC, < 2206.76, 1869.08, 453.9>, <0, -165.77, 0> )
 	FastballAddPanelSpawnsForLevel( "mp_rise", [
-		< 2189.09, 1841.74, 73.06 >, < 0, 0, 0 >,
+		< 141, 2484.71, 296.03 >, < 0, 0, 0 >,
 		< -448.54, 1091.42, 545.03 >, < 0, 0, 0 >,
-		< -4083.55, -669.75, 383.03 >, < 0, -90, 0 >  
+		< -2097, 1050, 320.03 >, < 0, 180, 0 >
 	]) 
 
 	//Current BT fast ball points are good

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
@@ -97,6 +97,14 @@ void function GamemodeFastball_Init()
 		< 8, 825, 1096 >, < 0, -90.00, 0 > ,
 		< 740 , -600, 960 >, < 0, 0, 0 >  
 	])
+	
+	FastballAddBuddySpawnForLevel( "mp_crashsite3", TEAM_MILITIA, < -6364.65,  -1291.28, 822.02>, <0, -19.17, 0> ) 
+	FastballAddBuddySpawnForLevel( "mp_crashsite3", TEAM_IMC, < -2455.29, 821.52, 539.21>, <0, -179.21, 0> )
+	FastballAddPanelSpawnsForLevel( "mp_crashsite3", [
+		< -672.27, -2786, 931.17 >, < 0, -45, 0 >,
+		< -3967.45, -1616.51, 1255.15 >, < 1.43, 80, 21.5 >,
+		< -6190.25, 1658.51, 1400.03 >, < 0, 144, 0 >  
+	])
 
 	//Current BT fast ball points are good
 	FastballAddPanelSpawnsForLevel( "mp_colony02", [

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
@@ -105,6 +105,14 @@ void function GamemodeFastball_Init()
 		< -3967.45, -1616.51, 1255.15 >, < 1.43, 80, 21.5 >,
 		< -6190.25, 1658.51, 1400.03 >, < 0, 144, 0 >  
 	])
+	
+	FastballAddBuddySpawnForLevel( "mp_rise", TEAM_MILITIA, < -3885.97, 35.11, 704.03>, <0, 11.86, 0> ) 
+	FastballAddBuddySpawnForLevel( "mp_rise", TEAM_IMC, < 2206.76, 1869.08, 453.9>, <0, -165.77, 0> )
+	FastballAddPanelSpawnsForLevel( "mp_rise", [
+		< 2189.09, 1841.74, 73.06 >, < 0, 0, 0 >,
+		< -448.54, 1091.42, 545.03 >, < 0, 0, 0 >,
+		< -4083.55, -669.75, 383.03 >, < 0, -90, 0 >  
+	]) 
 
 	//Current BT fast ball points are good
 	FastballAddPanelSpawnsForLevel( "mp_colony02", [


### PR DESCRIPTION
Created fastball spawns for the following maps:
- Crash Site
- Rise

The only maps that currently don't have any fastball spawns are Drydock, Glitch, Homestead, and Relic. I am planning on completing those as well.