### PR TITLE
Allow lobby admins and add ConVars to default autoexec_ns_server.cfg

### DIFF
--- a/Northstar.CustomServers/mod.json
+++ b/Northstar.CustomServers/mod.json
@@ -35,6 +35,10 @@
 			"DefaultValue": "0"
 		},
 		{
+			"Name": "ns_private_match_admin_uids",
+			"DefaultValue": ""
+		},
+		{
 			"Name": "ns_private_match_only_host_can_start",
 			"DefaultValue": "0"
 		},

--- a/Northstar.CustomServers/mod/cfg/autoexec_ns_server.cfg
+++ b/Northstar.CustomServers/mod/cfg/autoexec_ns_server.cfg
@@ -16,7 +16,7 @@ ns_should_return_to_lobby 1 // whether the server should return to private match
 ns_private_match_only_host_can_change_settings = 0 // If 0 Players can change all match settings. If 1 Players can only change map and gamemode. If 2 Players can change nothing.
 ns_private_match_only_host_can_start = 0 // same as settings above but for starting the match
 ns_private_match_countdown_length = 15 // sets the countdown length on which the countdown can still be cancelled in lobby.
-ns_private_match_admin_uids = "" // add coma separated UIDs to allow certain players to change map, even not being the host when ns_private_match_only_host_can_change_settings is enabled.
+ns_private_match_admin_uids = "" // add comma separated UIDs to allow certain players to change map, settings and start the match, even not being the host when ns_private_match_only_host_can_change_settings / can_start is enabled.
 
 net_chan_limit_mode 2 // kick clients that go over the limit
 net_chan_limit_msec_per_sec 100 // number of milliseconds of server netchan processing time clients can use per second before getting kicked

--- a/Northstar.CustomServers/mod/cfg/autoexec_ns_server.cfg
+++ b/Northstar.CustomServers/mod/cfg/autoexec_ns_server.cfg
@@ -13,6 +13,10 @@ everything_unlocked 1 // unlock everything
 
 // gameserver settings
 ns_should_return_to_lobby 1 // whether the server should return to private match lobby after completing a game, if 0, this will go to the next map/mode in the playlist
+ns_private_match_only_host_can_change_settings = 0 // If 0 Players can change all match settings. If 1 Players can only change map and gamemode. If 2 Players can change nothing.
+ns_private_match_only_host_can_start = 0 // same as settings above but for starting the match
+ns_private_match_countdown_length = 15 // sets the countdown length on which the countdown can still be cancelled in lobby.
+ns_private_match_admin_uids = "" // add coma separated UIDs to allow certain players to change map, even not being the host when ns_private_match_only_host_can_change_settings is enabled.
 
 net_chan_limit_mode 2 // kick clients that go over the limit
 net_chan_limit_msec_per_sec 100 // number of milliseconds of server netchan processing time clients can use per second before getting kicked

--- a/Northstar.CustomServers/mod/scripts/vscripts/lobby/_private_lobby.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/lobby/_private_lobby.gnut
@@ -6,6 +6,7 @@ struct {
 	int startState
 	string map = "mp_forwardbase_kodai"
 	string mode = "aitdm"
+	array<string> admin_uids = [""]
 } file 
 
 void function PrivateLobby_Init()
@@ -14,6 +15,7 @@ void function PrivateLobby_Init()
 	
 	file.map = GetConVarString( "ns_private_match_last_map" )
 	file.mode = GetConVarString( "ns_private_match_last_mode" )
+	file.admin_uids = split( GetConVarString( "ns_private_match_admin_uids" ), "," )
 	
 	thread SetupPrivateMatchUIVarsWhenReady()
 	
@@ -38,7 +40,7 @@ void function SetupPrivateMatchUIVarsWhenReady()
 bool function ClientCommandCallback_PrivateMatchLaunch( entity player, array<string> args )
 {
 	if ( GetConVarBool( "ns_private_match_only_host_can_start" ) )
-		if ( !NSIsPlayerIndexLocalPlayer( player.GetPlayerIndex() ) )
+		if ( !PlayerHasLobbyPermission( player ) )
 			return true
 	
 	PlayerChangedTheGame( player , " changed the game state." , args )
@@ -73,7 +75,7 @@ bool function ClientCommandCallback_PrivateMatchSetMode( entity player, array<st
 		return true
 	
 	if ( GetConVarInt( "ns_private_match_only_host_can_change_settings" ) == 2 )
-		if ( !NSIsPlayerIndexLocalPlayer( player.GetPlayerIndex() ) )
+		if ( !PlayerHasLobbyPermission( player ) )
 			return true
 	
 	PlayerChangedTheGame( player , " changed the mode to " , args )
@@ -97,7 +99,7 @@ bool function ClientCommandCallback_SetCustomMap( entity player, array<string> a
 		return true
 	
 	if ( GetConVarInt( "ns_private_match_only_host_can_change_settings" ) == 2 )
-		if ( !NSIsPlayerIndexLocalPlayer( player.GetPlayerIndex() ) )
+		if ( !PlayerHasLobbyPermission( player ) )
 			return true
 	
 	PlayerChangedTheGame( player , " changed the map to " , args )
@@ -217,7 +219,7 @@ bool function ClientCommandCallback_PrivateMatchSetPlaylistVarOverride( entity p
 		return true
 		
 	if ( GetConVarInt( "ns_private_match_only_host_can_change_settings" ) >= 1 )
-		if ( !NSIsPlayerIndexLocalPlayer( player.GetPlayerIndex() ) )
+		if ( !PlayerHasLobbyPermission( player ) )
 			return true
 	
 	PlayerChangedTheGame( player , " override the setting " , args )
@@ -263,4 +265,11 @@ void function PlayerChangedTheGame( entity player , string step , array<string> 
 	else{
 		print( player.GetPlayerName() + step + ".---" + "UID:" + player.GetUID())
 	}
+}
+
+bool function PlayerHasLobbyPermission( entity player )
+{
+	if ( NSIsPlayerIndexLocalPlayer( player.GetPlayerIndex() ) || file.admin_uids.contains( player.GetUID() ) )
+		return true
+	return false
 }


### PR DESCRIPTION
Allows to restrict lobby using `ns_private_match_only_host_can_change_settings` / `ns_private_match_only_host_can_start` but allow it for admins, if their UID was added to `ns_private_match_admin_uids`.

This allows, for example, server owners (dedicated) to add themselves as admin to go back to lobby, without allowing everybody to change stuff.

Also update default autoexec_ns_server.cfg so it contains by default:

- `ns_private_match_only_host_can_change_settings`
- `ns_private_match_only_host_can_start`
- `ns_private_match_countdown_length`
- `ns_private_match_admin_uids`

These are used often and people tend to change them in the `mod.json` file instead of adding the ConVars to `autoexec_ns_server.cfg` themselves.