### PR TITLE
Include clan tag in chat messages

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
@@ -84,7 +84,7 @@ void function CHudChat_OnReceivedSayTextMessageCallback(int fromPlayerIndex, str
             return
         }
 
-        fromPlayerName = fromPlayer.GetPlayerName()
+        fromPlayerName = fromPlayer.GetPlayerNameWithClanTag()
     }
 
     if (messageType == 0 || messageType == 1)


### PR DESCRIPTION
Turns out there's a `GetPlayerNameWithClanTag` which is far better than the 4 hours I just spent trying to reverse engineer how the native code fetched clan tags.

This doesn't actually do anything atm since clan tags don't work in NS yet (and networks are disabled at the moment anyway) but if and when they do work, this should show names in chat just like in vanilla.
