### PR TITLE
Prevent crashing when an NPC titan kills a player or tries to earn score in Attrition

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_aitdm.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_aitdm.nut
@@ -79,8 +79,8 @@ void function HandleScoreEvent( entity victim, entity attacker, var damageInfo )
 	if ( victim.GetOwner() == attacker )
 		return
 		
-	// NPC never earns score for the team, even if a Grunt killsteals an enemy player.
-	if ( attacker.IsNPC() )
+	// NPC titans without an owner player will not count towards any team's score
+	if ( attacker.IsNPC() && attacker.IsTitan() && !IsValid( GetPetTitanOwner( attacker ) ) )
 		return
 	
 	// Split score so we can check if we are over the score max

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_aitdm.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_aitdm.nut
@@ -78,6 +78,10 @@ void function HandleScoreEvent( entity victim, entity attacker, var damageInfo )
 	// Hacked spectre filter
 	if ( victim.GetOwner() == attacker )
 		return
+		
+	// NPC never earns score for the team, even if a Grunt killsteals an enemy player.
+	if ( attacker.IsNPC() )
+		return
 	
 	// Split score so we can check if we are over the score max
 	// without showing the wrong value on client

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
@@ -447,7 +447,20 @@ void function RespawnAsTitan( entity player, bool manualPosition = false )
 	AddCinematicFlag( player, CE_FLAG_CLASSIC_MP_SPAWNING ) // hide hud
 	
 	// do titanfall scoreevent
-	AddPlayerScore( player, "Titanfall", player )
+	if ( !level.firstTitanfall )
+	{
+		AddPlayerScore( player, "FirstTitanfall", player )
+
+		#if HAS_STATS
+		UpdatePlayerStat( player, "misc_stats", "titanFallsFirst" )
+		#endif
+
+		level.firstTitanfall = true
+	}
+	else
+	{
+		AddPlayerScore( player, "Titanfall", player )
+	}
 	
 	entity camera = CreateTitanDropCamera( spawnpoint.GetAngles(), < 90, titan.GetAngles().y, 0 > )
 	camera.SetParent( titan )

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
@@ -447,20 +447,7 @@ void function RespawnAsTitan( entity player, bool manualPosition = false )
 	AddCinematicFlag( player, CE_FLAG_CLASSIC_MP_SPAWNING ) // hide hud
 	
 	// do titanfall scoreevent
-	if ( !level.firstTitanfall )
-	{
-		AddPlayerScore( player, "FirstTitanfall", player )
-
-		#if HAS_STATS
-		UpdatePlayerStat( player, "misc_stats", "titanFallsFirst" )
-		#endif
-
-		level.firstTitanfall = true
-	}
-	else
-	{
-		AddPlayerScore( player, "Titanfall", player )
-	}
+	AddPlayerScore( player, "Titanfall", player )
 	
 	entity camera = CreateTitanDropCamera( spawnpoint.GetAngles(), < 90, titan.GetAngles().y, 0 > )
 	camera.SetParent( titan )


### PR DESCRIPTION
<!-- 
WHEN OPENING A PULL REQUEST KEEP IN MIND:
-> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
-> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)

-> Please use a sensible title for your pull request

-> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).

-> If you made multiple independent changes, please make a new PR for each one. This prevents your PR being blocked from merging by one of the changes you made.

Note that commit messages in PRs will generally be squashed to keep commit history clean.
-->

- Prevents crashing when an NPC titan kills a player or tries to earn score in Attrition. Fixes issue in https://github.com/R2Northstar/NorthstarMods/issues/387.
- ~~Added First To Fall score event when respawning as Titan besides calling a Titanfall. Fixes issue in https://github.com/R2Northstar/NorthstarMods/issues/264.~~ -> Moved to #427

~~(I was going to make the First To Fall a separate PR but Github commited changes to patch-1 instead of opening a new branch aaaa)~~