### PR TITLE
Fix mod menu slider

### DIFF
--- a/Northstar.Client/mod/scripts/kb_act.lst
+++ b/Northstar.Client/mod/scripts/kb_act.lst
@@ -1,5 +1,5 @@
 "blank"					"=========================="
-"blank"					"Northstar"
+"blank"					"NORTHSTAR"
 "blank"					"=========================="
 "toggleconsole"		"Toggle Developer Console"
 "blank"					"=========================="

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_modmenu.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_modmenu.nut
@@ -359,7 +359,7 @@ void function FlushMouseDeltaBuffer()
 
 void function SliderBarUpdate()
 {
-	if ( file.modsArrayFiltered.len() <= 15 )
+	if ( file.modsArrayFiltered.len() <= 17 )
 	{
 		FlushMouseDeltaBuffer()
 		return


### PR DESCRIPTION
- Fixes mod menu slider
- Capitalises "NORTHSTAR" in key binds so it follows the rest of the section names