### PR TITLE
Gun Game: Fix potentially transferring score from leaving player to new joining player

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
@@ -30,7 +30,7 @@ void function GamemodeGG_Init()
 
 void function OnPlayerDisconnected(entity player)
 {
-	// resetting a player's score when he leaves prevents a new player to join the leaver's team and having his points
+	// resetting a player's score when they leave prevents a new player to join the leaver's team and having the previous player's points
 	AddTeamScore( player.GetTeam(), -GameRules_GetTeamScore( player.GetTeam() ) )
 }
 

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
@@ -31,9 +31,7 @@ void function GamemodeGG_Init()
 void function OnPlayerDisconnected(entity player)
 {
 	// resetting a player's score when he leaves prevents a new player to join the leaver's team and having his points
-	while (GameRules_GetTeamScore(player.GetTeam()) > 0) {
-		AddTeamScore( player.GetTeam(), -1 )
-	}
+	AddTeamScore( player.GetTeam(), -GameRules_GetTeamScore( player.GetTeam() ) )
 }
 
 void function OnPlayerRespawned( entity player )

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
@@ -13,6 +13,7 @@ void function GamemodeGG_Init()
 
 	AddCallback_OnPlayerRespawned( OnPlayerRespawned )
 	AddCallback_OnPlayerKilled( OnPlayerKilled )
+	AddCallback_OnClientDisconnected( OnPlayerDisconnected )
 
 	AddCallback_GameStateEnter( eGameState.WinnerDetermined, OnWinnerDetermined )
 
@@ -25,6 +26,14 @@ void function GamemodeGG_Init()
 			SetPlaylistVarOverride( "scorelimit", GetGunGameWeapons().len().tostring() )
 	}
 	catch ( ex ) {}
+}
+
+void function OnPlayerDisconnected(entity player)
+{
+	// resetting a player's score when he leaves prevents a new player to join the leaver's team and having his points
+	while (GameRules_GetTeamScore(player.GetTeam()) > 0) {
+		AddTeamScore( player.GetTeam(), -1 )
+	}
 }
 
 void function OnPlayerRespawned( entity player )


### PR DESCRIPTION
fixed a bug in which a player that just joined the server might have someone who's left the server's score
(this fix should be applied to all ffa gamemodes)