### PR TITLE
Remove sv_cheats condition from kill and explode

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/_northstar_devcommands.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/_northstar_devcommands.gnut
@@ -23,7 +23,7 @@ bool function ClientCommandCallbackToggleNoclip( entity player, array<string> ar
 
 bool function ClientCommandCallbackKill( entity player, array<string> args )
 {
-	if ( IsAlive( player ) && GetConVarInt( "sv_cheats" ) == 1 )
+	if ( IsAlive( player ) )
 		player.Die()
 	
 	return true
@@ -31,7 +31,7 @@ bool function ClientCommandCallbackKill( entity player, array<string> args )
 
 bool function ClientCommandCallbackExplode( entity player, array<string> args )
 {
-	if ( IsAlive( player ) && GetConVarInt( "sv_cheats" ) == 1 )
+	if ( IsAlive( player ) )
 		player.Die( null, null, { scriptType = DF_GIB } )
 	
 	return true


### PR DESCRIPTION
Short little edit on mobile.

Main reasons is to make it more similar to community interactions in Team Fortress 2 where players killbind themselves for seemingly no reason. (It's funny)