### PR TITLE
Set `communities_hostname` on main menu

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
@@ -72,6 +72,8 @@ void function OnMainMenu_Open()
 {
 	Signal( uiGlobal.signalDummy, "EndOnMainMenu_Open" )
 	EndSignal( uiGlobal.signalDummy, "EndOnMainMenu_Open" )
+		
+	SetConVarString( "communities_hostname", "" ) // disable communities due to crash exploits that are still possible through it
 
 	UpdatePromoData() // On script restarts this gives us the last data until the new request is complete
 	RequestMainMenuPromos() // This will be ignored if there was a recent request. "infoblock_requestInterval"

--- a/Northstar.Client/mod/scripts/vscripts/ui/panel_mainmenu.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/panel_mainmenu.nut
@@ -526,7 +526,6 @@ void function OnPlayFDButton_Activate( var button ) // repurposed for launching 
 	if ( !Hud_IsLocked( button ) )
 	{
 		SetConVarBool( "ns_is_modded_server", true )
-		SetConVarString( "communities_hostname", "" ) // disable communities due to crash exploits that are still possible through it
 		NSTryAuthWithLocalServer()
 		thread TryAuthWithLocalServer()
 	}


### PR DESCRIPTION
Set `communities_hostname` convar on main menu, so that things like direct connect still set it properly.