### PR TITLE
Fix CTF half-time crash

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
@@ -334,7 +334,7 @@ void function DropFlagIfPhased( entity player, entity flag )
 		DropFlag( player, true )
 	})
 	
-	while( flag.GetParent() == player )
+	while( IsValid( flag ) && flag.GetParent() == player )
 		WaitFrame()
 }
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
@@ -221,6 +221,7 @@ void function CreateFlags()
 		flag.SetModel( CTF_FLAG_MODEL )
 		flag.SetOrigin( spawn.GetOrigin() + < 0, 0, base.GetBoundingMaxs().z * 2 > ) // ensure flag doesn't spawn clipped into geometry
 		flag.SetVelocity( < 0, 0, 1 > )
+		SetFlagStateForTeam( flag.GetTeam(), eFlagState.None ) // reset flag state to prevent half-time oddities
 		
 		flag.s.canTake <- true
 		flag.s.playersReturning <- []


### PR DESCRIPTION
I've been having crashes at half-time on CTF games in 1.4.0 if the flag was picked up at least once during the round:
```
[14:38:46] [info] [SERVER SCRIPT] started intro!
[14:38:46] [info] [SERVER SCRIPT] starting dropship intro!
[14:38:46] [info] [SERVER SPEW_MESSAGE] SERVER: Lunge_SetTargetEntity(): Setting lunge target to (null)
[14:38:46] [info] [SERVER SPEW_MESSAGE] Setting player "player Crryogen [1]" predicted first person proxy model to "" (class "spectator")
[14:38:46] [info] [SERVER SCRIPT] pilot primary skin/camo 1 64
[14:38:46] [info] [SERVER SCRIPT] pilot secondary skin/camo 1 64
[14:38:46] [info] [SERVER SCRIPT] pilot weapon3 skin/camo 1 64
[14:38:46] [info] [SERVER SPEW_MESSAGE] Setting player "player Crryogen [1]" predicted first person proxy model to "models/weapons/arms/pov_pilot_heavy_roog_m.mdl" (class "pilot_heavy_male")
[14:38:46] [info] [CLIENT SCRIPT] 0.48 1
[14:38:46] [info] [CLIENT SCRIPT] CTF_FlagEntChanged entity (100: class C_HealthKit [100]) imcFlagState
[14:38:46] [info] [CLIENT SCRIPT] CTF_FlagEntChanged entity (94: class C_HealthKit [94]) milFlagState
[14:38:46] [info] [CLIENT SCRIPT] CTF_FlagHomeEntChanged null null entity (98: class C_DynamicProp [98])
[14:38:46] [info] [CLIENT SCRIPT] CTF_FlagHomeEntChanged null null entity (93: class C_DynamicProp [93])
[14:38:47] [info] [SERVER SCRIPT] intro finished!
[14:38:52] [info] [SERVER SCRIPT] entity (1: player Crryogen [1]) picked up the flag!
[14:38:52] [info] [CLIENT SCRIPT] CTF_FlagEntChanged entity (1: player [1]) imcFlagState
[14:39:29] [info] [SERVER SPEW_MESSAGE] Setting player "player Crryogen [1]" predicted first person proxy model to "" (class "spectator")
[14:39:29] [info] [SERVER SCRIPT] respawn delay 6
[14:39:29] [info] [SERVER SCRIPT] started intro!
[14:39:29] [info] [SERVER SCRIPT] starting dropship intro!
[14:39:29] [info] [SERVER SCRIPT] SCRIPT ERROR: [SERVER] Attempted to call GetParent on invalid entity
[14:39:29] [info] [SERVER SCRIPT]  -> while( flag.GetParent() == player )
[14:39:29] [info] [SERVER SCRIPT]
CALLSTACK
*FUNCTION [DropFlagIfPhased()] gamemodes/_gamemode_ctf.nut line [337]

[14:39:29] [info] [SERVER SCRIPT] LOCALS
[flag] ENTITY (NULL)
[player] ENTITY (player Crryogen [1] (player "Crryogen" at <1166.07 1172.13 55.5079>))
[this] TABLE

DIAGPRINTS
```
Adding an `IsValid` check to the `while` apparently solves that. Not sure that's good enough tho.