### PR TITLE
Fix RespawnAsTitan not triggering FirstToFall

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
@@ -447,7 +447,20 @@ void function RespawnAsTitan( entity player, bool manualPosition = false )
 	AddCinematicFlag( player, CE_FLAG_CLASSIC_MP_SPAWNING ) // hide hud
 	
 	// do titanfall scoreevent
-	AddPlayerScore( player, "Titanfall", player )
+	if ( !level.firstTitanfall )
+	{
+		AddPlayerScore( player, "FirstTitanfall", player )
+
+		#if HAS_STATS
+		UpdatePlayerStat( player, "misc_stats", "titanFallsFirst" )
+		#endif
+
+		level.firstTitanfall = true
+	}
+	else
+	{
+		AddPlayerScore( player, "Titanfall", player )
+	}
 	
 	entity camera = CreateTitanDropCamera( spawnpoint.GetAngles(), < 90, titan.GetAngles().y, 0 > )
 	camera.SetParent( titan )


### PR DESCRIPTION
Spliced out from #425 by @x3Karma 

> Added First To Fall score event when respawning as Titan besides calling a Titanfall. Fixes issue in https://github.com/R2Northstar/NorthstarMods/issues/264.
