### PR TITLE
Add Table Utilities

### DIFF
--- a/Northstar.Custom/mod.json
+++ b/Northstar.Custom/mod.json
@@ -407,7 +407,11 @@
 			"ServerCallback": {
 				"After": "CustomPilotCollision_InitPlaylistVars"
 			}
-		}
+		}, 
+    {
+      "Path": "table_utilities.nut",
+			"RunOn": "CLIENT || SERVER || UI"
+    }
 	],
 
 	"Localisation": [

--- a/Northstar.Custom/mod/scripts/vscripts/table_utilities.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/table_utilities.nut
@@ -1,0 +1,80 @@
+untyped
+globalize_all_functions
+
+string function GetTableString( table t, string index, string defaultVal = "" )
+{
+    try
+    {
+    return expect string(t[index])
+    }
+    catch (ex)
+    {
+
+    }
+    return defaultVal
+}
+
+int function GetTableInt( table t, string index, int defaultVal = 0 )
+{
+    try
+    {
+        return expect int(t[index])
+    }
+    catch (ex)
+    {
+
+    }
+    return defaultVal
+}
+
+float function GetTableFloat( table t, string index, float defaultVal = 0.0 )
+{
+    try
+    {
+    return expect float(t[index])
+    }
+    catch (ex)
+    {
+
+    }
+    return defaultVal
+}
+
+array function GetTableArray( table t, string index, array defaultVal = [] )
+{
+    try
+    {
+    return expect array(t[index])
+    }
+    catch (ex)
+    {
+
+    }
+    return defaultVal
+}
+
+bool function GetTableBool( table t, string index, bool defaultVal = false )
+{
+    try
+    {
+    return expect bool(t[index])
+    }
+    catch (ex)
+    {
+
+    }
+    return defaultVal
+}
+
+table function GetTableTable( table t, string index, table defaultVal = {} )
+{
+    try
+    {
+    return expect table(t[index])
+    }
+    catch (ex)
+    {
+
+    }
+    return defaultVal
+}


### PR DESCRIPTION
<!-- 
WHEN OPENING A PULL REQUEST KEEP IN MIND:
-> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
-> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)

-> For fixes, description on how to reproduce the bug are appreciated and help your PR get merged faster
-> For features, description on how to use or a sample mod that makes use of the feature is appreciated and will help your PR get merged faster

-> Please use a sensible title for your pull request

-> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).

-> If you made multiple independent changes, please make a new PR for each one. This prevents your PR being blocked from merging by one of the changes you made.

Note that commit messages in PRs will generally be squashed to keep commit history clean.
-->

# Table Utilities

Adds common functions which replace common code segments to make scripting easier with tables from the DecodeJSON function.

## Documentation

```js
string function GetTableString( table t, string index, string defaultVal = "" )
```
Returns a string from the table. Returns `defaultVal` if the function fails.

```js
float function GetTableFloat( table t, string index, float defaultVal = 0.0 )
```
Returns a float from the table. Returns `defaultVal` if the function fails.

```js
int function GetTableInt( table t, string index, int defaultVal = 0 )
```
Returns an integer from the table. Returns `defaultVal` if the function fails.

```js
bool function GetTableBool( table t, string index, bool defaultVal = false )
```
Returns a boolean from the table. Returns `defaultVal` if the function fails.

```js
table function GetTableTable( table t, string index, table defaultVal = {} )
```
Returns a table from the table. Returns `defaultVal` if the function fails.