### PR TITLE
Re-enable communities

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
@@ -72,8 +72,7 @@ void function OnMainMenu_Open()
 {
 	Signal( uiGlobal.signalDummy, "EndOnMainMenu_Open" )
 	EndSignal( uiGlobal.signalDummy, "EndOnMainMenu_Open" )
-
-	SetConVarString( "communities_hostname", "" ) // disable communities due to crash exploits that are still possible through it
+	SetConVarString( "communities_hostname", "R2-pc.stryder.respawn.com" ) // reset communities to default
 
 	UpdatePromoData() // On script restarts this gives us the last data until the new request is complete
 	RequestMainMenuPromos() // This will be ignored if there was a recent request. "infoblock_requestInterval"

--- a/Northstar.Client/mod/scripts/vscripts/ui/panel_mainmenu.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/panel_mainmenu.nut
@@ -528,7 +528,7 @@ void function OnPlayFDButton_Activate( var button ) // repurposed for launching 
 	if ( !Hud_IsLocked( button ) )
 	{
 		SetConVarBool( "ns_is_modded_server", true )
-		SetConVarString( "communities_hostname", "" ) // disable communities due to crash exploits that are still possible through it
+		
 		NSTryAuthWithLocalServer()
 		thread TryAuthWithLocalServer()
 	}


### PR DESCRIPTION
With [patches added to Launcher](https://github.com/R2Northstar/NorthstarLauncher/blob/b8a7feabea6456f7fa5e8403c8d9bd2630401045/NorthstarDedicatedTest/ExploitFixes.cpp#L316) since disabling communities we should now no longer be susceptible to attacks currently targeted at the default Network in-game.

As such we could re-enable community functionality. Whether we should is up for debate. Hence I marked this PR as draft.

Please use :+1: and :-1: to vote on whether we should re-enable communities and/or leave feedback as comments <3

Reverts
- 5d51cdaabb4e88bf61414f5c2c7fba278aef7c6b
- 893db637d5471dc3eb43a8d0ba77cb5d49cd5008