### PR TITLE
Display Northstar version on title screen

### DIFF
--- a/Northstar.Client/mod.json
+++ b/Northstar.Client/mod.json
@@ -54,6 +54,13 @@
 			}
 		},
 		{
+			"Path": "ui/menu_ns_setversionlabel.nut",
+			"RunOn": "UI",
+			"UICallback": {
+				"After": "NS_SetVersionLabel"
+			}
+		},
+		{
 			"Path": "presence/ui_presence.nut",
 			"RunOn": "UI",
 			"UICallback": {

--- a/Northstar.Client/mod/resource/ui/menus/main.menu
+++ b/Northstar.Client/mod/resource/ui/menus/main.menu
@@ -1,0 +1,174 @@
+resource/ui/menus/main.menu
+{
+	menu
+	{
+		ControlName				Frame
+		xpos					0
+		ypos					0
+		zpos					3
+		wide					f0
+		tall					f0
+		autoResize				0
+		pinCorner				0
+		visible					1
+		enabled					1
+		tabPosition				0
+		PaintBackgroundType		0 // 0 for normal(opaque), 1 for single texture from Texture1, and 2 for rounded box w/ four corner textures
+		infocus_bgcolor_override	"0 0 0 0"
+		outoffocus_bgcolor_override	"0 0 0 0"
+
+		Screen
+		{
+			ControlName				Label
+		    wide			        %100
+		    tall			        %100
+			labelText				""
+			visible					0
+		}
+
+		SafeArea
+		{
+			ControlName				Label
+		    wide			        %90
+		    tall			        %90
+			labelText				""
+			visible					0
+
+            pin_to_sibling			Screen
+            pin_corner_to_sibling	CENTER
+            pin_to_sibling_corner	CENTER
+		}
+
+		TitleRui
+		{
+			ControlName				RuiPanel
+			xpos                    -50
+			ypos					-160
+			wide					1408
+			tall					288
+			rui                     "ui/basic_image_premul.rpak"
+			visible					1
+
+            pin_to_sibling			Screen
+            pin_corner_to_sibling	CENTER
+            pin_to_sibling_corner	CENTER
+		}
+
+        TrialLabel
+        {
+        	ControlName				Label
+        	xpos                    -850
+        	ypos                    -190
+        	auto_wide_tocontents 	1
+        	auto_tall_tocontents 	1
+        	labelText				"#TRIAL_MODE"
+        	font					DefaultBold_65
+        	visible					1
+            fgcolor_override		"254 184 0 255"
+
+        	pin_to_sibling			TitleRui
+        	pin_corner_to_sibling	TOP_RIGHT
+        	pin_to_sibling_corner	TOP_LEFT
+        }
+
+        VersionDisplay
+        {
+            ControlName				Label
+            xpos                    -920
+            ypos                    -198
+            auto_wide_tocontents 	1
+            auto_tall_tocontents 	1
+            labelText				""
+            font					Default_21
+            visible					0
+            fgcolor_override 		"120 120 140 255"
+
+            pin_to_sibling			TitleRui
+            pin_corner_to_sibling	TOP_LEFT
+            pin_to_sibling_corner	TOP_LEFT
+        }
+
+        CopyrightInfo
+        {
+        	ControlName				Label
+        	ypos					-4
+        	zpos 					5
+        	wide 					674
+        	auto_tall_tocontents 	1
+        	labelText				"#COPYRIGHT_TEXT"
+        	font					Default_16
+        	textAlignment			east
+        	allcaps					1
+        	visible					1
+            fgcolor_override		"255 255 255 127"
+
+        	pin_to_sibling			SafeArea
+        	pin_corner_to_sibling	BOTTOM_RIGHT
+        	pin_to_sibling_corner	BOTTOM_RIGHT
+        }
+
+		RespawnLogo
+		{
+			ControlName				ImagePanel
+			xpos					24
+			wide					284
+			tall					56
+			visible					1
+			image					"ui/menu/title_screen/title_respawn_logo"
+			scaleImage				1
+
+        	pin_to_sibling			CopyrightInfo
+        	pin_corner_to_sibling	BOTTOM_RIGHT
+        	pin_to_sibling_corner	TOP_RIGHT
+		}
+
+		NSVersion
+		{
+        	ControlName				Label
+			xpos					-57
+        	wide 					674
+        	auto_tall_tocontents 	1
+        	labelText				"Northstar v10.00.00"
+        	font					Default_32
+        	textAlignment			east
+        	allcaps					0
+        	visible					1
+            fgcolor_override		"255 255 255 127"
+			pin_to_sibling			RespawnLogo
+        	pin_corner_to_sibling	BOTTOM_RIGHT
+        	pin_to_sibling_corner	TOP_RIGHT
+		}
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+	    EstablishUserPanel
+	    {
+		    ControlName				CNestedPanel
+		    classname				"MainMenuPanelClass"
+			wide					1920
+			tall					1080
+		    visible					0
+		    controlSettingsFile		"resource/ui/menus/panels/establish_user.res"
+	    }
+
+	    MainMenuPanel
+	    {
+		    ControlName				CNestedPanel
+   		    classname				"MainMenuPanelClass"
+			//wide					1920
+			//tall					1080
+			wide					%100
+			tall					%100
+		    visible					0
+		    tabPosition             1
+		    controlSettingsFile		"resource/ui/menus/panels/mainmenu.res"
+	    }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+		FooterButtons
+		{
+			ControlName				CNestedPanel
+			InheritProperties       FooterButtons
+		}
+	}
+}

--- a/Northstar.Client/mod/resource/ui/menus/main.menu
+++ b/Northstar.Client/mod/resource/ui/menus/main.menu
@@ -125,10 +125,11 @@ resource/ui/menus/main.menu
 		NSVersion
 		{
         	ControlName				Label
+			classname				"nsVersionClass"
 			xpos					-57
         	wide 					674
         	auto_tall_tocontents 	1
-        	labelText				"Northstar v10.00.00"
+        	labelText				""
         	font					Default_32
         	textAlignment			east
         	allcaps					0

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_setversionlabel.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_setversionlabel.nut
@@ -1,0 +1,12 @@
+untyped
+global function NS_SetVersionLabel
+
+void function NS_SetVersionLabel()
+{
+    if( NSIsModEnabled( "Northstar.Custom" ) ) //Checks if Northstar.Custom is enabled for pulling version data.
+    {
+        var mainMenu = GetMenu( "MainMenu" ) //Gets main menu element
+        var versionLabel = GetElementsByClassname( mainMenu, "nsVersionClass" )[0] //Gets the label from the mainMenu element.
+        Hud_SetText( versionLabel, "Northstar v" + NSGetModVersionByModName("Northstar.Custom")) //Sets the label text (Getting Northstar version from Northstar.Custom)
+    }
+}


### PR DESCRIPTION
Hi.
The position of the text is still temporary, if someone'd like to change it just let me know. The script pulls the Northstar version from Northstar.Custom (now you'll have to keep that updated, lol) and displays it along with "Northstar" on the title screen. This feature was requested in the Northstar repository, issue number in the other repo is #272
