### PR TITLE
Fixed battery bug in LTS (#203)

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -676,7 +676,6 @@ void function CleanUpEntitiesForRoundEnd()
 	{
 		if ( !IsValid( npc ) )
 			continue
-		PROTO_CleanupTrackedProjectiles( npc )
 		// kill rather than destroy, as destroying will cause issues with children which is an issue especially for dropships and titans
 		npc.Die( svGlobal.worldspawn, svGlobal.worldspawn, { damageSourceId = eDamageSourceId.round_end } )
 	}

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -666,7 +666,6 @@ void function CleanUpEntitiesForRoundEnd()
 	foreach ( entity player in GetPlayerArray() )
 	{
 		ClearTitanAvailable( player )
-		PROTO_CleanupTrackedProjectiles( player )
 		player.SetPlayerNetInt( "batteryCount", 0 ) 
 		if ( IsAlive( player ) )
 			player.Die( svGlobal.worldspawn, svGlobal.worldspawn, { damageSourceId = eDamageSourceId.round_end } )

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -666,7 +666,7 @@ void function CleanUpEntitiesForRoundEnd()
 	foreach ( entity player in GetPlayerArray() )
 	{
 		ClearTitanAvailable( player )
-		
+		player.SetPlayerNetInt( "batteryCount", 0 ) 
 		if ( IsAlive( player ) )
 			player.Die( svGlobal.worldspawn, svGlobal.worldspawn, { damageSourceId = eDamageSourceId.round_end } )
 	}

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -676,7 +676,7 @@ void function CleanUpEntitiesForRoundEnd()
 	{
 		if ( !IsValid( npc ) )
 			continue
-	
+		PROTO_CleanupTrackedProjectiles( npc )
 		// kill rather than destroy, as destroying will cause issues with children which is an issue especially for dropships and titans
 		npc.Die( svGlobal.worldspawn, svGlobal.worldspawn, { damageSourceId = eDamageSourceId.round_end } )
 	}

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -666,6 +666,7 @@ void function CleanUpEntitiesForRoundEnd()
 	foreach ( entity player in GetPlayerArray() )
 	{
 		ClearTitanAvailable( player )
+		PROTO_CleanupTrackedProjectiles( player )
 		player.SetPlayerNetInt( "batteryCount", 0 ) 
 		if ( IsAlive( player ) )
 			player.Die( svGlobal.worldspawn, svGlobal.worldspawn, { damageSourceId = eDamageSourceId.round_end } )


### PR DESCRIPTION
Remove all batteries from players at the end of a round for round-based modes, prevents client thinking that they both have and don't have a battery, resulting in weird stuff (ui disagrees with player model, etc.)

From my testing this does fix #203 however if modders want to make batteries persist through rounds it'll be a bit more of a pain now