### PR TITLE
Restrict and log message sending on connect

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_custom_codecallbacks.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_custom_codecallbacks.gnut
@@ -22,7 +22,7 @@ void function CServerGameDLL_ProcessMessageStartThread(int playerIndex, string m
 void function CServerGameDLL_OnReceivedSayTextMessageCallback(int playerIndex, string message, bool isTeam)
 {
 	entity player = GetPlayerByIndex(playerIndex)
-	if (player == null) {
+	if (player == null || !player.hasConnected) {
 		print("Ignored chat message from invalid player index " + playerIndex + ": " + message)
 		return
 	}

--- a/Northstar.CustomServers/mod/scripts/vscripts/_custom_codecallbacks.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_custom_codecallbacks.gnut
@@ -26,6 +26,7 @@ void function CServerGameDLL_OnReceivedSayTextMessageCallback(int playerIndex, s
 		print("Ignored chat message from invalid player index " + playerIndex + ": " + message)
 		return
 	}
+	print("Received message from " + player + "(" + player.GetUID() + "): " + message)
 
 	ClServer_MessageStruct localMessage
 	localMessage.message = message

--- a/Northstar.CustomServers/mod/scripts/vscripts/lobby/_lobby.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/lobby/_lobby.gnut
@@ -25,6 +25,7 @@ void function Lobby_OnClientConnectionStarted( entity player )
 
 void function Lobby_OnClientConnectionCompleted( entity player )
 {
+	player.hasConnected = true
 	FinishClientScriptInitialization( player )
 }
 


### PR DESCRIPTION
Restricts users from sending messages until they are fully connected. This is related to a bug where if a player joins the server, send a message, and disconnects quickly enough the join message will not show up in the chat.

Also logs messages for debugging and security tracing reasons