### PR TITLE
[FD] Allow traps to be picked up by the owner

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/item_inventory/sv_item_inventory.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/item_inventory/sv_item_inventory.gnut
@@ -87,6 +87,10 @@ void function PlayerInventory_GiveInventoryItem( entity player, InventoryItem in
 	PlayerInventory_TakeInventoryItem( player )
 
 	player.GiveOffhandWeapon( inventoryItem.weaponRef, OFFHAND_INVENTORY, mods )
+	if ( inventoryItem.itemType == eInventoryItemType.burnmeter ) {
+		entity weapon = player.GetOffhandWeapon(OFFHAND_INVENTORY)
+		weapon.e.burnReward = inventoryItem.burnReward.ref
+	}
 }
 
 void function PlayerInventory_PushInventoryItem( entity player, InventoryItem inventoryItem )


### PR DESCRIPTION
weapon.e.burnReward being an empty string causes the function that picks up traps to return, so setting it when we give the weapon should prevent that