### PR TITLE
workaround fastball crash from serverside - revert this when proper fix

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fastball.gnut
@@ -286,7 +286,7 @@ function FastballOnPanelHacked( panel, player )
 		{
 			deadPlayer.SetOrigin( panel.s.startOrigin )
 			deadPlayer.RespawnPlayer( null )
-			Remote_CallFunction_NonReplay( deadPlayer, "ServerCallback_FastballRespawnPlayer" ) 
+			// Remote_CallFunction_NonReplay( deadPlayer, "ServerCallback_FastballRespawnPlayer" ) temporarily disabled due to causing clientside crash
 		}
 	}
 }


### PR DESCRIPTION
fixes: #280

this a workaround, not a fix. works serverside by just never calling the crashing remote function - it only plays a particle anyways.