### PR TITLE
Make keyboard nav wrap around again (fixed merge conflicts)

### DIFF
--- a/Northstar.Client/mod/resource/ui/menus/server_browser.menu
+++ b/Northstar.Client/mod/resource/ui/menus/server_browser.menu
@@ -435,6 +435,7 @@ resource/ui/menus/mods_browse.menu
 			pin_to_sibling				BtnServerPasswordProtectedTab
 			pin_corner_to_sibling		TOP_LEFT
 			pin_to_sibling_corner		TOP_RIGHT
+			navUp						BtnFiltersClear
 			navDown						BtnServer1
 			navRight 					BtnServerPlayersTab
 		}
@@ -683,8 +684,9 @@ resource/ui/menus/mods_browse.menu
 			pin_corner_to_sibling		TOP_LEFT
 			pin_to_sibling_corner		TOP_RIGHT
 			navDown						BtnServer1
-			navLeft 		BtnServerNameTab
-			navRight 		BtnServerMapTab
+			navLeft 					BtnServerNameTab
+			navRight 					BtnServerMapTab
+			navUp						BtnFiltersClear
 		}
 
 		BtnServerPlayers1
@@ -929,8 +931,9 @@ resource/ui/menus/mods_browse.menu
 			pin_corner_to_sibling		TOP_LEFT
 			pin_to_sibling_corner		TOP_RIGHT
 			navDown						BtnServer1
-			navLeft BtnServerPlayersTab
-			navRight BtnServerGamemodeTab
+			navLeft 					BtnServerPlayersTab
+			navRight 					BtnServerGamemodeTab
+			navUp						BtnFiltersClear
 		}
 
 		BtnServerMap1
@@ -1174,8 +1177,9 @@ resource/ui/menus/mods_browse.menu
 			pin_corner_to_sibling		TOP_LEFT
 			pin_to_sibling_corner		TOP_RIGHT
 			navDown						BtnServer1
-			navLeft BtnServerMapTab
-			navRight BtnServerLatencyTab
+			navLeft 					BtnServerMapTab
+			navRight 					BtnServerLatencyTab
+			navUp						BtnFiltersClear
 		}
 
 		BtnServerGamemode1
@@ -1419,8 +1423,9 @@ resource/ui/menus/mods_browse.menu
 			pin_corner_to_sibling		TOP_LEFT
 			pin_to_sibling_corner		TOP_RIGHT
 			navDown						BtnServer1
-			navLeft BtnServerGamemodeTab
-			navLeft BtnServerJoin
+			navLeft 					BtnServerGamemodeTab
+			navRight 					BtnServerJoin
+			navUp						BtnFiltersClear
 		}
 
 		BtnServerLatency1

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -490,7 +490,7 @@ void function OnHitDummyBottom(var button) {
 }
 
 void function OnHitDummyAfterFilterClear(var button) {
-	Hud_SetFocused(Hud_GetChild(file.menu, "BtnServer1"))
+	Hud_SetFocused(Hud_GetChild(file.menu, "BtnServerNameTab"))
 }
 
 


### PR DESCRIPTION
QOL fix for keyboard nav in server browser.
Makes it so pressing arrow-up focuses the filter panel when the server list title bar was focused before.

Same as #39 but with resolved merge conflicts.