### PR TITLE
make mod button in main menu accessible when running with -dev

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
@@ -57,7 +57,7 @@ void function InitMainMenu()
 
 #if DEV
 	if ( DevStartPoints() )
-		AddMenuFooterOption( menu, BUTTON_Y, "#Y_BUTTON_DEV_MENU", "#DEV_MENU", OpenSinglePlayerDevMenu )
+	    AddMenuFooterOption( menu, BUTTON_SHOULDER_LEFT, "#Y_BUTTON_DEV_MENU", "#DEV_MENU", OpenSinglePlayerDevMenu )
 #endif // DEV
 }
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
@@ -57,7 +57,7 @@ void function InitMainMenu()
 
 #if DEV
 	if ( DevStartPoints() )
-	    AddMenuFooterOption( menu, BUTTON_SHOULDER_LEFT, "#Y_BUTTON_DEV_MENU", "#DEV_MENU", OpenSinglePlayerDevMenu )
+		AddMenuFooterOption( menu, BUTTON_SHOULDER_LEFT, "#Y_BUTTON_DEV_MENU", "#DEV_MENU", OpenSinglePlayerDevMenu )
 #endif // DEV
 }
 


### PR DESCRIPTION
Just a minor thing, but if you run N* with the `-dev` option the `Mods` button in the main menu gets replaced with Tf2's `Dev Menu`.

This makes it so both buttons show up.

P.s.: was originally #319 but GH did what ever and just closed that PR

Before:
![image](https://user-images.githubusercontent.com/18683538/164712653-b479670a-e9bc-4a08-a0d5-57b21d02ce14.png)

After:
![image](https://user-images.githubusercontent.com/18683538/164712733-883bd738-9945-4d79-88ec-7a6f5ff2b119.png)
