### PR TITLE
Change PlayBattleChatterLine to only play to friendlies

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/conversation/_battle_chatter.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/conversation/_battle_chatter.gnut
@@ -11,7 +11,7 @@ void function PlayBattleChatterLine( entity player, string conversationType )
 {
 	int conversationIndex = GetConversationIndex( conversationType )
 
-	foreach( entity otherPlayer in GetPlayerArray() )
+	foreach( entity otherPlayer in foreach( entity otherPlayer in GetPlayerArrayOfTeam( player.GetTeam() ) ) )
 		if ( ShouldPlayBattleChatter( conversationType, otherPlayer, player ) && player != otherPlayer )
 			Remote_CallFunction_Replay( otherPlayer, "ServerCallback_PlayBattleChatter", conversationIndex, player.GetEncodedEHandle() )
 }


### PR DESCRIPTION
In vanilla MP the battle chatter for players is only played to friendlies, so I'm changing PlayBattleChatterLine to only play to friendly players. If needed I could make a similar function that plays the battle chatter to all players as well, something like PlayBattleChatterLineToAll 

Normally I would add a check to ShouldPlayBattleChatter but that is already shipped in mp_common and I would rather not change vanilla code