### PR TITLE
Revert #155 "Add E-Smoke reward to Core Meter"

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter_mp.gnut
@@ -71,37 +71,13 @@ void function OnPlayerRespawned( entity player )
 		EarnMeterMP_BoostEarned( player )
 }
 
-void function EarnMeterMP_ReplaceReward( entity player, EarnObject reward, float rewardFrac )
-{
-	PlayerEarnMeter_Reset( player )
-	if ( reward.id < 0 )  // Don't set the reward if it is nonexistent
-		return
-	PlayerEarnMeter_SetReward( player, reward )
-	PlayerEarnMeter_SetRewardFrac( player, rewardFrac )
-
-	if( PlayerEarnMeter_GetRewardFrac( player ) != 0 )
-		PlayerEarnMeter_EnableReward( player )
-}
-
 void function EarnMeterMP_PlayerLifeThink( entity player )
 {
 	player.EndSignal( "OnDeath" )
 	player.EndSignal( "OnDestroy" )
 
-	EarnObject pilotReward = PlayerEarnMeter_GetReward( player ) 
-	float pilotRewardFrac = PlayerEarnMeter_GetRewardFrac( player )
 	int lastEarnMeterMode = PlayerEarnMeter_GetMode( player )
 	float lastPassiveGainTime = Time()
-
-	OnThreadEnd(
-		function() : ( player, pilotReward, pilotRewardFrac )
-		{
-			// Resets the meter to the pilot version if the player dies in a titan (otherwise pilot gets e-smoke earn meter, which is bad)
-			int earnMode = PlayerEarnMeter_GetMode( player )
-			if( earnMode == eEarnMeterMode.CORE || earnMode == eEarnMeterMode.CORE_ACTIVE )
-				EarnMeterMP_ReplaceReward( player, pilotReward, pilotRewardFrac )
-		}
-	)
 
 	while ( true )
 	{
@@ -123,28 +99,25 @@ void function EarnMeterMP_PlayerLifeThink( entity player )
 		if ( desiredEarnMeterMode != lastEarnMeterMode )
 		{
 			PlayerEarnMeter_SetMode( player, desiredEarnMeterMode )
-			if ( lastEarnMeterMode == eEarnMeterMode.DEFAULT ) // Set these here in case the player changed boost during the match (e.g. in dropship)
-			{
-				pilotReward = PlayerEarnMeter_GetReward( player ) 
-				pilotRewardFrac = PlayerEarnMeter_GetRewardFrac( player )
-			}
 
 			if ( desiredEarnMeterMode == eEarnMeterMode.DEFAULT )
 			{
-				if ( !IsTitanAvailable( player ) && lastEarnMeterMode == eEarnMeterMode.PET ) // this should only be the case after player's auto died (or they ejected)
-					EarnMeterMP_ReplaceReward( player, pilotReward, pilotRewardFrac )
+				if ( !IsTitanAvailable( player ) && PlayerEarnMeter_GetOwnedFrac( player ) == 1.0 ) // this should only be the case after player has dropped their titan
+				{
+					float oldRewardFrac = PlayerEarnMeter_GetRewardFrac( player )
+					PlayerEarnMeter_Reset( player )
+					PlayerEarnMeter_SetRewardFrac( player, oldRewardFrac )
+					PlayerEarnMeter_EnableReward( player )
+				}
 
 				if ( PlayerEarnMeter_GetRewardFrac( player ) != 0 )
 					PlayerEarnMeter_EnableReward( player )
 			}
-			else if ( desiredEarnMeterMode == eEarnMeterMode.CORE )
+			else
 			{
-				EarnMeterMP_ReplaceReward( player, EarnObject_GetByRef( "core_electric_smoke" ), CORE_SMOKE_FRAC )
-				if( SoulTitanCore_GetNextAvailableTime( player.GetTitanSoul() ) >= CORE_SMOKE_FRAC )
-					PlayerEarnMeter_SetRewardUsed( player )
+				PlayerEarnMeter_DisableGoal( player )
+				PlayerEarnMeter_DisableReward( player )
 			}
-			else if ( desiredEarnMeterMode == eEarnMeterMode.CORE_ACTIVE ) // Enables smoke after core use (doesn't show up during active, so looks fine)
-				PlayerEarnMeter_EnableReward( player )
 
 			lastEarnMeterMode = desiredEarnMeterMode
 		}
@@ -175,10 +148,6 @@ void function EarnMeterMP_PlayerLifeThink( entity player )
 
 void function EarnMeterMP_BoostEarned( entity player )
 {
-	// Can't have smoke earned via meter. Otherwise, Auto Titan could hit reward frac and get nothing
-	if( player.IsTitan() )
-		return
-
 	EarnObject earnobject = PlayerEarnMeter_GetReward( player )
 	BurnReward burncard = BurnReward_GetByRef( earnobject.ref )
 


### PR DESCRIPTION
Revert #155 as during testing we found a bug where pilots would receive `core_electric_smoke`, causing the server to crash on a script error.
