### PR TITLE
Disable Triple Threat until ready for release

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/sh_northstar_custom_precache.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/sh_northstar_custom_precache.gnut
@@ -4,7 +4,8 @@ global function NorthstarCustomPrecache
 void function NorthstarCustomPrecache()
 {
 	PrecacheWeapon( "mp_weapon_peacekraber" )
-	PrecacheWeapon( "mp_titanweapon_triplethreat" )
+	// Triple Threat disabled due to compat issues, see #331
+	// PrecacheWeapon( "mp_titanweapon_triplethreat" )
 	PrecacheWeapon( "melee_pilot_kunai" )
 
 	// create kunai damage source so game won't crash when we hit smth with it


### PR DESCRIPTION
While there is no known issue with the Triple Threat (apart from missing logic where the crosshair wouldn't rotate on ADS), it introduces full compatibility break with older versions that do not have the Triple Threat. This is especially problematic atm as with "_Titanfall day_" coming up we want as much compatibility as possible between `1.6`, `1.7` and maybe a version thereafter.

To make running testing things on `main` branch less of a hassle I'd suggest not precaching it for now until ready for release.

In order to actually release it, I'd suggest an update solely dedicated to it with no other changes. That way server owners can update their servers without any fear of breakage introduced by other features which should hopefully result in a quick update rate.

Probably best to release it in ~2 weeks from now once the potential new crowd of players from "_Titanfall day_" has gone down a bit again.

Supersedes #330 