### PR TITLE
Server Browser: QOL and hide server info if no server focused

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_connect_password.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_connect_password.nut
@@ -47,7 +47,7 @@ void function OnConnectWithPasswordMenuOpened()
 	Hud_SetText( file.connectButton, "#MENU_CONNECT_MENU_CONNECT" )
 	Hud_SetText( file.enterPasswordBox, "" )
 	Hud_SetText( file.enterPasswordDummy, "" )
-	Hud_SetFocused(Hud_GetChild( file.menu, "EnterPasswordBox"))
+	Hud_SetFocused( file.enterPasswordBox )
 
 }
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_connect_password.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_connect_password.nut
@@ -47,6 +47,8 @@ void function OnConnectWithPasswordMenuOpened()
 	Hud_SetText( file.connectButton, "#MENU_CONNECT_MENU_CONNECT" )
 	Hud_SetText( file.enterPasswordBox, "" )
 	Hud_SetText( file.enterPasswordDummy, "" )
+	Hud_SetFocused(Hud_GetChild( file.menu, "EnterPasswordBox"))
+
 }
 
 void function ConnectWithPassword( var button )

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -556,7 +556,8 @@ bool function IsServerButtonFocused()
 	return false;
 }
 
-bool function IsSearchBarFocused() {
+bool function IsSearchBarFocused() 
+{
 	return Hud_GetChild( file.menu, "BtnServerSearch") == GetFocus()
 }
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -535,7 +535,8 @@ void function OnEnterPressed(arg)
 
 void function OnKeyRPressed(arg) 
 {
-	if (!IsSearchBarFocused()) {
+	if (!IsSearchBarFocused()) 
+	{
 		RefreshServers(0);
 	}
 }

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -533,7 +533,8 @@ void function OnEnterPressed(arg)
 	}
 }
 
-void function OnKeyRPressed(arg) {
+void function OnKeyRPressed(arg) 
+{
 	if (!IsSearchBarFocused()) {
 		RefreshServers(0);
 	}

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -164,7 +164,6 @@ void function InitServerBrowserMenu()
 	{
 		AddButtonEventHandler( button, UIE_CLICK, OnServerButtonClicked )
 		AddButtonEventHandler( button, UIE_GET_FOCUS, OnServerButtonFocused )
-		AddButtonEventHandler( button, UIE_LOSE_FOCUS, OnServerButtonFocusLost )
 		Hud_SetWidth( button , width )
 	}
 
@@ -457,6 +456,7 @@ void function OnKeyTabPressed(var button) {
 		}
 		else {
 			Hud_SetFocused(Hud_GetChild(file.menu, "BtnServerSearch"))
+			HideServerInfo()
 		}
 	}
 	catch ( ex ) {}
@@ -484,6 +484,7 @@ void function OnHitDummyBottom(var button) {
 		// was at bottom already
 		file.scrollOffset = file.serversArrayFiltered.len() - BUTTONS_PER_PAGE
 		Hud_SetFocused(Hud_GetChild(file.menu, "BtnServerSearch"))
+		HideServerInfo()
 	} else {
 		// only update if list position changed
 		UpdateShownPage()
@@ -611,6 +612,7 @@ void function FilterAndUpdateList( var n )
 	file.scrollOffset = 0
 	UpdateListSliderPosition( file.serversArrayFiltered.len() )
 
+	HideServerInfo()
 	FilterServerList()
 
 
@@ -828,10 +830,6 @@ void function OnServerButtonFocused( var button )
 		file.focusedServerIndex = file.serversArrayFiltered[ file.scrollOffset + scriptID ].serverIndex
 	DisplayFocusedServerInfo(scriptID);
 
-}
-
-void function OnServerButtonFocusLost( var button ) {
-	HideServerInfo()
 }
 
 void function OnServerButtonClicked(var button)

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -1021,6 +1021,8 @@ void function ThreadedAuthAndConnectToServer( string password = "" )
 	if (file.cancelConnection)
 	{
 		file.cancelConnection = false
+		// re-focus server list
+		Hud_SetFocused( Hud_GetChild( file.menu, "BtnServer" + (file.serverButtonFocusedID + 1)) )
 		return
 	}
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -527,7 +527,8 @@ void function OnUpArrowSelected( var button )
 void function OnEnterPressed(arg) 
 {
 	// only trigger if a server is focused
-	if (IsServerButtonFocused()) {
+	if (IsServerButtonFocused()) 
+	{
 		OnServerSelected(0)
 	}
 }

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -548,7 +548,8 @@ bool function IsServerButtonFocused()
 
 	foreach (element in GetElementsByClassname( file.menu, "ServerButton")) 
 	{
-		if ( element == focusedElement ) return true
+		if ( element == focusedElement ) 
+			return true
 	}
 
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -546,7 +546,8 @@ bool function IsServerButtonFocused()
 	var focusedElement = GetFocus();
 	var name = Hud_GetHudName(focusedElement);
 
-	foreach (element in GetElementsByClassname( file.menu, "ServerButton")) {
+	foreach (element in GetElementsByClassname( file.menu, "ServerButton")) 
+	{
 		if ( element == focusedElement ) return true
 	}
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -164,6 +164,7 @@ void function InitServerBrowserMenu()
 	{
 		AddButtonEventHandler( button, UIE_CLICK, OnServerButtonClicked )
 		AddButtonEventHandler( button, UIE_GET_FOCUS, OnServerButtonFocused )
+		AddButtonEventHandler( button, UIE_LOSE_FOCUS, OnServerButtonFocusLost )
 		Hud_SetWidth( button , width )
 	}
 
@@ -399,6 +400,8 @@ void function OnCloseServerBrowserMenu()
 		DeregisterButtonPressedCallback(MOUSE_WHEEL_UP , OnScrollUp)
 		DeregisterButtonPressedCallback(MOUSE_WHEEL_DOWN , OnScrollDown)
 		DeregisterButtonPressedCallback(KEY_TAB , OnKeyTabPressed)
+		DeregisterButtonPressedCallback(KEY_ENTER, OnEnterPressed)
+		DeregisterButtonPressedCallback(KEY_R, OnKeyRPressed)
 	}
 	catch ( ex ) {}
 }
@@ -425,6 +428,8 @@ void function OnServerBrowserMenuOpened()
 	RegisterButtonPressedCallback(MOUSE_WHEEL_UP , OnScrollUp)
 	RegisterButtonPressedCallback(MOUSE_WHEEL_DOWN , OnScrollDown)
 	RegisterButtonPressedCallback(KEY_TAB , OnKeyTabPressed)
+	RegisterButtonPressedCallback(KEY_ENTER, OnEnterPressed)
+	RegisterButtonPressedCallback(KEY_R, OnKeyRPressed)
 }
 
 ////////////////////////////
@@ -448,13 +453,10 @@ void function OnKeyTabPressed(var button) {
 	{
 		// toggle focus between server list and filter panel
 		if (IsFilterPanelElementFocused()) {
-			// print("Switching focus from filter panel to server list")
 			Hud_SetFocused(Hud_GetChild(file.menu, "BtnServer1"))
 		}
 		else {
-			// print("Switching focus from server list to filter panel")
 			Hud_SetFocused(Hud_GetChild(file.menu, "BtnServerSearch"))
-			HideServerInfo()
 		}
 	}
 	catch ( ex ) {}
@@ -516,6 +518,38 @@ void function OnUpArrowSelected( var button )
 	}
 	UpdateShownPage()
 	UpdateListSliderPosition( file.serversArrayFiltered.len() )
+}
+
+////////////////////////
+// Key Callbacks
+////////////////////////
+void function OnEnterPressed(arg) {
+	// only trigger if a server is focused
+	if (IsServerButtonFocused()) {
+		OnServerSelected(0)
+	}
+}
+
+void function OnKeyRPressed(arg) {
+	if (!IsSearchBarFocused()) {
+		RefreshServers(0);
+	}
+}
+
+bool function IsServerButtonFocused() {
+	var focusedElement = GetFocus();
+	var name = Hud_GetHudName(focusedElement);
+
+	foreach (element in GetElementsByClassname( file.menu, "ServerButton")) {
+		if ( element == focusedElement ) return true
+	}
+
+
+	return false;
+}
+
+bool function IsSearchBarFocused() {
+	return Hud_GetChild( file.menu, "BtnServerSearch") == GetFocus()
 }
 
 
@@ -794,6 +828,10 @@ void function OnServerButtonFocused( var button )
 		file.focusedServerIndex = file.serversArrayFiltered[ file.scrollOffset + scriptID ].serverIndex
 	DisplayFocusedServerInfo(scriptID);
 
+}
+
+void function OnServerButtonFocusLost( var button ) {
+	HideServerInfo()
 }
 
 void function OnServerButtonClicked(var button)

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -541,7 +541,8 @@ void function OnKeyRPressed(arg)
 	}
 }
 
-bool function IsServerButtonFocused() {
+bool function IsServerButtonFocused() 
+{
 	var focusedElement = GetFocus();
 	var name = Hud_GetHudName(focusedElement);
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -524,7 +524,8 @@ void function OnUpArrowSelected( var button )
 ////////////////////////
 // Key Callbacks
 ////////////////////////
-void function OnEnterPressed(arg) {
+void function OnEnterPressed(arg) 
+{
 	// only trigger if a server is focused
 	if (IsServerButtonFocused()) {
 		OnServerSelected(0)


### PR DESCRIPTION
- Hide server info if no server selected (sometimes showed (the wrong server) even so no server was selected, e.g. if changing the filters)

QOL:
- Pressing enter once connects to a server (was handled by 'double click handler' before, so you had to press it twice)
- Add 'R' key bind to reload the server list (Had a controller bind, but none for keyboard)
- Auto focus password field on connect to password protected server