### PR TITLE
Additional Bug Fixes for PR #438

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
@@ -376,8 +376,8 @@ void function AddPlayerToEvacDropship( entity dropship, entity player )
 	if ( !PlayerInDropship( player, dropship ) )
 		return
 
-    // need to cancel if the dropship dies
-    dropship.EndSignal( "OnDeath", "OnDestroy" )
+    	// need to cancel if the dropship dies
+    	dropship.EndSignal( "OnDeath", "OnDestroy" )
 
 	player.SetInvulnerable()
 	player.UnforceCrouch()
@@ -421,7 +421,7 @@ void function EvacDropshipKilled( entity dropship, var damageInfo )
 {
 	foreach ( entity player in dropship.s.evacSlots )
 	{
-		if ( IsValid( player ) )
+		if ( IsValid( player ) && IsAlive( player ) )
 		{
 			player.ClearParent()
 			player.Die( DamageInfo_GetAttacker( damageInfo ), DamageInfo_GetWeapon( damageInfo ), { damageSourceId = eDamageSourceId.evac_dropship_explosion, scriptType = DF_GIB } )

--- a/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
@@ -421,7 +421,7 @@ void function EvacDropshipKilled( entity dropship, var damageInfo )
 {
 	foreach ( entity player in dropship.s.evacSlots )
 	{
-		if ( IsValid( player ) && IsAlive( player ) )
+		if ( IsValid( player ) )
 		{
 			player.ClearParent()
 			player.Die( DamageInfo_GetAttacker( damageInfo ), DamageInfo_GetWeapon( damageInfo ), { damageSourceId = eDamageSourceId.evac_dropship_explosion, scriptType = DF_GIB } )

--- a/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
@@ -268,8 +268,8 @@ void function Evac( int evacTeam, float initialWait, float arrivalTime, float wa
 	thread PlayAnim( dropship, "cd_dropship_rescue_side_idle", evacNode )
 	
 	// eta until leave
-	SetTeamActiveObjective( evacTeam, "EG_DropshipExtract2", Time() + EVAC_WAIT_TIME, file.evacIcon )
-	SetTeamActiveObjective( GetOtherTeam( evacTeam ), "EG_StopExtract2", Time() + EVAC_WAIT_TIME, file.evacIcon )	
+	SetTeamActiveObjective( evacTeam, "EG_DropshipExtract2", Time() + waitTime, file.evacIcon )
+	SetTeamActiveObjective( GetOtherTeam( evacTeam ), "EG_StopExtract2", Time() + waitTime, file.evacIcon )	
 	
 	// setup evac trigger
 	entity trigger = CreateEntity( "trigger_cylinder" )
@@ -376,8 +376,8 @@ void function AddPlayerToEvacDropship( entity dropship, entity player )
 	if ( !PlayerInDropship( player, dropship ) )
 		return
 
-    	// need to cancel if the dropship dies
-    	dropship.EndSignal( "OnDeath", "OnDestroy" )
+	// need to cancel if the dropship dies
+	dropship.EndSignal( "OnDeath", "OnDestroy" )
 
 	player.SetInvulnerable()
 	player.UnforceCrouch()


### PR DESCRIPTION
### Added IsAlive to players check when dropship is killed
- In gamemodes that do not use Evac during epilogue but during eGameState.Playing, this prevents a possible crash when the script tries to kill the player twice.

### Swap EVAC_WAIT_TIME to waitTime
- Clients would see an 18 seconds before dropship leaves even if waitTime was modified due to it using the const EVAC_WAIT_TIME.