### PR TITLE
Fix chathooks logic

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
@@ -76,7 +76,7 @@ void function CHudChat_OnReceivedSayTextMessageCallback(int fromPlayerIndex, str
     entity fromPlayer = null
     string fromPlayerName = ""
 
-    if (fromPlayerIndex >= 0 && fromPlayerIndex < GetPlayerArray().len())
+    if (fromPlayerIndex >= 0 && fromPlayerIndex <= 128)
     {
         fromPlayer = GetEntByIndex(fromPlayerIndex + 1)
         if (fromPlayer == null) {


### PR DESCRIPTION
The original behaviour causes a bug where random players with high player indices would be interpreted as if they were sending server messages