### PR TITLE
Update _riff_floor_is_lava.nut

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/sh_riff_floor_is_lava.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/sh_riff_floor_is_lava.nut
@@ -124,8 +124,8 @@ float function GetFogHeight()
 	file.lethalFogHeights[ "mp_relic02" ] <- 250.0 // not great, tf1's would honestly be worse though imo
 	
 	// lf maps: overall a bit hit or miss, many likely have spawn issues
-	file.lethalFogHeights[ "mp_lf_stacks" ] <- -9999.0 // entirely nonworking, breaks spawns no matter what from what i can tell, could potentially use safe zones for this?
-	file.lethalFogHeights[ "mp_lf_deck" ] <- -9999.0 // nonworking fogcontroller so fog is invisible
+	file.lethalFogHeights[ "mp_lf_stacks" ] <- 105.0 // nonworking fogcontroller so fog is invisible | 105
+	file.lethalFogHeights[ "mp_lf_deck" ] <- 200.0 // nonworking fogcontroller so fog is invisible | 200
 	file.lethalFogHeights[ "mp_lf_uma" ] <- 64.0
 	file.lethalFogHeights[ "mp_lf_meadow" ] <- 64.0
 	file.lethalFogHeights[ "mp_lf_traffic" ] <- 50.0

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_riff_floor_is_lava.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_riff_floor_is_lava.nut
@@ -46,7 +46,6 @@ void function CreateCustomSpawns_Threaded()
 	else
 		raycastTop = raycastTop + 2650
 
-		print( "\n\n\n\n\n\n				RAYCASTTOP:" + raycastTop + "\n\n\n\n\n\n" ) // this has to be higher than what you want to spawn on. May spawn in wall if lower than some rooftops
 
 	array< vector > raycastPositions
 	foreach ( entity hardpoint in GetEntArrayByClass_Expensive( "info_hardpoint" ) )

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_riff_floor_is_lava.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_riff_floor_is_lava.nut
@@ -11,7 +11,7 @@ void function RiffFloorIsLava_Init()
 
 bool function VerifyFloorIsLavaSpawnpoint( entity spawnpoint, int team )
 {
-	return ( ( spawnpoint.GetOrigin().z > GetLethalFogTop() ) && ( (GetLethalFogTop() + 300 ) > spawnpoint.GetOrigin().z ) ) // Spawns must be between the fog and 300 over the fog
+	return ( ( spawnpoint.GetOrigin().z > GetLethalFogTop() + 0 ) && ( (GetLethalFogTop() + 350 ) > spawnpoint.GetOrigin().z ) ) // OG spawnpoint.GetOrigin().z > GetLethalFogTop()
 }
 
 void function InitLavaFogController( entity fogController )
@@ -36,7 +36,18 @@ void function CreateCustomSpawns_Threaded()
 {
 	WaitEndFrame() // wait for spawns to clear
 	
-	float raycastTop = GetLethalFogTop() + 3500.0 // Tested this extensivly at this level and did not notice anything worse. Raised to guarantee no objects at this height.
+	string thismap = GetMapName()
+	
+	float raycastTop = GetLethalFogTop() // OG 2500, Lf 545, TDM 3500
+	if ( ( thismap.find( "_lf_" ) ) || ( thismap.find( "_coliseum" ) ) ) // coliseum is only there because I can. Maps like boomtown (grave) already let the ray cast through the ceiling
+		raycastTop = raycastTop + 545 // 545
+	else if ( thismap.find( "_grave" ) )
+		raycastTop = raycastTop + 1900
+	else
+		raycastTop = raycastTop + 2650
+
+		print( "\n\n\n\n\n\n				RAYCASTTOP:" + raycastTop + "\n\n\n\n\n\n" ) // this has to be higher than what you want to spawn on. May spawn in wall if lower than some rooftops
+
 	array< vector > raycastPositions
 	foreach ( entity hardpoint in GetEntArrayByClass_Expensive( "info_hardpoint" ) )
 	{

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_riff_floor_is_lava.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_riff_floor_is_lava.nut
@@ -11,7 +11,7 @@ void function RiffFloorIsLava_Init()
 
 bool function VerifyFloorIsLavaSpawnpoint( entity spawnpoint, int team )
 {
-	return spawnpoint.GetOrigin().z > GetLethalFogTop()
+	return ( ( spawnpoint.GetOrigin().z > GetLethalFogTop() ) && ( (GetLethalFogTop() + 300 ) > spawnpoint.GetOrigin().z ) ) // Spawns must be between the fog and 300 over the fog
 }
 
 void function InitLavaFogController( entity fogController )
@@ -36,7 +36,7 @@ void function CreateCustomSpawns_Threaded()
 {
 	WaitEndFrame() // wait for spawns to clear
 	
-	float raycastTop = GetLethalFogTop() + 2500.0
+	float raycastTop = GetLethalFogTop() + 3500.0 // Tested this extensivly at this level and did not notice anything worse. Raised to guarantee no objects at this height.
 	array< vector > raycastPositions
 	foreach ( entity hardpoint in GetEntArrayByClass_Expensive( "info_hardpoint" ) )
 	{


### PR DESCRIPTION
# This Update
Limits spawn heights to 300 units over the fog. The effect is pilots do not spawn on rooftops out of bounds and die. Mostly noticeable in crashsite, drydock, and complex.
Newest: Live fire maps revised, Spawns working for all.

# Needs Next
Spawns for this riff will still need work, like lava damage to auto-titans, and spawns considering enemy proximity or lava spawns being added to the main spawn.nut as a condition.