### PR TITLE
Guard against null player in chat hooks

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_custom_codecallbacks.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_custom_codecallbacks.gnut
@@ -26,16 +26,18 @@ void function CServerGameDLL_OnReceivedSayTextMessageCallback()
 	localMessage.channelId = NSChatGetCurrentChannel()
 	localMessage.shouldBlock = false
 
+	if (localMessage.player == null)
+		return
+
 	foreach ( callbackFunc in NsCustomCallbacks.OnReceivedSayTextMessageCallbacks )
 	{
 		ClServer_MessageStruct returnStruct = callbackFunc(localMessage)
 		localMessage.message = returnStruct.message
-		localMessage.player = returnStruct.player
 		localMessage.channelId = returnStruct.channelId
 		localMessage.shouldBlock = localMessage.shouldBlock || returnStruct.shouldBlock
 	}
 
-	NSSetMessage(localMessage.message, localMessage.player.GetPlayerIndex(), localMessage.channelId, localMessage.shouldBlock)
+	NSSetMessage(localMessage.message, localMessage.channelId, localMessage.shouldBlock)
 }
 
 void function AddCallback_OnReceivedSayTextMessage( ClServer_MessageStruct functionref (ClServer_MessageStruct) callbackFunc )


### PR DESCRIPTION
This would be good to get into 1.5.2 as it fixes crashes players have been experiencing with chat hooks enabled (#227).

 - Skip callbacks if `GetPlayerByIndex` returns null.
 - Ignore player changes from callbacks to avoid spoofing.
 - Don't pass player index back into native code (needs https://github.com/R2Northstar/NorthstarLauncher/pull/85).

This could break mods that rely on being able to change `localMessage.player` and have later callbacks see the changed player. To my knowledge that's not something any mods currently do, nor should we support it.

Fixes #227 