### PR TITLE
this very much still crashes

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/cl_gamemode_fastball.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/cl_gamemode_fastball.gnut
@@ -92,8 +92,9 @@ void function FastballRespawnPlayerEffects_Threaded()
 	// sometimes this seems to get called before the player has respawned clientside, so we just wait until the client thinks they're alive
 	entity player = GetLocalClientPlayer()
 	
-	while ( !IsAlive( player ) || !IsValid( player.GetCockpit() ) )
+	while ( !( IsAlive( player ) && IsValid( player.GetCockpit() ) )
 		WaitFrame()
 		
-	StartParticleEffectOnEntity( player.GetCockpit(), GetParticleSystemIndex( $"P_pod_screen_lasers_OUT" ), FX_PATTACH_ABSORIGIN_FOLLOW, -1 )
+	if ( IsValid( player.GetCockpit() ) 
+		StartParticleEffectOnEntity( player.GetCockpit(), GetParticleSystemIndex( $"P_pod_screen_lasers_OUT" ), FX_PATTACH_ABSORIGIN_FOLLOW, -1 )
 }


### PR DESCRIPTION
idk how but this should at least make sure it don't

```
[2022-05-20 20:36:12.589] [info] [CLIENT SCRIPT] SCRIPT ERROR: [CLIENT] Entity is null
[2022-05-20 20:36:12.589] [info] [CLIENT SCRIPT]  -> StartParticleEffectOnEntity( player.GetCockpit(), GetParticleSystemIndex( $"P_pod_screen_lasers_OUT" ), FX_PATTACH_ABSORIGIN_FOLLOW, -1 )
[2022-05-20 20:36:12.589] [info] [CLIENT SCRIPT] 
CALLSTACK
*FUNCTION [FastballRespawnPlayerEffects_Threaded()] gamemodes/cl_gamemode_fastball.gnut line [98]

[2022-05-20 20:36:12.589] [info] [CLIENT SCRIPT] LOCALS
[player] ENTITY (player [10] (player "crypt6___2" at <7200.16 -2675.22 2425.4>))
[this] TABLE
```