### PR TITLE
[FD] The Cursed Nuke Titans Fix

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/ai/_ai_nuke_titans.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/ai/_ai_nuke_titans.gnut
@@ -58,7 +58,8 @@ void function NukeTitanSeekOutGenerator( entity titan, entity generator )
 	{
 		titan.SetEnemy( generator )
 		thread AssaultOrigin( titan, validPos[0], goalRadius )
-		titan.AssaultSetFightRadius( goalRadius )
+		titan.AssaultSetGoalRadius( goalRadius )
+		titan.AssaultSetFightRadius( 0 )
 
 		wait 0.5
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd.nut
@@ -1062,6 +1062,8 @@ void function NukeTitanExplosionCallback_Threaded( entity ent, var damageInfo )
 	ent.TakeDamage( DamageInfo_GetDamage( damageInfo ), inflictor, DamageInfo_GetInflictor( damageInfo ), { weapon = DamageInfo_GetWeapon( damageInfo ), origin = DamageInfo_GetDamagePosition( damageInfo ), force = DamageInfo_GetDamageForce( damageInfo ), scriptType = DamageInfo_GetCustomDamageType( damageInfo ), damageSourceId = DamageInfo_GetDamageSourceIdentifier( damageInfo ) } )
 	// now zero out the normal damage and return
 	DamageInfo_SetDamage( damageInfo, 0 )
+	wait 2.0
+	inflictor.Destroy()
 }
 
 int function GetTeamIntFromEnt( entity teamEnt )


### PR DESCRIPTION
- incredibly funny
- works as well as you expect ( no error at all )
- I don't know what the fuck Respawn did to patch this but its most likely something like this

**Why did I do this?**
- When Nuke Titans explode, they get destroyed after the first explosion tick.
- Instead, the explosion owner becomes the `team_manager` entity from `GetTeamEnt( TEAM_IMC )`. (yes no idea what the fuck is this entity)
- We can't `.GetTeam()` this entity for no fucking reason so we use a for loop to check if this is indeed the same `team_manager` for TEAM_IMC to prevent friendly damage
- However, since the explosion owner is no longer the invalid Nuke Titan, the obituary doesn't display an enemy when you die to this explosion
- Solution is to use a placeholder invisible tick that has the Nuke Titan's name to replace the missing enemy in obituary
- Since there isn't a `DamageDef_SetAttacker( entity )` function, we just negate the damage entirely and make a totally new damage source using `ent.TakeDamage(...)`
