### PR TITLE
require sv_cheats for kill and explode commands

### DIFF
--- a/Northstar.CustomServers/mod.json
+++ b/Northstar.CustomServers/mod.json
@@ -49,6 +49,10 @@
 		{
 			"Name": "ns_should_log_unknown_clientcommands",
 			"DefaultValue": "1"
+		},
+		{
+			"Name": "ns_allow_kill_commands",
+			"DefaultValue": "0"
 		}
 	],
 	"Scripts": [

--- a/Northstar.CustomServers/mod/scripts/vscripts/_northstar_cheatcommands.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_northstar_cheatcommands.nut
@@ -54,7 +54,7 @@ bool function ClientCommandCallbackToggleDemigod( entity player, array<string> a
 
 bool function ClientCommandCallbackKill( entity player, array<string> args )
 {
-	if ( IsAlive( player ) )
+	if ( IsAlive( player ) && ( GetConVarBool( "sv_cheats" ) || GetConVarBool( "ns_allow_kill_commands" ) ) )
 		player.Die()
 	
 	return true
@@ -62,7 +62,7 @@ bool function ClientCommandCallbackKill( entity player, array<string> args )
 
 bool function ClientCommandCallbackExplode( entity player, array<string> args )
 {
-	if ( IsAlive( player ) )
+	if ( IsAlive( player ) && ( GetConVarBool( "sv_cheats" ) || GetConVarBool( "ns_allow_kill_commands" ) ) )
 		player.Die( null, null, { scriptType = DF_GIB } )
 	
 	return true


### PR DESCRIPTION
Require sv_cheats 1 or ns_allow_kill_commands 1 to use the explode and kill commands
unsure why the change to remove the sv_cheats requirement was ever merged tbh