### PR TITLE
Improving support for multiple players in a Gun Game team (duplicate of #116)

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
@@ -63,7 +63,10 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 		{
 			AddTeamScore( attacker.GetTeam(), 1 )
 			attacker.AddToPlayerGameStat( PGS_ASSAULT_SCORE, 1 )
-			UpdateLoadout( attacker )
+			// example: "ASpoonPlaysGames got a kill with the softball"
+			string message = attacker.GetPlayerName() + " got a kill with the " + DamageInfo_GetDamageSourceIdentifier( damageInfo )
+			UpdateLoadoutForTeam( attacker )
+			
 		}
 		
 		if ( DamageInfo_GetDamageSourceIdentifier( damageInfo ) == eDamageSourceId.human_execution )
@@ -76,8 +79,33 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 			{
 				AddTeamScore( victim.GetTeam(), -1 ) // get absolutely fucking destroyed lol
 				victim.AddToPlayerGameStat( PGS_ASSAULT_SCORE, -1 )
+				UpdateLoadoutForTeam( victim ) 
 			}
 		}
+	}
+}
+
+void function SendHudMessageToTeam( entity player, string message )
+{
+	// sends a hud message to everybody on the same team as the player, except the player
+	int team = player.GetTeam()
+	foreach ( entity teamPlayer in GetPlayerArrayOfTeam( team ) )
+	{
+		if (teamPlayer == player)
+			return
+		// message should be near the top of the screen and green, should hold for 2 seconds, then fade out over 0.15 seconds
+		SendHudMessage( teamPlayer, message, -1, 0.2, 0, 255, 0, 0, 0, 2, 0.15 )
+	}
+}
+
+void function UpdateLoadoutForTeam( entity player )
+{
+	// updates guns for everybody on the same team as the player
+	int team = player.GetTeam()
+	foreach ( entity teamPlayer in GetPlayerArrayOfTeam( team ) )
+	{
+		if (teamPlayer.IsAlive()) // don't try and give guns to dead people (not sure if game cares about this tbh, but its just a precaution)
+			UpdateLoadout( teamPlayer )
 	}
 }
 

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
@@ -63,8 +63,17 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 		{
 			AddTeamScore( attacker.GetTeam(), 1 )
 			attacker.AddToPlayerGameStat( PGS_ASSAULT_SCORE, 1 )
-			// example: "ASpoonPlaysGames got a kill with the softball"
-			string message = attacker.GetPlayerName() + " got a kill with the " + DamageInfo_GetDamageSourceIdentifier( damageInfo )
+
+			// until i can find a way to localize only certain parts of strings for hud messages, i cant show the weapon that the teammate got a kill with
+
+			// ideal output: "ASpoonPlaysGames got a kill with the softball"
+			// but trying to localize the string only gives this
+			// "ASpoonPlaysGames got a kill with the #<localiseable thing here>"
+			// would be neat if Localize() would try to localize each word individually
+
+
+			// actual output: "ASpoonPlaysGames got a kill."
+			string message = attacker.GetPlayerName() + " got a kill."
 			SendHudMessageToTeam( attacker, message )
 			UpdateLoadoutForTeam( attacker )
 			
@@ -105,7 +114,7 @@ void function UpdateLoadoutForTeam( entity player )
 	int team = player.GetTeam()
 	foreach ( entity teamPlayer in GetPlayerArrayOfTeam( team ) )
 	{
-		if (teamPlayer.IsAlive()) // don't try and give guns to dead people (not sure if game cares about this tbh, but its just a precaution)
+		if (IsAlive( teamPlayer )) // don't try and give guns to dead people (not sure if game cares about this tbh, but its just a precaution)
 			UpdateLoadout( teamPlayer )
 	}
 }

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
@@ -65,6 +65,7 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 			attacker.AddToPlayerGameStat( PGS_ASSAULT_SCORE, 1 )
 			// example: "ASpoonPlaysGames got a kill with the softball"
 			string message = attacker.GetPlayerName() + " got a kill with the " + DamageInfo_GetDamageSourceIdentifier( damageInfo )
+			SendHudMessageToTeam( attacker, message )
 			UpdateLoadoutForTeam( attacker )
 			
 		}


### PR DESCRIPTION
Fucked up my branches on my fork, fixed now, but have to remake my pull request

original description below:

Added a hud message that is sent to the player's team when they get a kill, as well as adding a function that updates the whole team's loadout instead of just the player's (prevents people from skipping pulse blade and guns in general)