### PR TITLE
Apply default air accel (500) on disconnect

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/sh_custom_air_accel.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/sh_custom_air_accel.gnut
@@ -11,6 +11,7 @@ void function CustomAirAccelVars_Init()
 		AddCallback_OnTitanBecomesPilot( ApplyCustomPlayerAirAccelFromTitan ) // airaccel is reset after player leaves titan
 		AddCallback_OnPilotBecomesTitan( ApplyCustomPlayerAirAccelFromTitan ) // airaccel is also reset after player enters titan
 		AddCallback_OnPlayerGetsNewPilotLoadout( ApplyCustomPlayerAirAccelOnLoadoutChange ) // airaccel is also reset on loadout change for some reason
+		AddCallback_OnClientConnected( ApplyDefaultPlayerAirAceelOnDisconnect ) // applies default air accel (500) when leaving a game to prevent non-500 air accel in campaign
 	#endif
 }
 
@@ -28,5 +29,13 @@ void function ApplyCustomPlayerAirAccelFromTitan( entity player, entity titan )
 void function ApplyCustomPlayerAirAccelOnLoadoutChange( entity player, PilotLoadoutDef loadout ) 
 {
 	player.kv.airAcceleration = GetCurrentPlaylistVarInt( "custom_air_accel_pilot", int( player.GetPlayerSettingsField( "airAcceleration" ) ) )
+}
+void function ApplyDefaultPlayerAirAceelOnDisconnect( entity player )
+{
+	int defaultairaccel = 500
+    if ( !multiplayer() )
+		return 0
+	if else
+		player.kv.airAcceleration = GetCurrentPlaylistVarInt( "defaultairaccel", int( player.GetPlayerSettingsField( "airAcceleration" ) ) )
 }
 #endif


### PR DESCRIPTION
Air accel isnt reset on disconnect so you can get 9k in campaign etc
worked when i tested it like a week or 2 ago just been sitting around waiting to make a pr