### PR TITLE
Fixes Kodai + Angel battery spawns

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_powerup.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_powerup.gnut
@@ -5,19 +5,6 @@ struct {
 	array<entity> powerupSpawns
 } file
 
-const table< string, array<vector> > LTSBatterySpawns = {
-	mp_forwardbase_kodai = [
-		< 3960, 1215.04, 942 >,
-		< 31, 462.459, 797 >,
-		< -4150.21, 693.654, 1123 >
-	],
-	mp_angel_city = [
-		< -1444.55, -1108.55, 127 >,
-		< -730, 644, 121 >,
-		< 535, 2657.67, 119 >
-	]
-}
-
 void function PowerUps_Init()
 {
 	SH_PowerUp_Init()
@@ -34,16 +21,9 @@ void function AddPowerupSpawn( entity spawnpoint )
 
 void function RespawnPowerups()
 {
-	string map = GetMapName()
-	bool editSpawns = GAMETYPE == LAST_TITAN_STANDING && map in LTSBatterySpawns
-	int index = 0
-
 	foreach ( entity spawnpoint in file.powerupSpawns )
 	{
 		PowerUp powerupDef = GetPowerUpFromItemRef( expect string( spawnpoint.kv.powerUpType ) )
-		if ( editSpawns && index < LTSBatterySpawns[map].len() && powerupDef.spawnFunc() )
-			spawnpoint.SetOrigin( LTSBatterySpawns[map][index++] )
-
 		thread PowerupSpawnerThink( spawnpoint, powerupDef )
 	}
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_angel_city.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_angel_city.nut
@@ -1,5 +1,15 @@
 global function CodeCallback_MapInit
 
+struct {
+	int batteryIndex = 0
+} file
+
+const array<vector> BATTERY_SPAWNS = [
+	< -1444.55, -1108.55, 127 >, // field
+	< -730, 644, 121 >,          // mid
+	< 535, 2657.67, 119 >        // bridge
+]
+
 void function CodeCallback_MapInit()
 {
 	AddEvacNode( CreateScriptRef( < 2527.889893, -2865.360107, 753.002991 >, < 0, -80.54, 0 > ) )
@@ -9,11 +19,22 @@ void function CodeCallback_MapInit()
 
 	SetEvacSpaceNode( CreateScriptRef( < -1700, -5500, -7600 >, < -3.620642, 270.307129, 0 > ) )
 	
-	// todo: also we need to change the powerup spawns on this map, they use a version from an older patch
-	
+	// Battery spawns (in LTS/Free Agents) are in old locations, so we move them to the proper locations
+	AddSpawnCallbackEditorClass( "script_ref", "script_power_up_other", FixBatterySpawns )
+
 	// there are some really busted titan startspawns that are on the fucking other side of the map from where they should be, so we remove them
 	AddSpawnCallback( "info_spawnpoint_titan_start", TrimBadTitanStartSpawns )
 	AddSpawnCallback( "sky_camera", FixSkycamFog )
+}
+
+void function FixBatterySpawns( entity spawn )
+{
+	if ( GAMETYPE != LAST_TITAN_STANDING && GAMETYPE != FREE_AGENCY )
+		return
+
+	PowerUp powerupDef = GetPowerUpFromItemRef( expect string( spawn.kv.powerUpType ) )
+	if ( powerupDef.spawnFunc() )
+		spawn.SetOrigin( BATTERY_SPAWNS[file.batteryIndex++] )
 }
 
 void function TrimBadTitanStartSpawns( entity spawn )

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_forwardbase_kodai.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_forwardbase_kodai.nut
@@ -1,1 +1,27 @@
-//fuck
+global function CodeCallback_MapInit
+
+struct {
+	int batteryIndex = 0
+} file
+
+const array<vector> BATTERY_SPAWNS = [
+	< 3960, 1215.04, 942 >,     // cliff
+	< 31, 462.459, 797 >,       // mid
+	< -4150.21, 693.654, 1123 > // mountain
+]
+
+void function CodeCallback_MapInit()
+{
+	// Battery spawns (in LTS/Free Agents) are in old locations, so we move them to the proper locations
+	AddSpawnCallbackEditorClass( "script_ref", "script_power_up_other", FixBatterySpawns )
+}
+
+void function FixBatterySpawns( entity spawn )
+{
+	if ( GAMETYPE != LAST_TITAN_STANDING && GAMETYPE != FREE_AGENCY )
+		return
+
+	PowerUp powerupDef = GetPowerUpFromItemRef( expect string( spawn.kv.powerUpType ) )
+	if ( powerupDef.spawnFunc() )
+		spawn.SetOrigin( BATTERY_SPAWNS[file.batteryIndex++] )
+}


### PR DESCRIPTION
Updates Kodai and Angel City LTS battery spawns to match the up-to-date locations in vanilla. (Taken from my LTSRebalance mod)

Spawn points were manually placed & adjusted by eye based on recordings of vanilla locations. May not be perfect, but any differences are negligible.