### PR TITLE
Add IsValid Check to DelayedGamemodeAnnouncement

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_wargames.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_wargames.nut
@@ -339,7 +339,8 @@ void function PlayerWatchesWargamesIntro( entity player )
 void function DelayedGamemodeAnnouncement( entity player )
 {
 	wait 1.0
-	TryGameModeAnnouncement( player )
+	if ( IsValid( player ) && IsAlive( player ) )
+		TryGameModeAnnouncement( player )
 }
 
 void function PlaySound_SimPod_DoorShut( entity playerFirstPersonProxy  ) // stolen from sp_training


### PR DESCRIPTION
`DelayedGamemodeAnnouncement` has a 1-second delay without a check or endsignal which would crash the server if the player leaves.