### PR TITLE
Add convar to log all clientcommands

### DIFF
--- a/Northstar.CustomServers/mod.json
+++ b/Northstar.CustomServers/mod.json
@@ -49,6 +49,10 @@
 		{
 			"Name": "ns_should_log_unknown_clientcommands",
 			"DefaultValue": "1"
+		},
+		{
+			"Name": "ns_should_log_all_clientcommands",
+			"DefaultValue": "0"
 		}
 	],
 	"Scripts": [

--- a/Northstar.CustomServers/mod/scripts/vscripts/_mapspawn.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_mapspawn.gnut
@@ -199,6 +199,11 @@ var function CodeCallback_ClientCommand( entity player, array<string> args )
 		printl( key + " : " + value )
 	printl( "############################" )*/
 
+	if ( GetConVarBool("ns_should_log_all_clientcommands") )
+	{
+		printl("ClientCommand: " + player + "(" + player.GetUID() + "): " + JoinStringArray(args, " "))
+	}
+
 	string commandString = args.remove( 0 )
 
 	//TODO: Track down Why VModEnable is being called from code?


### PR DESCRIPTION
<!-- 
WHEN OPENING A PULL REQUEST KEEP IN MIND:
-> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
-> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)

-> Please use a sensible title for your pull request

-> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).

-> If you made multiple independent changes, please make a new PR for each one. This prevents your PR being blocked from merging by one of the changes you made.

Note that commit messages in PRs will generally be squashed to keep commit history clean.
-->

Adds a convar `ns_should_log_all_clientcommands` to CustomServers that, when enabled, will cause _all_ clientcommands to be printed to the console.

This is useful for finding and debugging suspicious activity in logs, but it's not enabled by default since it allows players to fill up a server's log very fast.
