### PR TITLE
Fix resetting communities_hostname to stryder

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
@@ -72,7 +72,6 @@ void function OnMainMenu_Open()
 {
 	Signal( uiGlobal.signalDummy, "EndOnMainMenu_Open" )
 	EndSignal( uiGlobal.signalDummy, "EndOnMainMenu_Open" )
-	SetConVarString( "communities_hostname", "R2-pc.stryder.respawn.com" ) // reset communities to default
 
 	UpdatePromoData() // On script restarts this gives us the last data until the new request is complete
 	RequestMainMenuPromos() // This will be ignored if there was a recent request. "infoblock_requestInterval"


### PR DESCRIPTION
Seems like loading screen counts as a "main menu", hence resetting communities_hostname ¯\\\_(ツ)\_/¯