### PR TITLE
[FD] General Small Changes

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/ai/_ai_nuke_titans.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/ai/_ai_nuke_titans.gnut
@@ -58,7 +58,7 @@ void function NukeTitanSeekOutGenerator( entity titan, entity generator )
 	{
 		titan.SetEnemy( generator )
 		thread AssaultOrigin( titan, validPos[0], goalRadius )
-		titan.AssaultSetFightRadius( goalRadius )
+		//titan.AssaultSetFightRadius( goalRadius ) // dont want to set a fight radius because then the nuke titan will stop and shoot
 
 		wait 0.5
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/ai/_ai_nuke_titans.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/ai/_ai_nuke_titans.gnut
@@ -58,7 +58,7 @@ void function NukeTitanSeekOutGenerator( entity titan, entity generator )
 	{
 		titan.SetEnemy( generator )
 		thread AssaultOrigin( titan, validPos[0], goalRadius )
-		//titan.AssaultSetFightRadius( goalRadius ) // dont want to set a fight radius because then the nuke titan will stop and shoot
+		titan.AssaultSetFightRadius( 0 ) // dont want to set a fight radius because then the nuke titan will stop and shoot
 
 		wait 0.5
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd.nut
@@ -929,6 +929,9 @@ void function DamageScaleByDifficulty( entity ent, var damageInfo )
 
 	if ( attacker.IsPlayer() && attacker.GetTeam() == TEAM_IMC ) // in case we ever want a PvP in Frontier Defense, don't scale their damage
 		return
+	
+	if ( attacker == ent ) // dont scale self damage
+		return
 
 	int difficultyLevel = FD_GetDifficultyLevel()
 	switch ( difficultyLevel )

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd_nav.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd_nav.nut
@@ -4,7 +4,7 @@ global function getRoute
 
 
 
-void function singleNav_thread(entity npc, string routeName,int nodesToScip= 0,float nextDistance = 500.0)
+void function singleNav_thread(entity npc, string routeName,int nodesToSkip= 0,float nextDistance = 500.0)
 {
 	npc.EndSignal( "OnDeath" )
 	npc.EndSignal( "OnDestroy" )
@@ -25,14 +25,14 @@ void function singleNav_thread(entity npc, string routeName,int nodesToScip= 0,f
 		npc.Signal("OnFailedToPath")
 		return
 	}
-	int scippedNodes = 0
+	int skippedNodes = 0
 	foreach(entity node in routeArray)
 	{
 		if(!IsAlive(fd_harvester.harvester))
 			return
-		if(scippedNodes < nodesToScip)
+		if(skippedNodes < nodesToSkip)
 		{
-			scippedNodes++
+			skippedNodes++
 			continue
 		}
 		npc.AssaultPoint(node.GetOrigin())
@@ -45,7 +45,7 @@ void function singleNav_thread(entity npc, string routeName,int nodesToScip= 0,f
 	npc.Signal("FD_ReachedHarvester")
 }
 
-void function SquadNav_Thread( array<entity> npcs ,string routeName,int nodesToScip = 0,float nextDistance = 200.0)
+void function SquadNav_Thread( array<entity> npcs ,string routeName,int nodesToSkip = 0,float nextDistance = 200.0)
 {
 	//TODO this function wont stop when noone alive anymore also it only works half of the time
 
@@ -59,7 +59,7 @@ void function SquadNav_Thread( array<entity> npcs ,string routeName,int nodesToS
 	{
 		if(!IsAlive(fd_harvester.harvester))
 			return
-		if(nodeIndex++ < nodesToScip)
+		if(nodeIndex++ < nodesToSkip)
 			continue
 		
 		SquadAssaultOrigin(npcs,node.GetOrigin(),nextDistance)


### PR DESCRIPTION
- Removes the AssaultSetFightRadius for nuke titans, this prevents them from stopping and shooting at things, now they head straight for the harvester without distractions
- Removes the damage scaling on self-inflicted damage to more accurately mimic vanilla
- `scip` -> `skip`