### PR TITLE
Queued GunGame Meter

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/gg_earn_meter/_gg_earn_meter.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/gg_earn_meter/_gg_earn_meter.gnut
@@ -43,13 +43,8 @@ void function CheckQueue( entity player )
 {
 	file.checkingQueue = true
 
-	print("start checking")
-
 	while ( file.rewardQueue.len() > 0 )
 	{
-
-		print("check")
-
 		RewardStruct reward = file.rewardQueue.remove(0)
 
 		float newValue = reward.amount

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/gg_earn_meter/_gg_earn_meter.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/gg_earn_meter/_gg_earn_meter.gnut
@@ -2,21 +2,87 @@ global function Sv_GGEarnMeter_SetPercentage
 global function Sv_GGEarnMeter_AddPercentage
 global function AddCallback_GGEarnMeterFull
 
+enum RewardType
+{
+	SET,
+	ADD
+}
+
+struct RewardStruct
+{
+	float amount = 0.0
+	int type = RewardType.ADD
+}
+
 struct
 {
-	array< bool functionref( entity ) > onGGEarnMeterFullCallbacks
+	array< bool functionref( entity ) > onGGEarnMeterFullCallbacks,
+	array< RewardStruct > rewardQueue, // Because we have delayed reward handling, let's queue things so that everything gets handled eventually.
+	bool checkingQueue = false
 } file
+
+void function AddReward( entity player, float amount, int type )
+{
+	RewardStruct reward
+	reward.amount = amount
+	reward.type = type
+
+	file.rewardQueue.append( reward )
+
+	TryCheckQueue( player )
+}
+
+void function TryCheckQueue( entity player )
+{
+	if ( !file.checkingQueue ) {
+		thread CheckQueue( player )
+	}
+}
+
+void function CheckQueue( entity player )
+{
+	file.checkingQueue = true
+
+	print("start checking")
+
+	while ( file.rewardQueue.len() > 0 )
+	{
+
+		print("check")
+
+		RewardStruct reward = file.rewardQueue.remove(0)
+
+		float newValue = reward.amount
+		if ( reward.type == RewardType.ADD )
+			newValue += player.GetPlayerNetFloat( "gunGameLevelPercentage")
+		newValue = clamp( newValue, 0.0, 1.0 )
+
+		player.SetPlayerNetFloat( "gunGameLevelPercentage", newValue )
+
+		wait 0.2
+
+		if ( (newValue * 100) < 99 ) // To try and catch fun rounding issues.
+			continue
+
+		bool keepFull = false
+		foreach ( callbackFunc in file.onGGEarnMeterFullCallbacks )
+			keepFull = callbackFunc( player )
+
+		if ( !keepFull )
+			Sv_GGEarnMeter_SetPercentage(player, 0.0)
+	}
+
+	file.checkingQueue = false
+}
 
 void function Sv_GGEarnMeter_SetPercentage( entity player, float percentage )
 {
-	player.SetPlayerNetFloat( "gunGameLevelPercentage", clamp(percentage, 0.0, 1.0) )
-
-	thread CheckPercentage( player )
+	AddReward( player, percentage, RewardType.SET )
 }
 
 void function Sv_GGEarnMeter_AddPercentage( entity player, float percentage )
 {
-	Sv_GGEarnMeter_SetPercentage(player, player.GetPlayerNetFloat( "gunGameLevelPercentage") + percentage)
+	AddReward( player, percentage, RewardType.ADD )
 }
 
 void function AddCallback_GGEarnMeterFull( bool functionref( entity ) callbackFunc )
@@ -24,21 +90,4 @@ void function AddCallback_GGEarnMeterFull( bool functionref( entity ) callbackFu
 	Assert( !file.onGGEarnMeterFullCallbacks.contains( callbackFunc ), "Already added " + FunctionToString( callbackFunc ) + " with AddCallback_GGEarnMeterFull" )
 
 	file.onGGEarnMeterFullCallbacks.append( callbackFunc )
-}
-
-void function CheckPercentage( entity player )
-{
-	float percentage = player.GetPlayerNetFloat( "gunGameLevelPercentage")
-
-	if ( percentage < 1.0 )
-		return
-
-	wait 0.2
-
-	bool lastWeapon = false
-	foreach ( callbackFunc in file.onGGEarnMeterFullCallbacks )
-		lastWeapon = callbackFunc( player )
-
-	if ( !lastWeapon )
-		Sv_GGEarnMeter_SetPercentage(player, 0.0)
 }

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/gg_earn_meter/_gg_earn_meter.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/gg_earn_meter/_gg_earn_meter.gnut
@@ -1,3 +1,4 @@
+global function Sv_GGEarnMeter_Init
 global function Sv_GGEarnMeter_SetPercentage
 global function Sv_GGEarnMeter_AddPercentage
 global function AddCallback_GGEarnMeterFull
@@ -17,9 +18,20 @@ struct RewardStruct
 struct
 {
 	array< bool functionref( entity ) > onGGEarnMeterFullCallbacks,
-	array< RewardStruct > rewardQueue, // Because we have delayed reward handling, let's queue things so that everything gets handled eventually.
-	bool checkingQueue = false
+	table< entity, array< RewardStruct > > rewardQueue, // Because we have delayed reward handling, let's queue things so that everything gets handled eventually.
+	table< entity, bool > checkingQueue
 } file
+
+void function Sv_GGEarnMeter_Init()
+{
+	AddCallback_OnClientConnected( Sv_GGEarnMeter_OnClientConnected )
+}
+
+void function Sv_GGEarnMeter_OnClientConnected( entity player )
+{
+	file.rewardQueue[ player ] <- []
+	file.checkingQueue[ player ] <- false
+}
 
 void function AddReward( entity player, float amount, int type )
 {
@@ -27,25 +39,27 @@ void function AddReward( entity player, float amount, int type )
 	reward.amount = amount
 	reward.type = type
 
-	file.rewardQueue.append( reward )
+	file.rewardQueue[player].append( reward )
 
 	TryCheckQueue( player )
 }
 
 void function TryCheckQueue( entity player )
 {
-	if ( !file.checkingQueue ) {
+	if ( !file.checkingQueue[player] ) {
 		thread CheckQueue( player )
 	}
 }
 
 void function CheckQueue( entity player )
 {
-	file.checkingQueue = true
+	player.EndSignal( "OnDestroy" ) // If the player disconnects or stops existing for some reason, stop doing shit with it so the server doesn't break.
 
-	while ( file.rewardQueue.len() > 0 )
+	file.checkingQueue[player] = true
+
+	while ( file.rewardQueue[player].len() > 0 && IsValid(player) )
 	{
-		RewardStruct reward = file.rewardQueue.remove(0)
+		RewardStruct reward = file.rewardQueue[player].remove(0)
 
 		float newValue = reward.amount
 		if ( reward.type == RewardType.ADD )
@@ -69,7 +83,7 @@ void function CheckQueue( entity player )
 		wait 0.2
 	}
 
-	file.checkingQueue = false
+	file.checkingQueue[player] = false
 }
 
 void function Sv_GGEarnMeter_SetPercentage( entity player, float percentage )

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/gg_earn_meter/_gg_earn_meter.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/gg_earn_meter/_gg_earn_meter.gnut
@@ -69,7 +69,9 @@ void function CheckQueue( entity player )
 			keepFull = callbackFunc( player )
 
 		if ( !keepFull )
-			Sv_GGEarnMeter_SetPercentage(player, 0.0)
+			player.SetPlayerNetFloat( "gunGameLevelPercentage", 0.0 )
+
+		wait 0.2
 	}
 
 	file.checkingQueue = false

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/gg_earn_meter/sh_gg_earn_meter.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/gg_earn_meter/sh_gg_earn_meter.gnut
@@ -15,6 +15,10 @@ void function Sh_GGEarnMeter_Init(string gamemode)
 		file.callbackAdded = true
 		AddCallback_OnRegisteringCustomNetworkVars( RegisterSharedNetwork )
 	}
+
+	#if SERVER
+		Sv_GGEarnMeter_Init()
+	#endif
 }
 
 void function RegisterSharedNetwork()


### PR DESCRIPTION
Changed the gungame earn meter to queue up rewards, reducing the chances of rapidly gained rewards from being handled incorrectly.