### PR TITLE
Log player UIDs on connect

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
@@ -132,7 +132,7 @@ void function CodeCallback_OnClientConnectionStarted( entity player )
 		callbackFunc( player )
 	}
 
-	printl( "Player connect started: " + player )
+	printl( "Player connect started: " + player + "---UID:" + player.GetUID() )
 	
 	InitPassives( player )
 }


### PR DESCRIPTION
Primarily to help server admins find cheater UIDs without requiring other mods. Uses a similar style to #154.