### PR TITLE
Removal of live fire map from titan tag

### DIFF
--- a/Northstar.Custom/keyvalues/playlists_v2.txt
+++ b/Northstar.Custom/keyvalues/playlists_v2.txt
@@ -357,7 +357,6 @@ playlists
 						mp_angel_city 1
 						mp_colony02 1
 						mp_glitch 1
-						mp_lf_stacks 1
 						mp_relic02 1
 						mp_wargames 1
 						mp_rise 1


### PR DESCRIPTION
I noticed that Stacks is listed under Titan Tag so I removed it :) 
Might also fix #386 