### PR TITLE
GetTimeLimit_ForGameMode() is no longer a stub

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -848,5 +848,9 @@ void function GiveTitanToPlayer( entity player )
 
 float function GetTimeLimit_ForGameMode()
 {
-	return 100.0
+	string mode = GameRules_GetGameMode()
+	string playlistString = "timelimit"
+
+	// default to 10 mins, because that seems reasonable
+	return GetCurrentPlaylistVarFloat( playlistString, 10 )
 }


### PR DESCRIPTION
This should make it so that infection timer changes for last survivor work properly as well as just being generally useful