### PR TITLE
call InitPersistentData on client connect to mirror vanilla behaviour and clear unwanted stuff

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
@@ -123,6 +123,8 @@ void function CodeCallback_OnClientConnectionStarted( entity player )
 // playerconnected
 void function CodeCallback_OnClientConnectionCompleted( entity player )
 {
+	InitPersistentData( player )
+
 	if ( IsLobby() )
 	{
 		Lobby_OnClientConnectionCompleted( player )


### PR DESCRIPTION
mainly implementing to reset titans being locked in fd, but also could be good if we wanna remove the placeholder persistent data stuff from native