### PR TITLE
fix servercrash because batteryContainer entity is null when respawning as titan

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
@@ -484,7 +484,12 @@ void function RespawnAsTitan( entity player, bool manualPosition = false )
 	player.RespawnPlayer( null ) // spawn player as pilot so they get their pilot loadout on embark
 	player.SetOrigin( titan.GetOrigin() )
 	
-	PilotBecomesTitan( player, titan ) // make player titan
+	// don't make player titan when entity batteryContainer is not valid.
+	// This will prevent a servercrash that sometimes occur when evac is disabled and somebody is calling a titan in the defeat screen.
+	if( IsValid( titan.GetTitanSoul().soul.batteryContainer ) )
+		PilotBecomesTitan( player, titan ) // make player titan
+	else
+		print( "batteryContainer is not a valid entity in RespawnAsTitan(). Skipping PilotBecomesTitan()." )
 }
 
 


### PR DESCRIPTION
Issue related to this PR: https://github.com/R2Northstar/NorthstarMods/issues/231



Add a simple check to batteryContainer and if it is not a valid entity dont do PilotBecomesTitan()
This will prevent a servercrash that sometimes occur when evac is disabled and somebody directly respawning as titan in the defeat screen.

Me and a few others on Discord tried to reproduce the issue and it's really hard. It seems to happen when you are in the Defeat screen and you're trying to spawn in directly as a titan (even the match is over).
Adding a check if the batteryContainer entity exists seems to avoid that issue. 4 servers are running that check and did not experience that crash anymore for like 4 days now.
also we see that print in the log (from else) every few hours when the server is full so I assume it works.

Also I assume we do not care about the player not  being able to respawn as titan after the match is over. 