### PR TITLE
Additional kill score fixes

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_score.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_score.nut
@@ -95,7 +95,7 @@ void function ScoreEvent_PlayerKilled( entity victim, entity attacker, var damag
 	
 	// have to do this early before we reset victim's player killstreaks
 	// nemesis when you kill a player that is dominating you
-	if ( attacker.IsPlayer() && attacker in victim.p.playerKillStreaks && victim.p.playerKillStreaks[ attacker ] == NEMESIS_KILL_REQUIREMENT )
+	if ( attacker.IsPlayer() && attacker in victim.p.playerKillStreaks && victim.p.playerKillStreaks[ attacker ] >= NEMESIS_KILL_REQUIREMENT )
 		AddPlayerScore( attacker, "Nemesis" )
 	
 	// reset killstreaks on specific players

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_score.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_score.nut
@@ -108,7 +108,7 @@ void function ScoreEvent_PlayerKilled( entity victim, entity attacker, var damag
 	if ( !attacker.IsPlayer() )
 		return
 
-
+	attacker.p.numberOfDeathsSinceLastKill = 0 // since they got a kill, remove the comeback trigger
 	// pilot kill
 	AddPlayerScore( attacker, "KillPilot", victim )
 	
@@ -145,7 +145,7 @@ void function ScoreEvent_PlayerKilled( entity victim, entity attacker, var damag
 		attacker.p.playerKillStreaks[ victim ]++
 	
 	// dominating
-	if ( attacker.p.playerKillStreaks[ victim ] == DOMINATING_KILL_REQUIREMENT )
+	if ( attacker.p.playerKillStreaks[ victim ] >= DOMINATING_KILL_REQUIREMENT )
 		AddPlayerScore( attacker, "Dominating" )
 	
 	if ( Time() - attacker.s.lastKillTime > CASCADINGKILL_REQUIREMENT_TIME )
@@ -163,7 +163,7 @@ void function ScoreEvent_PlayerKilled( entity victim, entity attacker, var damag
 			AddPlayerScore( attacker, "DoubleKill" )
 		else if ( attacker.s.currentTimedKillstreak == TRIPLEKILL_REQUIREMENT_KILLS )
 			AddPlayerScore( attacker, "TripleKill" )
-		else if ( attacker.s.currentTimedKillstreak == MEGAKILL_REQUIREMENT_KILLS )
+		else if ( attacker.s.currentTimedKillstreak >= MEGAKILL_REQUIREMENT_KILLS )
 			AddPlayerScore( attacker, "MegaKill" )
 	}
 	


### PR DESCRIPTION
- Reset number of deaths since last kill when the attacker gets a kill (to prevent dying once and immediately get a Comeback medal)
- Change == sign to >= sign for Dominating killstreaks
- Change == sign to >= sign for Mega Kills