### PR TITLE
Add support for hiding the [SERVER] tag in server messages

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
@@ -11,6 +11,7 @@ global struct ClClient_MessageStruct {
     bool isDead
     bool isWhisper
 	bool shouldBlock
+    bool noServerTag
 }
 
 struct {
@@ -29,6 +30,7 @@ void function OnReceivedMessage(ClClient_MessageStruct localMessage) {
             localMessage.isDead = returnStruct.isDead
             localMessage.isWhisper = returnStruct.isWhisper
             localMessage.shouldBlock = localMessage.shouldBlock || returnStruct.shouldBlock
+            localMessage.noServerTag = returnStruct.noServerTag
         }
     }
 
@@ -39,7 +41,13 @@ void function OnReceivedMessage(ClClient_MessageStruct localMessage) {
 
     NSChatWriteRaw(1, "\n")
 
-    if (localMessage.player == null) NSChatWrite(1, "\x1b[95m")
+    if (localMessage.player == null)
+    {
+        if (!localMessage.noServerTag || localMessage.isWhisper)
+        {
+            NSChatWrite(1, "\x1b[95m")
+        }
+    } 
     else
     {
         bool isFriendly = localMessage.player.GetTeam() == GetLocalClientPlayer().GetTeam()
@@ -54,15 +62,18 @@ void function OnReceivedMessage(ClClient_MessageStruct localMessage) {
 
     if (localMessage.player == null)
     {
-        NSChatWriteRaw(1, Localize("#HUD_CHAT_SERVER_PREFIX") + " ")
+        if (!localMessage.noServerTag)
+        {
+            NSChatWriteRaw(1, Localize("#HUD_CHAT_SERVER_PREFIX") + " ")
+        }
     }
-    else {
+    else 
+    {
         NSChatWriteRaw(1, localMessage.playerName)
         NSChatWriteRaw(1, ": ")
     }
 
-    NSChatWrite(1, "\x1b[0m")
-
+    if (localMessage.player != null || !localMessage.noServerTag || localMessage.isWhisper) NSChatWrite(1, "\x1b[0m")
     NSChatWrite(1, localMessage.message)
 }
 
@@ -87,16 +98,19 @@ void function CHudChat_OnReceivedSayTextMessageCallback(int fromPlayerIndex, str
         fromPlayerName = fromPlayer.GetPlayerNameWithClanTag()
     }
 
+    // Null player + isTeam == true: Server with no tag.
+
     if (messageType == 0 || messageType == 1)
     {
         ClClient_MessageStruct localMessage
         localMessage.message = message
         localMessage.player = fromPlayer
         localMessage.playerName = fromPlayerName
-        localMessage.isTeam = isTeam
+        localMessage.isTeam = fromPlayer != null && isTeam
         localMessage.isDead = isDead
         localMessage.isWhisper = false
         localMessage.shouldBlock = false
+        localMessage.noServerTag = fromPlayer == null && isTeam
         OnReceivedMessage(localMessage)
         return
     }
@@ -107,10 +121,11 @@ void function CHudChat_OnReceivedSayTextMessageCallback(int fromPlayerIndex, str
         localMessage.message = message
         localMessage.player = fromPlayer
         localMessage.playerName = fromPlayerName
-        localMessage.isTeam = isTeam
+        localMessage.isTeam = fromPlayer != null && isTeam
         localMessage.isDead = isDead
         localMessage.isWhisper = true
         localMessage.shouldBlock = false
+        localMessage.noServerTag = fromPlayer == null && isTeam
         OnReceivedMessage(localMessage)
         return
     }

--- a/Northstar.CustomServers/mod/scripts/vscripts/_chat.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_chat.gnut
@@ -25,26 +25,26 @@ void function Chat_PrivateMessage(entity fromPlayer, entity toPlayer, string tex
 }
 
 // Broadcasts a message from the server to all players.
-void function Chat_ServerBroadcast(string text)
+void function Chat_ServerBroadcast(string text, bool withServerTag = true)
 {
     NSBroadcastMessage(
         -1,
         -1,
         text,
-        false,
+        !withServerTag,
         false,
         eChatMessageType.CHAT
     )
 }
 
 // Sends a message from the server to one player. Will be shown as a whisper if whisper is set.
-void function Chat_ServerPrivateMessage(entity toPlayer, string text, bool whisper)
+void function Chat_ServerPrivateMessage(entity toPlayer, string text, bool whisper, bool withServerTag = true)
 {
     NSBroadcastMessage(
         -1,
         toPlayer.GetPlayerIndex(),
         text,
-        false,
+        !withServerTag,
         false,
         whisper ? eChatMessageType.WHISPER : eChatMessageType.CHAT
     )


### PR DESCRIPTION
This PR adds support for removing the purple `[SERVER]` tag from server messages sent to clients.

![image](https://user-images.githubusercontent.com/25248023/190882125-6c0a2677-72bc-4c9c-bbc6-b4f74b921b3f.png)

This change is 100% backward compatible, and will not affect any existing mod. Flagging the message to hide the `[SERVER]` tag is simply done by using the existing `isTeam` field on messages, which was unused for messages sent by the server.

A message with a null player and `isTeam` as true will be considered a server message without the `[SERVER]` tag. Due to this, no compatibility is broken.

The two server to client, and server to all clients functions have been given an additional parameter, to disable the server tag. 
By default, they are set to keep it.

```squirrel
void function Chat_ServerBroadcast(string text, bool withServerTag = true)
void function Chat_ServerPrivateMessage(entity toPlayer, string text, bool whisper, bool withServerTag = true)
```
