### PR TITLE
Fixed EarnMeter OverDrive not reset after player died

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/earn_meter/sv_earn_meter.gnut
@@ -315,12 +315,12 @@ void function PlayerEarnMeter_Empty( entity player )
 	PlayerEarnMeter_SetRewardFrac( player, 0.0 )
 }
 
-
 void function EarnMeterDecayThink( entity player )
 {
 	player.EndSignal( "OnDeath" )
 	player.Signal( "EarnMeterDecayThink" )
 	player.EndSignal( "EarnMeterDecayThink" )
+	thread OverDriveClearOnDeath( player )
 
 	if ( EarnMeter_DecayHold() < 0 )
 		return
@@ -348,6 +348,12 @@ void function EarnMeterDecayThink( entity player )
 	}
 }
 
+void function OverDriveClearOnDeath( entity player )
+{
+	player.EndSignal( "OnDestroy" )
+	player.WaitSignal( "OnDeath" )
+	PlayerEarnMeter_SetEarnedFrac( player, PlayerEarnMeter_GetOwnedFrac( player ) )
+}
 
 bool function PlayerEarnMeter_TryMakeGoalAvailable( entity player )
 {


### PR DESCRIPTION
Earn meter Overdrive( yellow bar ) will be reset to 0 after player died