### PR TITLE
Fix Netchan kick from crashing server

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/titan/sh_titan.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/titan/sh_titan.gnut
@@ -223,7 +223,8 @@ void function AddArmBadgeToTitan_Internal( entity soul )
 
 	// wait until the end of the frame to allow the soul to become owned by a boss player
 	WaitEndFrame()
-
+	if( !IsValid( soul ) ) 	//Players kicked by netchannel limit on titan brawl can stop being
+		return 				//valid after this frame, though wont normally happen without mods
 	entity titan = soul.GetTitan()
 
 	var model = GetTitanArmBadge( soul )


### PR DESCRIPTION


![image](https://user-images.githubusercontent.com/41163714/179529938-b2470322-43cd-428f-b1d2-9ddc841b7e6f.png)
Fixes server crash that occurs when players are netchan kicked while connecting during titan brawl. Extremely specific and won't occur without either mods that do a lot of stuff on connect or servers that have low netchan limits, but probably worth fixing 