### PR TITLE
Add flag carrier scoring to Live Fire Arena

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_speedball.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_speedball.nut
@@ -23,6 +23,7 @@ void function GamemodeSpeedball_Init()
 	
 	AddCallback_GameStateEnter( eGameState.Prematch, CreateFlagIfNoFlagSpawnpoint )
 	AddCallback_GameStateEnter( eGameState.Playing, ResetFlag )
+	AddCallback_GameStateEnter( eGameState.WinnerDetermined,GamemodeSpeedball_OnWinnerDetermined)
 	AddCallback_OnTouchHealthKit( "item_flag", OnFlagCollected )
 	AddCallback_OnPlayerKilled( OnPlayerKilled )
 	SetTimeoutWinnerDecisionFunc( TimeoutCheckFlagHolder )

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_speedball.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_speedball.nut
@@ -147,3 +147,9 @@ int function TimeoutCheckFlagHolder()
 		
 	return file.flagCarrier.GetTeam()
 }
+
+void function GamemodeSpeedball_OnWinnerDetermined()
+{
+	if(IsValid(file.flagCarrier))
+		file.flagCarrier.AddToPlayerGameStat( PGS_ASSAULT_SCORE, 1 )
+}


### PR DESCRIPTION
Adds a Point to the assault score of the player who carries the Flag at round end. 
