### PR TITLE
Allow for adding a client command notify callback

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_codecallbacks_common.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_codecallbacks_common.gnut
@@ -35,6 +35,7 @@ global function AddCallback_OnUpdateDerivedPilotLoadout
 global function AddCallback_OnUpdateDerivedTitanLoadout
 global function AddCallback_OnUpdateDerivedPlayerTitanLoadout
 global function AddClientCommandCallback
+global function AddClientCommandNotifyCallback
 global function AddPlayerDropScriptedItemsCallback
 global function AddCallback_OnPlayerInventoryChanged
 
@@ -498,6 +499,20 @@ void function AddClientCommandCallback( string commandString, bool functionref( 
 {
 	Assert( !( commandString in svGlobal.clientCommandCallbacks ), "Already added " + commandString + " with AddClientCommandCallback" )
 	svGlobal.clientCommandCallbacks[ commandString ] <- callbackFunc
+}
+
+void function AddClientCommandNotifyCallback( string commandString, void functionref( entity player, array<string> args ) callbackFunc )
+{
+	if ( !( commandString in svGlobal.notifyClientCommandCallbacks ) )
+	{
+		svGlobal.notifyClientCommandCallbacks[ commandString ] <- [ callbackFunc ]
+		return
+	}
+	else
+	{
+		Assert( !svGlobal.notifyClientCommandCallbacks.contains( callbackFunc ), "Already added " + string( callbackFunc ) + " with AddClientCommandNotifyCallback" )
+		svGlobal.notifyClientCommandCallbacks[ commandString ].append(callbackFunc)
+	}
 }
 
 void function AddPlayerDropScriptedItemsCallback( void functionref(entity player) callbackFunc )

--- a/Northstar.CustomServers/mod/scripts/vscripts/_mapspawn.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_mapspawn.gnut
@@ -94,6 +94,8 @@ global struct SvGlobals
 	table<string, array<void functionref( entity ent )> >onEntityChangedTeamCallbacks
 
 	table<string, bool functionref( entity player, array<string>args )> clientCommandCallbacks
+	table<string, array<void functionref( entity player, array<string>args )> > notifyClientCommandCallbacks
+
 	array<void functionref()>[ eGameState._count_ ] gameStateEnterCallbacks
 
 	bool allowPointsOverLimit = false
@@ -204,7 +206,14 @@ var function CodeCallback_ClientCommand( entity player, array<string> args )
 	//Assert( commandString in svGlobal.clientCommandCallbacks )
 	if ( commandString in svGlobal.clientCommandCallbacks  )
 	{
-		return svGlobal.clientCommandCallbacks[ commandString ]( player, args )
+		var result = svGlobal.clientCommandCallbacks[ commandString ]( player, args )
+		if ( commandString in svGlobal.notifyClientCommandCallbacks  )
+		{
+			foreach ( callbackfunc in svGlobal.notifyClientCommandCallbacks[ commandString ]){
+				callbackfunc(player, args)
+			}
+		}
+		return result
 	}
 	else
 	{


### PR DESCRIPTION
This PR allows mods to add a callback to Client Commands that's used to notify a mod that the command was called, without being the callback handling the command.

Before this, mods could only AddClientCommandCallback which only allows one script to handle any command.

example usage:
```squirrel
void function init(){
    AddClientCommandNotifyCallback("PrivateMatchLaunch", started)
}

void function started(entity player, array<string> args){
    print(player + " started the match")
}
```