### PR TITLE
Create empty mod.pdiff in NS Custom

### DIFF
--- a/Northstar.Custom/mod.pdiff
+++ b/Northstar.Custom/mod.pdiff
@@ -1,0 +1,1 @@
+// this is just an empty pdiff file so that if people roll back an update the pdiff file will be overwritten


### PR DESCRIPTION
Making a PR for this just so if people rollback an update or something in the future the pdiff file will be overwritten, means if we break stuff with pdiff people wont have to manually delete the .pdiff file to fix things