### PR TITLE
Fix titan loadout callbacks forcibly applying all loadouts after the first

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_loadouts_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_loadouts_mp.gnut
@@ -100,7 +100,7 @@ TitanLoadoutDef function GetTitanLoadoutForPlayer( entity player )
 		
 		// whether the callback has changed the player's titan loadout
 		wasChanged = wasChanged || callbackRet.wasChanged 
-		if ( wasChanged )
+		if ( callbackRet.wasChanged )
 			loadout = callbackRet.loadout
 		
 		// whether the callback has indicated that we should run no more callbacks ( e.g. if we're forcing a given loadout to be chosen, we shouldn't run any more )


### PR DESCRIPTION
Simple one-liner PR. Currently, once a single titan loadout callback changes the loadout, all following callbacks will have their loadout forcibly applied. This just changes the variable checked so it only replaces the loadout if the callback says to (i.e. predecessors have no impact).