### PR TITLE
Add Fastball locations for Glitch and Relic

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
@@ -112,6 +112,14 @@ void function GamemodeFastball_Init()
 		< -192, 129, -55 >, < 0, 90.00, 0 >,
 		< -3088, -1905, 25 >, < 0, -180.00, 0 >
 	])
+
+	FastballAddBuddySpawnForLevel( "mp_relic02", TEAM_MILITIA, < 4504, -3500, 150 >, < 0, -170, 0 > )
+	FastballAddBuddySpawnForLevel( "mp_relic02", TEAM_IMC, < -4505, -3750, 367>, < 0, 10, 0 > )
+	FastballAddPanelSpawnsForLevel( "mp_relic02", [
+		< -2258, -5286, 356 >, < 0, 0.00, 0 >,
+		< -32, -2600, -75 >, < 0, 90.00, 0 >,
+		< 2028, -5332, 128 >, < 0, 90.00, 0 >
+	])
 }
 
 void function SpawnPanelsForLevel()

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
@@ -104,6 +104,14 @@ void function GamemodeFastball_Init()
 		< -87, 1630, 22 >, < 0, 90.00, 0 >,
 		< -2167 , 448, 54 >, <0 , 90, 0 >  
 	])
+
+	FastballAddBuddySpawnForLevel( "mp_glitch", TEAM_MILITIA, < -4450, -629, 320 >, < 0, 0, 0 > )
+	FastballAddBuddySpawnForLevel( "mp_glitch", TEAM_IMC, < 4100, 890, 320>, < 0, 180, 0 > )
+	FastballAddPanelSpawnsForLevel( "mp_glitch", [
+		< 2703, 2170, 25 >, < 0, 0.00, 0 >,
+		< -192, 129, -55 >, < 0, 90.00, 0 >,
+		< -3088, -1905, 25 >, < 0, -180.00, 0 >
+	])
 }
 
 void function SpawnPanelsForLevel()


### PR DESCRIPTION
Adds panel and BT locations for Glitch and Relic. Together with #70 and #76 all non-livefire maps should have panel locations and BT spawns now.

Locations where decided on together with @theroylee 