### PR TITLE
Add E-Smoke reward to Core Meter

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
@@ -73,12 +73,12 @@ void function OnPlayerRespawned( entity player )
 
 void function EarnMeterMP_ReplaceReward( entity player, EarnObject reward, float rewardFrac )
 {
-    PlayerEarnMeter_Reset( player )
-    PlayerEarnMeter_SetReward( player, reward )
-    PlayerEarnMeter_SetRewardFrac( player, rewardFrac )
+	PlayerEarnMeter_Reset( player )
+	PlayerEarnMeter_SetReward( player, reward )
+	PlayerEarnMeter_SetRewardFrac( player, rewardFrac )
 
-    if( PlayerEarnMeter_GetRewardFrac( player ) != 0 )
-        PlayerEarnMeter_EnableReward( player )
+	if( PlayerEarnMeter_GetRewardFrac( player ) != 0 )
+		PlayerEarnMeter_EnableReward( player )
 }
 
 void function EarnMeterMP_PlayerLifeThink( entity player )
@@ -86,20 +86,20 @@ void function EarnMeterMP_PlayerLifeThink( entity player )
 	player.EndSignal( "OnDeath" )
 	player.EndSignal( "OnDestroy" )
 
-    EarnObject pilotReward
-    float pilotRewardFrac
+	EarnObject pilotReward
+	float pilotRewardFrac
 	int lastEarnMeterMode = PlayerEarnMeter_GetMode( player )
 	float lastPassiveGainTime = Time()
 
-    OnThreadEnd(
-        function() : ( player, pilotReward, pilotRewardFrac )
-        {
-            // Resets the meter to the pilot version if the player dies in a titan (otherwise pilot gets e-smoke earn meter, which is bad)
-            int earnMode = PlayerEarnMeter_GetMode( player )
-            if( earnMode == eEarnMeterMode.CORE || earnMode == eEarnMeterMode.CORE_ACTIVE )
-                EarnMeterMP_ReplaceReward( player, pilotReward, pilotRewardFrac )
-        }
-    )
+	OnThreadEnd(
+		function() : ( player, pilotReward, pilotRewardFrac )
+		{
+			// Resets the meter to the pilot version if the player dies in a titan (otherwise pilot gets e-smoke earn meter, which is bad)
+			int earnMode = PlayerEarnMeter_GetMode( player )
+			if( earnMode == eEarnMeterMode.CORE || earnMode == eEarnMeterMode.CORE_ACTIVE )
+				EarnMeterMP_ReplaceReward( player, pilotReward, pilotRewardFrac )
+		}
+	)
 
 	while ( true )
 	{
@@ -121,11 +121,11 @@ void function EarnMeterMP_PlayerLifeThink( entity player )
 		if ( desiredEarnMeterMode != lastEarnMeterMode )
 		{
 			PlayerEarnMeter_SetMode( player, desiredEarnMeterMode )
-            if ( lastEarnMeterMode == eEarnMeterMode.DEFAULT ) // Set these here in case the player changed boost during the match (e.g. in dropship)
-            {
-                pilotReward = PlayerEarnMeter_GetReward( player ) 
-                pilotRewardFrac = PlayerEarnMeter_GetRewardFrac( player )
-            }
+			if ( lastEarnMeterMode == eEarnMeterMode.DEFAULT ) // Set these here in case the player changed boost during the match (e.g. in dropship)
+			{
+				pilotReward = PlayerEarnMeter_GetReward( player ) 
+				pilotRewardFrac = PlayerEarnMeter_GetRewardFrac( player )
+			}
 
 			if ( desiredEarnMeterMode == eEarnMeterMode.DEFAULT )
 			{
@@ -135,14 +135,14 @@ void function EarnMeterMP_PlayerLifeThink( entity player )
 				if ( PlayerEarnMeter_GetRewardFrac( player ) != 0 )
 					PlayerEarnMeter_EnableReward( player )
 			}
-            else if ( desiredEarnMeterMode == eEarnMeterMode.CORE )
-            {
-                EarnMeterMP_ReplaceReward( player, EarnObject_GetByRef( "core_electric_smoke" ), CORE_SMOKE_FRAC )
-                if( SoulTitanCore_GetNextAvailableTime( player.GetTitanSoul() ) >= CORE_SMOKE_FRAC )
-                    PlayerEarnMeter_SetRewardUsed( player )
-            }
-            else if ( desiredEarnMeterMode == eEarnMeterMode.CORE_ACTIVE ) // Enables smoke after core use (doesn't show up during active, so looks fine)
-                PlayerEarnMeter_EnableReward( player )
+			else if ( desiredEarnMeterMode == eEarnMeterMode.CORE )
+			{
+				EarnMeterMP_ReplaceReward( player, EarnObject_GetByRef( "core_electric_smoke" ), CORE_SMOKE_FRAC )
+				if( SoulTitanCore_GetNextAvailableTime( player.GetTitanSoul() ) >= CORE_SMOKE_FRAC )
+					PlayerEarnMeter_SetRewardUsed( player )
+			}
+			else if ( desiredEarnMeterMode == eEarnMeterMode.CORE_ACTIVE ) // Enables smoke after core use (doesn't show up during active, so looks fine)
+				PlayerEarnMeter_EnableReward( player )
 
 			lastEarnMeterMode = desiredEarnMeterMode
 		}
@@ -173,9 +173,9 @@ void function EarnMeterMP_PlayerLifeThink( entity player )
 
 void function EarnMeterMP_BoostEarned( entity player )
 {
-    // Can't have smoke earned via meter. Otherwise, Auto Titan could hit reward frac and get nothing
-    if( player.IsTitan() )
-        return
+	// Can't have smoke earned via meter. Otherwise, Auto Titan could hit reward frac and get nothing
+	if( player.IsTitan() )
+		return
 
 	EarnObject earnobject = PlayerEarnMeter_GetReward( player )
 	BurnReward burncard = BurnReward_GetByRef( earnobject.ref )

--- a/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
@@ -74,6 +74,8 @@ void function OnPlayerRespawned( entity player )
 void function EarnMeterMP_ReplaceReward( entity player, EarnObject reward, float rewardFrac )
 {
 	PlayerEarnMeter_Reset( player )
+	if ( reward.id < 0 )  // Don't set the reward if it is nonexistent
+		return
 	PlayerEarnMeter_SetReward( player, reward )
 	PlayerEarnMeter_SetRewardFrac( player, rewardFrac )
 
@@ -86,8 +88,8 @@ void function EarnMeterMP_PlayerLifeThink( entity player )
 	player.EndSignal( "OnDeath" )
 	player.EndSignal( "OnDestroy" )
 
-	EarnObject pilotReward
-	float pilotRewardFrac
+	EarnObject pilotReward = PlayerEarnMeter_GetReward( player ) 
+	float pilotRewardFrac = PlayerEarnMeter_GetRewardFrac( player )
 	int lastEarnMeterMode = PlayerEarnMeter_GetMode( player )
 	float lastPassiveGainTime = Time()
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
@@ -130,10 +130,7 @@ void function EarnMeterMP_PlayerLifeThink( entity player )
 			if ( desiredEarnMeterMode == eEarnMeterMode.DEFAULT )
 			{
 				if ( !IsTitanAvailable( player ) && lastEarnMeterMode == eEarnMeterMode.PET ) // this should only be the case after player's auto died (or they ejected)
-				{
-					lastPassiveGainTime = Time()
 					EarnMeterMP_ReplaceReward( player, pilotReward, pilotRewardFrac )
-				}
 
 				if ( PlayerEarnMeter_GetRewardFrac( player ) != 0 )
 					PlayerEarnMeter_EnableReward( player )

--- a/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
@@ -71,13 +71,35 @@ void function OnPlayerRespawned( entity player )
 		EarnMeterMP_BoostEarned( player )
 }
 
+void function EarnMeterMP_ReplaceReward( entity player, EarnObject reward, float rewardFrac )
+{
+    PlayerEarnMeter_Reset( player )
+    PlayerEarnMeter_SetReward( player, reward )
+    PlayerEarnMeter_SetRewardFrac( player, rewardFrac )
+
+    if( PlayerEarnMeter_GetRewardFrac( player ) != 0 )
+        PlayerEarnMeter_EnableReward( player )
+}
+
 void function EarnMeterMP_PlayerLifeThink( entity player )
 {
 	player.EndSignal( "OnDeath" )
 	player.EndSignal( "OnDestroy" )
 
+    EarnObject pilotReward
+    float pilotRewardFrac
 	int lastEarnMeterMode = PlayerEarnMeter_GetMode( player )
 	float lastPassiveGainTime = Time()
+
+    OnThreadEnd(
+        function() : ( player, pilotReward, pilotRewardFrac )
+        {
+            // Resets the meter to the pilot version if the player dies in a titan (otherwise pilot gets e-smoke earn meter, which is bad)
+            int earnMode = PlayerEarnMeter_GetMode( player )
+            if( earnMode == eEarnMeterMode.CORE || earnMode == eEarnMeterMode.CORE_ACTIVE )
+                EarnMeterMP_ReplaceReward( player, pilotReward, pilotRewardFrac )
+        }
+    )
 
 	while ( true )
 	{
@@ -99,25 +121,28 @@ void function EarnMeterMP_PlayerLifeThink( entity player )
 		if ( desiredEarnMeterMode != lastEarnMeterMode )
 		{
 			PlayerEarnMeter_SetMode( player, desiredEarnMeterMode )
+            if ( lastEarnMeterMode == eEarnMeterMode.DEFAULT ) // Set these here in case the player changed boost during the match (e.g. in dropship)
+            {
+                pilotReward = PlayerEarnMeter_GetReward( player ) 
+                pilotRewardFrac = PlayerEarnMeter_GetRewardFrac( player )
+            }
 
 			if ( desiredEarnMeterMode == eEarnMeterMode.DEFAULT )
 			{
 				if ( !IsTitanAvailable( player ) && PlayerEarnMeter_GetOwnedFrac( player ) == 1.0 ) // this should only be the case after player has dropped their titan
-				{
-					float oldRewardFrac = PlayerEarnMeter_GetRewardFrac( player )
-					PlayerEarnMeter_Reset( player )
-					PlayerEarnMeter_SetRewardFrac( player, oldRewardFrac )
-					PlayerEarnMeter_EnableReward( player )
-				}
+					EarnMeterMP_ReplaceReward( player, pilotReward, pilotRewardFrac )
 
 				if ( PlayerEarnMeter_GetRewardFrac( player ) != 0 )
 					PlayerEarnMeter_EnableReward( player )
 			}
-			else
-			{
-				PlayerEarnMeter_DisableGoal( player )
-				PlayerEarnMeter_DisableReward( player )
-			}
+            else if ( desiredEarnMeterMode == eEarnMeterMode.CORE )
+            {
+                EarnMeterMP_ReplaceReward( player, EarnObject_GetByRef( "core_electric_smoke" ), CORE_SMOKE_FRAC )
+                if( SoulTitanCore_GetNextAvailableTime( player.GetTitanSoul() ) >= CORE_SMOKE_FRAC )
+                    PlayerEarnMeter_SetRewardUsed( player )
+            }
+            else if ( desiredEarnMeterMode == eEarnMeterMode.CORE_ACTIVE ) // Enables smoke after core use (doesn't show up during active, so looks fine)
+                PlayerEarnMeter_EnableReward( player )
 
 			lastEarnMeterMode = desiredEarnMeterMode
 		}
@@ -148,6 +173,10 @@ void function EarnMeterMP_PlayerLifeThink( entity player )
 
 void function EarnMeterMP_BoostEarned( entity player )
 {
+    // Can't have smoke earned via meter. Otherwise, Auto Titan could hit reward frac and get nothing
+    if( player.IsTitan() )
+        return
+
 	EarnObject earnobject = PlayerEarnMeter_GetReward( player )
 	BurnReward burncard = BurnReward_GetByRef( earnobject.ref )
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
@@ -129,8 +129,11 @@ void function EarnMeterMP_PlayerLifeThink( entity player )
 
 			if ( desiredEarnMeterMode == eEarnMeterMode.DEFAULT )
 			{
-				if ( !IsTitanAvailable( player ) && PlayerEarnMeter_GetOwnedFrac( player ) == 1.0 ) // this should only be the case after player has dropped their titan
+				if ( !IsTitanAvailable( player ) && lastEarnMeterMode == eEarnMeterMode.PET ) // this should only be the case after player's auto died (or they ejected)
+				{
+					lastPassiveGainTime = Time()
 					EarnMeterMP_ReplaceReward( player, pilotReward, pilotRewardFrac )
+				}
 
 				if ( PlayerEarnMeter_GetRewardFrac( player ) != 0 )
 					PlayerEarnMeter_EnableReward( player )


### PR DESCRIPTION
Edits earn meter to add E-Smoke as a reward during the core earn meter state. E-Smoke is still earned via the hard coded method that connects to core build directly, since otherwise Auto-Titans could not earn E-Smoke.
Also, noticed that the logic for passive meter gain isn't quite correct. After looking up gameplay, vanilla passive gain seems to be on an independent timer, ticking only if the player isn't dead. It also seems to vary: CTF pugs seem to have a 5s period, yet Attrition seems to start at ~4s and get faster as the game goes on. But that's a change for another commit.