### PR TITLE
Scrollbar Component

### DIFF
--- a/Northstar.Client/mod.json
+++ b/Northstar.Client/mod.json
@@ -105,6 +105,10 @@
 		{
 			"Path": "ui/controller_prompts.nut",
 			"RunOn": "UI"
+		},
+		{
+			"Path": "ui/custom_scrollbar.nut",
+			"RunOn": "UI"
 		}
 	],
 	"Localisation": [

--- a/Northstar.Client/mod/resource/ui/menus/panels/scrollbar.res
+++ b/Northstar.Client/mod/resource/ui/menus/panels/scrollbar.res
@@ -7,10 +7,7 @@ resource/ui/menus/panels/scrollbar.res
 
 			wide	50
 			tall	50
-			xpos	0
-			ypos	0
 			zpos	2
-			visible 1
 
 			drawColor	"255 255 255 128"
 		}
@@ -21,8 +18,6 @@ resource/ui/menus/panels/scrollbar.res
 				
 			wide	50
 			tall	50
-			xpos	0
-			ypos	0
 			zpos	1
 		}
 
@@ -33,9 +28,6 @@ resource/ui/menus/panels/scrollbar.res
 			
 			wide	50
 			tall	50
-			xpos	0
-			ypos	0
-			zpos	0
 
 			image		"vgui/hud/white"
 			drawColor	"255 255 255 128"
@@ -47,8 +39,6 @@ resource/ui/menus/panels/scrollbar.res
 			
 			wide	50
 			tall	50
-			xpos	0
-			ypos	0
 			zpos	-1
 
 			rui		"ui/knowledgebase_panel.rpak"

--- a/Northstar.Client/mod/resource/ui/menus/panels/scrollbar.res
+++ b/Northstar.Client/mod/resource/ui/menus/panels/scrollbar.res
@@ -1,0 +1,56 @@
+resource/ui/menus/panels/scrollbar.res
+{
+		SliderCover
+		{
+			ControlName			RuiButton
+			InheritProperties	RuiSmallButton
+
+			wide	50
+			tall	50
+			xpos	0
+			ypos	0
+			zpos	2
+			visible 1
+
+			drawColor	"255 255 255 128"
+		}
+
+		MouseMovementCapture
+		{
+			ControlName	CMouseMovementCapturePanel
+				
+			wide	50
+			tall	50
+			xpos	0
+			ypos	0
+			zpos	1
+		}
+
+		SliderButton
+		{
+			ControlName			RuiButton
+			InheritProperties	RuiSmallButton
+			
+			wide	50
+			tall	50
+			xpos	0
+			ypos	0
+			zpos	0
+
+			image		"vgui/hud/white"
+			drawColor	"255 255 255 128"
+		}
+
+		BtnModListSliderPanel
+		{
+			ControlName	RuiPanel
+			
+			wide	50
+			tall	50
+			xpos	0
+			ypos	0
+			zpos	-1
+
+			rui		"ui/knowledgebase_panel.rpak"
+		}
+}

--- a/Northstar.Client/mod/resource/ui/menus/panels/scrollbar.res
+++ b/Northstar.Client/mod/resource/ui/menus/panels/scrollbar.res
@@ -28,6 +28,7 @@ resource/ui/menus/panels/scrollbar.res
 			
 			wide	50
 			tall	50
+			zpos	0
 
 			image		"vgui/hud/white"
 			drawColor	"255 255 255 128"

--- a/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
@@ -7,6 +7,7 @@ global function SetScrollbarWidth
 global function SetScrollbarOriginalHeight
 global function SetScrollbarOriginalWidth
 global function SetScrollbarHorizontal
+global function FindScrollbarSafe
 global function FindScrollbar
 
 global struct ScrollbarExt {
@@ -83,6 +84,12 @@ void function SetScrollbarHorizontal( var scrollbar, bool horizontal )
 
 void function RegisterScrollbar( var scrollbar, bool horizontal = false )
 {
+	if( FindScrollbarSafe( scrollbar ) )
+	{
+		printt( format( "%s is already registered. omitting registration." ), scrollbar.tostring() )
+		return
+	}
+
 	var cover = Hud_GetChild( scrollbar, "SliderCover" )
 	AddButtonEventHandler( cover, UIE_GET_FOCUS, CoverGetFocus )
 	file.covers.append( cover )
@@ -100,11 +107,19 @@ void function RegisterScrollbar( var scrollbar, bool horizontal = false )
 	file.scrollbars.append( bar )
 }
 
-ScrollbarExt function FindScrollbar( var scrollbar )
+ScrollbarExt ornull function FindScrollbarSafe( var scrollbar )
 {
 	foreach( ScrollbarExt container in file.scrollbars )
 		if( container.scrollbar == scrollbar )
 			return container
+	return null
+}
+
+ScrollbarExt function FindScrollbar( var scrollbar )
+{
+	var scr = FindScrollbarSafe( scrollbar )
+	if( scr )
+		return scr
 	throw "scrollbar not registered"
 	unreachable
 }

--- a/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
@@ -7,8 +7,9 @@ global function SetScrollbarWidth
 global function SetScrollbarOriginalHeight
 global function SetScrollbarOriginalWidth
 global function SetScrollbarHorizontal
+global function FindScrollbar
 
-struct ScrollbarExt {
+global struct ScrollbarExt {
 	array<void functionref( int x, int y )> callbacks
 	int originalX
 	int originalY
@@ -44,12 +45,12 @@ void function UseCustomScrollbars( var menu )
 
 void function RegisterScrollbarMoveCallback( var scrollbar, void functionref( int x, int y ) f )
 {
-	FindScrollbarByRef( scrollbar ).callbacks.append( f )
+	FindScrollbar( scrollbar ).callbacks.append( f )
 }
 
 void function SetScrollbarHeight( var scrollbar, int height )
 {
-	ScrollbarExt ctn = FindScrollbarByRef( scrollbar )
+	ScrollbarExt ctn = FindScrollbar( scrollbar )
 	Hud_SetHeight( ctn.cover, height )
 	Hud_SetHeight( ctn.movementCapture, height )
 	Hud_SetHeight( ctn.button, height )
@@ -58,7 +59,7 @@ void function SetScrollbarHeight( var scrollbar, int height )
 
 void function SetScrollbarWidth( var scrollbar, int width )
 {
-	ScrollbarExt ctn = FindScrollbarByRef( scrollbar )
+	ScrollbarExt ctn = FindScrollbar( scrollbar )
 	Hud_SetWidth( ctn.cover, width )
 	Hud_SetWidth( ctn.movementCapture, width )
 	Hud_SetWidth( ctn.button, width )
@@ -67,17 +68,17 @@ void function SetScrollbarWidth( var scrollbar, int width )
 
 void function SetScrollbarOriginalHeight( var scrollbar, int height )
 {
-	FindScrollbarByRef( scrollbar ).originalHeight = height
+	FindScrollbar( scrollbar ).originalHeight = height
 }
 
 void function SetScrollbarOriginalWidth( var scrollbar, int width )
 {
-	FindScrollbarByRef( scrollbar ).originalWidth = width
+	FindScrollbar( scrollbar ).originalWidth = width
 }
 
 void function SetScrollbarHorizontal( var scrollbar, bool horizontal )
 {
-	FindScrollbarByRef( scrollbar ).horizontal = horizontal
+	FindScrollbar( scrollbar ).horizontal = horizontal
 }
 
 void function RegisterScrollbar( var scrollbar, bool horizontal = false )
@@ -99,6 +100,15 @@ void function RegisterScrollbar( var scrollbar, bool horizontal = false )
 	file.scrollbars.append( bar )
 }
 
+ScrollbarExt function FindScrollbar( var scrollbar )
+{
+	foreach( ScrollbarExt container in file.scrollbars )
+		if( container.scrollbar == scrollbar )
+			return container
+	throw "scrollbar not registered"
+	unreachable
+}
+
 // * #####################
 // * internal functions ##
 // * #####################
@@ -117,7 +127,7 @@ void function CoverGetFocus( var cover )
 void function MouseMovementHandler( int x, int y )
 {
 	int idx = GetFocusedScrollbarIndex()
-	Hud_SetFocused( Hud_GetChild( file.scrollbars[ idx ].scrollbar, "SliderButton" ) )
+	Hud_SetFocused( file.scrollbars[ idx ].scrollbar.button )
 	if( idx < 0 )
 		return
 	foreach( void functionref( int x, int y ) callback in file.scrollbars[ idx ].callbacks )
@@ -181,13 +191,4 @@ void function RepositionScrollbar_Vertical( ScrollbarExt scrollbar, int x, int y
 int function GetFocusedScrollbarIndex()
 {
 	return file.covers.find( file.invisCover )
-}
-
-ScrollbarExt function FindScrollbarByRef( var scrollbar )
-{
-	foreach( ScrollbarExt container in file.scrollbars )
-		if( container.scrollbar == scrollbar )
-			return container
-	throw "scrollbar not registered"
-	unreachable
 }

--- a/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
@@ -2,21 +2,26 @@ untyped
 global function UseCustomScrollbars
 global function RegisterScrollbar
 global function RegisterScrollbarMoveCallback
+global function RegisterScrollbarMoveCallbackAttached
 global function SetScrollbarHeight
 global function SetScrollbarWidth
 global function SetScrollbarHorizontal
 global function FindScrollbarSafe
 global function FindScrollbar
 global function SetScrollbarPosition
+global function GetFocusedScrollbar
 
 global struct ScrollbarExt {
 	array<void functionref( int x, int y )> callbacks
-	var scrollbar
+	array<void functionref( ScrollbarExt component, int x, int y )> attachedCallbacks
+	var component
 	var cover
 	var movementCapture
 	var button
 	var panel
 	bool horizontal
+	int vX
+	int vY
 }
 
 struct {
@@ -42,6 +47,11 @@ void function UseCustomScrollbars( var menu )
 void function RegisterScrollbarMoveCallback( var scrollbar, void functionref( int x, int y ) f )
 {
 	FindScrollbar( scrollbar ).callbacks.append( f )
+}
+
+void function RegisterScrollbarMoveCallbackAttached( var scrollbar, void functionref( ScrollbarExt component, int x, int y ) f )
+{
+	FindScrollbar( scrollbar ).attachedCallbacks.append( f )
 }
 
 void function SetScrollbarHeight( var scrollbar, int height )
@@ -79,19 +89,24 @@ void function RegisterScrollbar( var scrollbar, bool horizontal = false )
 	AddButtonEventHandler( cover, UIE_GET_FOCUS, CoverGetFocus )
 	file.covers.append( cover )
 	ScrollbarExt bar
-	bar.scrollbar = scrollbar
+	bar.component = scrollbar
 	bar.cover = cover
 	bar.movementCapture = Hud_GetChild( scrollbar, "MouseMovementCapture" )
 	bar.button = Hud_GetChild( scrollbar, "SliderButton" )
 	bar.panel = Hud_GetChild( scrollbar, "BtnModListSliderPanel" )
 	bar.horizontal = horizontal
 	file.scrollbars.append( bar )
+
+	if( horizontal )
+		SetScrollbarHeight( scrollbar, Hud_GetHeight( scrollbar ) )
+	else
+		SetScrollbarWidth( scrollbar, Hud_GetWidth( scrollbar ) )
 }
 
 ScrollbarExt ornull function FindScrollbarSafe( var scrollbar )
 {
 	foreach( ScrollbarExt container in file.scrollbars )
-		if( container.scrollbar == scrollbar )
+		if( container.component == scrollbar )
 			return container
 	return null
 }
@@ -113,6 +128,11 @@ void function SetScrollbarPosition( ScrollbarExt scrollbar, int x, int y )
 	Hud_SetPos( scrollbar.panel, x, y )
 }
 
+ScrollbarExt function GetFocusedScrollbar()
+{
+	return file.scrollbars[ GetFocusedScrollbarIndex() ]
+}
+
 // * #####################
 // * internal functions ##
 // * #####################
@@ -126,38 +146,116 @@ void function CoverGetFocus( var cover )
 
 	ScrollbarExt s = file.scrollbars[ GetFocusedScrollbarIndex() ]
 	Hud_SetFocused( s.button )
+
+	s.vY = Hud_GetY( s.button )
+	s.vX = Hud_GetX( s.button )
 }
 
 void function MouseMovementHandler( int x, int y )
 {
 	int idx = GetFocusedScrollbarIndex()
-	Hud_SetFocused( file.scrollbars[ idx ].button )
+	ScrollbarExt scrollbar = file.scrollbars[ idx ]
+	Hud_SetFocused( scrollbar.button )
 	if( idx < 0 )
 		return
-	foreach( void functionref( int x, int y ) callback in file.scrollbars[ idx ].callbacks )
+	
+	bool oob
+	if( scrollbar.horizontal )
 	{
-		callback( x, y )
+		// printt( scrollbar.vX, Hud_GetBaseX( scrollbar.component ), Hud_GetWidth( scrollbar.component ) )
+		oob = scrollbar.vX < Hud_GetBaseX( scrollbar.component ) || scrollbar.vX > Hud_GetWidth( scrollbar.component )
+	} else {
+		oob = scrollbar.vY < Hud_GetBaseY( scrollbar.component ) || scrollbar.vY > Hud_GetHeight( scrollbar.component )
 	}
 
-	if( file.scrollbars[ idx ].horizontal )
-		RepositionScrollbar_Horizontal( file.scrollbars[ idx ], x, y )
-	else
-		RepositionScrollbar_Vertical( file.scrollbars[ idx ], x, y )
+	if( oob )
+	{
+		if( scrollbar.horizontal )
+		{
+			int outerX
+			int diff
+			if( scrollbar.vX < Hud_GetBaseX( scrollbar.component ) )
+			{
+				outerX = Hud_GetX( scrollbar.component )
+				diff = outerX - Hud_GetX( scrollbar.button )
+			}
+			else
+			{
+				outerX = Hud_GetBaseX( scrollbar.button ) + Hud_GetWidth( scrollbar.component ) - Hud_GetWidth( scrollbar.button )
+				diff = outerX - Hud_GetX( scrollbar.button )
+			}
+			if( abs( diff ) )
+				// foreach( void functionref( ScrollbarExt component, int x, int y ) callback in scrollbar.attachedCallbacks )
+				// 	callback( scrollbar, x, y )
+
+			SetScrollbarPosition( scrollbar, outerX, Hud_GetY( scrollbar.button ) )
+
+			InvokeCallbacks( scrollbar, diff, 0)
+		}
+		else
+		{
+			int outerY
+			int diff
+			if( scrollbar.vY < Hud_GetBaseY( scrollbar.component ) )
+			{
+				outerY = Hud_GetY( scrollbar.component )
+				diff = outerY - Hud_GetY( scrollbar.button )
+			}
+			else
+			{
+				outerY = Hud_GetBaseY( scrollbar.button ) + Hud_GetHeight( scrollbar.component ) - Hud_GetHeight( scrollbar.button )
+				diff = outerY - Hud_GetY( scrollbar.button )
+			}
+			if( abs( diff ) )
+				// foreach( void functionref( ScrollbarExt component, int x, int y ) callback in scrollbar.attachedCallbacks )
+				// 	callback( scrollbar, x, y )
+
+
+			SetScrollbarPosition( scrollbar, Hud_GetX( scrollbar.button ), outerY )
+			// scrollbar.vY = Hud_GetHeight( scrollbar.component )
+			InvokeCallbacks( scrollbar, 0, diff )
+		}
+	}
+
+	if( !oob )
+	{
+		InvokeCallbacks( scrollbar, x, y )
+
+		if( scrollbar.horizontal )
+			RepositionScrollbar_Horizontal( scrollbar, x, y )
+		else
+			RepositionScrollbar_Vertical( scrollbar, x, y )
+	}
+	scrollbar.vX += x
+	scrollbar.vY += y
+}
+
+void function InvokeCallbacks( ScrollbarExt scrollbar, int x, int y )
+{
+	foreach( void functionref( int x, int y ) callback in scrollbar.callbacks )
+		callback( x, y )
+	foreach( void functionref( ScrollbarExt component, int x, int y ) callback in scrollbar.attachedCallbacks )
+		callback( scrollbar, x, y )
 }
 
 void function RepositionScrollbar_Horizontal( ScrollbarExt scrollbar, int x, int y )
 {
-	x = x * -1
-	y = y * -1
-
 	int minXPos = Hud_GetBaseX( scrollbar.button )
-	int maxXPos = minXPos + Hud_GetWidth( scrollbar.scrollbar ) - Hud_GetWidth( scrollbar.button )
+	int maxXPos = minXPos + Hud_GetWidth( scrollbar.component ) - Hud_GetWidth( scrollbar.button )
 
 	int pos = expect int( Hud_GetPos( scrollbar.button )[0] )
-	int newPos = pos - x
+	int newPos = pos + x
 
-	if ( newPos > maxXPos ) newPos = maxXPos
-	if ( newPos < minXPos ) newPos = minXPos
+	if ( newPos > maxXPos )
+	{
+		newPos = maxXPos
+		scrollbar.vX = Hud_GetWidth( scrollbar.component )
+	}
+	else if ( newPos < minXPos )
+	{
+		newPos = minXPos
+		scrollbar.vX = 0
+	}
 
 	int yPos = expect int( Hud_GetPos( scrollbar.button )[1] )
 
@@ -166,20 +264,24 @@ void function RepositionScrollbar_Horizontal( ScrollbarExt scrollbar, int x, int
 
 void function RepositionScrollbar_Vertical( ScrollbarExt scrollbar, int x, int y )
 {
-	x = x * -1
-	y = y * -1
-
-	int[2] screenSize = GetScreenSize()
 	var sliderPanel = scrollbar.panel
 
 	int minYPos = Hud_GetBaseY( scrollbar.button )
-	int maxYPos = minYPos + Hud_GetHeight( scrollbar.scrollbar ) - Hud_GetHeight( scrollbar.button )
+	int maxYPos = minYPos + Hud_GetHeight( scrollbar.component ) - Hud_GetHeight( scrollbar.button )
 
 	int pos = expect int( Hud_GetPos( scrollbar.button )[1] )
-	int newPos = pos - y
+	int newPos = pos + y
 
-	if ( newPos > maxYPos ) newPos = maxYPos
-	if ( newPos < minYPos ) newPos = minYPos
+	if ( newPos > maxYPos )
+	{
+		newPos = maxYPos
+		scrollbar.vY = Hud_GetHeight( scrollbar.component )
+	}
+	else if ( newPos < minYPos )
+	{
+		newPos = minYPos
+		scrollbar.vY = 0
+	}
 
 	int xPos = expect int( Hud_GetPos( scrollbar.button )[0] )
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
@@ -1,0 +1,187 @@
+untyped
+global function UseCustomScrollbars
+global function RegisterScrollbar
+global function RegisterScrollbarMoveCallback
+global function SetScrollbarHeight
+global function SetScrollbarWidth
+global function SetScrollbarOriginalHeight
+global function SetScrollbarOriginalWidth
+global function SetScrollbarHorizontal
+
+struct ScrollbarExt {
+	array<void functionref( int x, int y )> callbacks
+	int originalX
+	int originalY
+	int originalHeight
+	int originalWidth
+	var scrollbar
+	var cover
+	var movementCapture
+	var button
+	var panel
+	bool horizontal
+}
+
+struct {
+	array<ScrollbarExt> scrollbars
+	array<var> covers
+	var invisCover
+} file
+
+// * ###################
+// * global functions ##
+// * ###################
+
+void function UseCustomScrollbars( var menu )
+{
+	foreach( var scrollbar in GetElementsByClassname( menu, "NS_Scrollbar" ) )
+		RegisterScrollbar( scrollbar )
+	foreach( var scrollbar in GetElementsByClassname( menu, "NS_Scrollbar_h" ) )
+		RegisterScrollbar( scrollbar, true )
+
+	AddMouseMovementCaptureHandler( menu, MouseMovementHandler )
+}
+
+void function RegisterScrollbarMoveCallback( int scrollbarIndex, void functionref( int x, int y ) f )
+{
+	file.scrollbars[ scrollbarIndex ].callbacks.append( f )
+}
+
+void function SetScrollbarHeight( int idx, int height )
+{
+	Hud_SetHeight( file.scrollbars[ idx ].cover, height)
+	Hud_SetHeight( file.scrollbars[ idx ].movementCapture, height)
+	Hud_SetHeight( file.scrollbars[ idx ].button, height)
+	Hud_SetHeight( file.scrollbars[ idx ].panel, height)
+}
+
+void function SetScrollbarWidth( int idx, int width )
+{
+	Hud_SetWidth( file.scrollbars[ idx ].cover, width)
+	Hud_SetWidth( file.scrollbars[ idx ].movementCapture, width)
+	Hud_SetWidth( file.scrollbars[ idx ].button, width)
+	Hud_SetWidth( file.scrollbars[ idx ].panel, width)
+}
+
+void function SetScrollbarOriginalHeight( int idx, int height )
+{
+	file.scrollbars[ idx ].originalHeight = height
+}
+
+void function SetScrollbarOriginalWidth( int idx, int width )
+{
+	file.scrollbars[ idx ].originalWidth = width
+}
+
+void function SetScrollbarHorizontal( int idx, bool horizontal )
+{
+	file.scrollbars[ idx ].horizontal = horizontal
+}
+
+void function RegisterScrollbar( var scrollbar, bool horizontal = false )
+{
+	var cover = Hud_GetChild( scrollbar, "SliderCover" )
+	AddButtonEventHandler( cover, UIE_GET_FOCUS, CoverGetFocus )
+	file.covers.append( cover )
+	ScrollbarExt bar
+	bar.originalX = expect int( Hud_GetPos( cover )[0] )
+	bar.originalY = expect int( Hud_GetPos( cover )[1] )
+	bar.originalHeight = Hud_GetHeight( scrollbar )
+	bar.originalWidth = Hud_GetWidth( scrollbar )
+	bar.scrollbar = scrollbar
+	bar.cover = cover
+	bar.movementCapture = Hud_GetChild( scrollbar, "MouseMovementCapture" )
+	bar.button = Hud_GetChild( scrollbar, "SliderButton" )
+	bar.panel = Hud_GetChild( scrollbar, "BtnModListSliderPanel" )
+	bar.horizontal = horizontal
+	file.scrollbars.append( bar )
+}
+
+// * #####################
+// * internal functions ##
+// * #####################
+
+void function CoverGetFocus( var cover )
+{
+	Hud_SetVisible( cover, false )
+	if( file.invisCover )
+		Hud_SetVisible( file.invisCover, true )
+	file.invisCover = cover
+
+	ScrollbarExt s = file.scrollbars[ GetFocusedScrollbarIndex() ]
+	Hud_SetFocused( s.button )
+}
+
+void function MouseMovementHandler( int x, int y )
+{
+	int idx = GetFocusedScrollbarIndex()
+	Hud_SetFocused( Hud_GetChild( file.scrollbars[ idx ].scrollbar, "SliderButton" ) )
+	if( idx < 0 )
+		return
+	foreach( void functionref( int x, int y ) callback in file.scrollbars[ idx ].callbacks)
+	{
+		callback( x, y )
+	}
+
+	if( file.scrollbars[ idx ].horizontal )
+		RepositionScrollbar_Horizontal( file.scrollbars[ idx ], x, y )
+	else
+		RepositionScrollbar_Vertical( file.scrollbars[ idx ], x, y )
+}
+
+void function RepositionScrollbar_Horizontal( ScrollbarExt scrollbar, int x, int y )
+{
+	x = x * -1
+	y = y * -1
+
+	int minXPos = scrollbar.originalX
+	int maxXPos = scrollbar.originalX + scrollbar.originalWidth - Hud_GetWidth( scrollbar.button )
+
+	int pos = expect int( Hud_GetPos( scrollbar.button )[0] )
+	int newPos = pos - x
+
+	if ( newPos > maxXPos ) newPos = maxXPos
+	if ( newPos < minXPos ) newPos = minXPos
+
+	int yPos = expect int( Hud_GetPos( scrollbar.button )[1] )
+
+	Hud_SetPos( scrollbar.cover , newPos, yPos )
+	Hud_SetPos( scrollbar.movementCapture , newPos, yPos )
+	Hud_SetPos( scrollbar.button , newPos, yPos )
+	Hud_SetPos( scrollbar.panel , newPos, yPos )
+}
+
+void function RepositionScrollbar_Vertical( ScrollbarExt scrollbar, int x, int y )
+{
+	x = x * -1
+	y = y * -1
+
+	int[2] screenSize = GetScreenSize()
+	var sliderPanel = scrollbar.panel
+
+	int minYPos = scrollbar.originalY
+	int maxYPos = scrollbar.originalY + scrollbar.originalHeight - Hud_GetHeight( scrollbar.button )
+
+	int pos = expect int( Hud_GetPos( scrollbar.button )[1] )
+	int newPos = pos - y
+
+	if ( newPos > maxYPos ) newPos = maxYPos
+	if ( newPos < minYPos ) newPos = minYPos
+
+	int xPos = expect int( Hud_GetPos( scrollbar.button )[0] )
+
+	Hud_SetPos( scrollbar.cover , xPos, newPos )
+	Hud_SetPos( scrollbar.movementCapture , xPos, newPos )
+	Hud_SetPos( scrollbar.button , xPos, newPos )
+	Hud_SetPos( scrollbar.panel , xPos, newPos )
+}
+
+var function GetFocusedScrollbar()
+{
+	return file.scrollbars[ file.covers.find( file.invisCover ) ].scrollbar
+}
+
+int function GetFocusedScrollbarIndex()
+{
+	return file.covers.find( file.invisCover )
+}

--- a/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
@@ -12,8 +12,6 @@ global function FindScrollbar
 
 global struct ScrollbarExt {
 	array<void functionref( int x, int y )> callbacks
-	int originalX
-	int originalY
 	int originalHeight
 	int originalWidth
 	var scrollbar
@@ -94,8 +92,6 @@ void function RegisterScrollbar( var scrollbar, bool horizontal = false )
 	AddButtonEventHandler( cover, UIE_GET_FOCUS, CoverGetFocus )
 	file.covers.append( cover )
 	ScrollbarExt bar
-	bar.originalX = expect int( Hud_GetPos( cover )[0] )
-	bar.originalY = expect int( Hud_GetPos( cover )[1] )
 	bar.originalHeight = Hud_GetHeight( scrollbar )
 	bar.originalWidth = Hud_GetWidth( scrollbar )
 	bar.scrollbar = scrollbar
@@ -161,8 +157,8 @@ void function RepositionScrollbar_Horizontal( ScrollbarExt scrollbar, int x, int
 	x = x * -1
 	y = y * -1
 
-	int minXPos = scrollbar.originalX
-	int maxXPos = scrollbar.originalX + scrollbar.originalWidth - Hud_GetWidth( scrollbar.button )
+	int minXPos = Hud_GetBaseX( scrollbar.button )
+	int maxXPos = minXPos + scrollbar.originalWidth - Hud_GetWidth( scrollbar.button )
 
 	int pos = expect int( Hud_GetPos( scrollbar.button )[0] )
 	int newPos = pos - x
@@ -186,8 +182,8 @@ void function RepositionScrollbar_Vertical( ScrollbarExt scrollbar, int x, int y
 	int[2] screenSize = GetScreenSize()
 	var sliderPanel = scrollbar.panel
 
-	int minYPos = scrollbar.originalY
-	int maxYPos = scrollbar.originalY + scrollbar.originalHeight - Hud_GetHeight( scrollbar.button )
+	int minYPos = Hud_GetBaseY( scrollbar.button )
+	int maxYPos = minYPos + scrollbar.originalHeight - Hud_GetHeight( scrollbar.button )
 
 	int pos = expect int( Hud_GetPos( scrollbar.button )[1] )
 	int newPos = pos - y

--- a/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
@@ -4,16 +4,13 @@ global function RegisterScrollbar
 global function RegisterScrollbarMoveCallback
 global function SetScrollbarHeight
 global function SetScrollbarWidth
-global function SetScrollbarOriginalHeight
-global function SetScrollbarOriginalWidth
 global function SetScrollbarHorizontal
 global function FindScrollbarSafe
 global function FindScrollbar
+global function SetScrollbarPosition
 
 global struct ScrollbarExt {
 	array<void functionref( int x, int y )> callbacks
-	int originalHeight
-	int originalWidth
 	var scrollbar
 	var cover
 	var movementCapture
@@ -65,16 +62,6 @@ void function SetScrollbarWidth( var scrollbar, int width )
 	Hud_SetWidth( ctn.panel, width )
 }
 
-void function SetScrollbarOriginalHeight( var scrollbar, int height )
-{
-	FindScrollbar( scrollbar ).originalHeight = height
-}
-
-void function SetScrollbarOriginalWidth( var scrollbar, int width )
-{
-	FindScrollbar( scrollbar ).originalWidth = width
-}
-
 void function SetScrollbarHorizontal( var scrollbar, bool horizontal )
 {
 	FindScrollbar( scrollbar ).horizontal = horizontal
@@ -92,8 +79,6 @@ void function RegisterScrollbar( var scrollbar, bool horizontal = false )
 	AddButtonEventHandler( cover, UIE_GET_FOCUS, CoverGetFocus )
 	file.covers.append( cover )
 	ScrollbarExt bar
-	bar.originalHeight = Hud_GetHeight( scrollbar )
-	bar.originalWidth = Hud_GetWidth( scrollbar )
 	bar.scrollbar = scrollbar
 	bar.cover = cover
 	bar.movementCapture = Hud_GetChild( scrollbar, "MouseMovementCapture" )
@@ -118,6 +103,14 @@ ScrollbarExt function FindScrollbar( var scrollbar )
 		return expect ScrollbarExt( scr )
 	throw "scrollbar not registered"
 	unreachable
+}
+
+void function SetScrollbarPosition( ScrollbarExt scrollbar, int x, int y )
+{
+	Hud_SetPos( scrollbar.cover, x, y )
+	Hud_SetPos( scrollbar.movementCapture, x, y )
+	Hud_SetPos( scrollbar.button, x, y )
+	Hud_SetPos( scrollbar.panel, x, y )
 }
 
 // * #####################
@@ -158,7 +151,7 @@ void function RepositionScrollbar_Horizontal( ScrollbarExt scrollbar, int x, int
 	y = y * -1
 
 	int minXPos = Hud_GetBaseX( scrollbar.button )
-	int maxXPos = minXPos + scrollbar.originalWidth - Hud_GetWidth( scrollbar.button )
+	int maxXPos = minXPos + Hud_GetWidth( scrollbar.scrollbar ) - Hud_GetWidth( scrollbar.button )
 
 	int pos = expect int( Hud_GetPos( scrollbar.button )[0] )
 	int newPos = pos - x
@@ -168,10 +161,7 @@ void function RepositionScrollbar_Horizontal( ScrollbarExt scrollbar, int x, int
 
 	int yPos = expect int( Hud_GetPos( scrollbar.button )[1] )
 
-	Hud_SetPos( scrollbar.cover, newPos, yPos )
-	Hud_SetPos( scrollbar.movementCapture, newPos, yPos )
-	Hud_SetPos( scrollbar.button, newPos, yPos )
-	Hud_SetPos( scrollbar.panel, newPos, yPos )
+	SetScrollbarPosition( scrollbar, newPos, yPos )
 }
 
 void function RepositionScrollbar_Vertical( ScrollbarExt scrollbar, int x, int y )
@@ -183,7 +173,7 @@ void function RepositionScrollbar_Vertical( ScrollbarExt scrollbar, int x, int y
 	var sliderPanel = scrollbar.panel
 
 	int minYPos = Hud_GetBaseY( scrollbar.button )
-	int maxYPos = minYPos + scrollbar.originalHeight - Hud_GetHeight( scrollbar.button )
+	int maxYPos = minYPos + Hud_GetHeight( scrollbar.scrollbar ) - Hud_GetHeight( scrollbar.button )
 
 	int pos = expect int( Hud_GetPos( scrollbar.button )[1] )
 	int newPos = pos - y
@@ -193,10 +183,7 @@ void function RepositionScrollbar_Vertical( ScrollbarExt scrollbar, int x, int y
 
 	int xPos = expect int( Hud_GetPos( scrollbar.button )[0] )
 
-	Hud_SetPos( scrollbar.cover, xPos, newPos )
-	Hud_SetPos( scrollbar.movementCapture, xPos, newPos )
-	Hud_SetPos( scrollbar.button, xPos, newPos )
-	Hud_SetPos( scrollbar.panel, xPos, newPos )
+	SetScrollbarPosition( scrollbar, xPos, newPos )
 }
 
 int function GetFocusedScrollbarIndex()

--- a/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
@@ -86,7 +86,7 @@ void function RegisterScrollbar( var scrollbar, bool horizontal = false )
 {
 	if( FindScrollbarSafe( scrollbar ) )
 	{
-		printt( format( "%s is already registered. omitting registration." ), scrollbar.tostring() )
+		printt( format( "%s is already registered. omitting registration.", scrollbar.tostring() ) )
 		return
 	}
 
@@ -117,9 +117,9 @@ ScrollbarExt ornull function FindScrollbarSafe( var scrollbar )
 
 ScrollbarExt function FindScrollbar( var scrollbar )
 {
-	var scr = FindScrollbarSafe( scrollbar )
-	if( scr )
-		return scr
+	ScrollbarExt ornull scr = FindScrollbarSafe( scrollbar )
+	if( scr != null )
+		return expect ScrollbarExt( scr )
 	throw "scrollbar not registered"
 	unreachable
 }

--- a/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
@@ -127,7 +127,7 @@ void function CoverGetFocus( var cover )
 void function MouseMovementHandler( int x, int y )
 {
 	int idx = GetFocusedScrollbarIndex()
-	Hud_SetFocused( file.scrollbars[ idx ].scrollbar.button )
+	Hud_SetFocused( file.scrollbars[ idx ].button )
 	if( idx < 0 )
 		return
 	foreach( void functionref( int x, int y ) callback in file.scrollbars[ idx ].callbacks )

--- a/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/custom_scrollbar.nut
@@ -42,40 +42,42 @@ void function UseCustomScrollbars( var menu )
 	AddMouseMovementCaptureHandler( menu, MouseMovementHandler )
 }
 
-void function RegisterScrollbarMoveCallback( int scrollbarIndex, void functionref( int x, int y ) f )
+void function RegisterScrollbarMoveCallback( var scrollbar, void functionref( int x, int y ) f )
 {
-	file.scrollbars[ scrollbarIndex ].callbacks.append( f )
+	FindScrollbarByRef( scrollbar ).callbacks.append( f )
 }
 
-void function SetScrollbarHeight( int idx, int height )
+void function SetScrollbarHeight( var scrollbar, int height )
 {
-	Hud_SetHeight( file.scrollbars[ idx ].cover, height)
-	Hud_SetHeight( file.scrollbars[ idx ].movementCapture, height)
-	Hud_SetHeight( file.scrollbars[ idx ].button, height)
-	Hud_SetHeight( file.scrollbars[ idx ].panel, height)
+	ScrollbarExt ctn = FindScrollbarByRef( scrollbar )
+	Hud_SetHeight( ctn.cover, height )
+	Hud_SetHeight( ctn.movementCapture, height )
+	Hud_SetHeight( ctn.button, height )
+	Hud_SetHeight( ctn.panel, height )
 }
 
-void function SetScrollbarWidth( int idx, int width )
+void function SetScrollbarWidth( var scrollbar, int width )
 {
-	Hud_SetWidth( file.scrollbars[ idx ].cover, width)
-	Hud_SetWidth( file.scrollbars[ idx ].movementCapture, width)
-	Hud_SetWidth( file.scrollbars[ idx ].button, width)
-	Hud_SetWidth( file.scrollbars[ idx ].panel, width)
+	ScrollbarExt ctn = FindScrollbarByRef( scrollbar )
+	Hud_SetWidth( ctn.cover, width )
+	Hud_SetWidth( ctn.movementCapture, width )
+	Hud_SetWidth( ctn.button, width )
+	Hud_SetWidth( ctn.panel, width )
 }
 
-void function SetScrollbarOriginalHeight( int idx, int height )
+void function SetScrollbarOriginalHeight( var scrollbar, int height )
 {
-	file.scrollbars[ idx ].originalHeight = height
+	FindScrollbarByRef( scrollbar ).originalHeight = height
 }
 
-void function SetScrollbarOriginalWidth( int idx, int width )
+void function SetScrollbarOriginalWidth( var scrollbar, int width )
 {
-	file.scrollbars[ idx ].originalWidth = width
+	FindScrollbarByRef( scrollbar ).originalWidth = width
 }
 
-void function SetScrollbarHorizontal( int idx, bool horizontal )
+void function SetScrollbarHorizontal( var scrollbar, bool horizontal )
 {
-	file.scrollbars[ idx ].horizontal = horizontal
+	FindScrollbarByRef( scrollbar ).horizontal = horizontal
 }
 
 void function RegisterScrollbar( var scrollbar, bool horizontal = false )
@@ -118,7 +120,7 @@ void function MouseMovementHandler( int x, int y )
 	Hud_SetFocused( Hud_GetChild( file.scrollbars[ idx ].scrollbar, "SliderButton" ) )
 	if( idx < 0 )
 		return
-	foreach( void functionref( int x, int y ) callback in file.scrollbars[ idx ].callbacks)
+	foreach( void functionref( int x, int y ) callback in file.scrollbars[ idx ].callbacks )
 	{
 		callback( x, y )
 	}
@@ -145,10 +147,10 @@ void function RepositionScrollbar_Horizontal( ScrollbarExt scrollbar, int x, int
 
 	int yPos = expect int( Hud_GetPos( scrollbar.button )[1] )
 
-	Hud_SetPos( scrollbar.cover , newPos, yPos )
-	Hud_SetPos( scrollbar.movementCapture , newPos, yPos )
-	Hud_SetPos( scrollbar.button , newPos, yPos )
-	Hud_SetPos( scrollbar.panel , newPos, yPos )
+	Hud_SetPos( scrollbar.cover, newPos, yPos )
+	Hud_SetPos( scrollbar.movementCapture, newPos, yPos )
+	Hud_SetPos( scrollbar.button, newPos, yPos )
+	Hud_SetPos( scrollbar.panel, newPos, yPos )
 }
 
 void function RepositionScrollbar_Vertical( ScrollbarExt scrollbar, int x, int y )
@@ -170,18 +172,22 @@ void function RepositionScrollbar_Vertical( ScrollbarExt scrollbar, int x, int y
 
 	int xPos = expect int( Hud_GetPos( scrollbar.button )[0] )
 
-	Hud_SetPos( scrollbar.cover , xPos, newPos )
-	Hud_SetPos( scrollbar.movementCapture , xPos, newPos )
-	Hud_SetPos( scrollbar.button , xPos, newPos )
-	Hud_SetPos( scrollbar.panel , xPos, newPos )
-}
-
-var function GetFocusedScrollbar()
-{
-	return file.scrollbars[ file.covers.find( file.invisCover ) ].scrollbar
+	Hud_SetPos( scrollbar.cover, xPos, newPos )
+	Hud_SetPos( scrollbar.movementCapture, xPos, newPos )
+	Hud_SetPos( scrollbar.button, xPos, newPos )
+	Hud_SetPos( scrollbar.panel, xPos, newPos )
 }
 
 int function GetFocusedScrollbarIndex()
 {
 	return file.covers.find( file.invisCover )
+}
+
+ScrollbarExt function FindScrollbarByRef( var scrollbar )
+{
+	foreach( ScrollbarExt container in file.scrollbars )
+		if( container.scrollbar == scrollbar )
+			return container
+	throw "scrollbar not registered"
+	unreachable
 }


### PR DESCRIPTION
There's currently no implementation for multiple scrollbars on the same menu.
This pr adds a nested panel and other functions to use scrollbars in other menus without fiddling with menus.

https://user-images.githubusercontent.com/113718637/191086238-c3bd6583-db07-4f3c-bddc-36e484f2ce27.mp4

https://user-images.githubusercontent.com/113718637/190923631-0669bf31-7a91-440d-b22a-e23cf2a9bbf0.mp4


The move bounds of a scrollbar are defined by the original element's **height** and **width** as given in the  **.menu file**.
However, if you want to, you can override them with ``SetScrollbarOriginalHeight`` and ``SetScrollbarOriginalWidth``.

Some functions take a HUD element as a parameter. Pass a CNestedPanel here, not elements of the panel.

## API

```squirrel
void function UseCustomScrollbars( var menu )
```
Automatically register scrollbars in the given menu. HUD elements with the `NS_Scrollbar` classname are recognized as vertical scrollbars and elements with the classname `NS_Scrollbar_h` are treated as horizontal scrollbars.
Call this when **initializing** the menu.

```squirrel
void function RegisterScrollbar( var scrollbar, bool horizontal = false )
```
Manually register a scrollbar by HUD element reference.

```squirrel
void function RegisterScrollbarMoveCallback( var scrollbar, void functionref( int x, int y ) f )
```
Register a function that receives the MouseMovementCapture mouse movement of a specific scrollbar.

```squirrel
void function SetScrollbarHeight( var scrollbar, int height )
```
Set the height of all HUD elements associated with the registered scrollbar identified by CNestedPanel reference

```squirrel
void function SetScrollbarWidth( var scrollbar, int width )
```
Set the width of all HUD elements associated with the registered scrollbar identified by CNestedPanel reference

```squirrel
void function SetScrollbarHorizontal( var scrollbar, bool horizontal )
```
Sets if the scrollbar can be dragged horizontally / vertically

```squirrel
void function SetScrollbarOriginalHeight( var scrollbar, int height )
```
**REMOVED**
use `Hud_SetHeight` instead!
Redefine vertical movement bounds. **The max position a slider can move vertically is limited by it's own height**

```squirrel
void function SetScrollbarOriginalWidth( var scrollbar, int width )
```
**REMOVED**
use `Hud_SetWidth` instead!
Redefine horizontal movement bounds. **The max position a slider can move horizontally is limited by it's own width**

```squirrel
ScrollbarExt function FindScrollbar( var scrollbar )
```
Returns the extra data struct describing the scrollbar. **throws an error if the scrollbar is not found**

```squirrel
ScrollbarExt ornull function FindScrollbarSafe( var scrollbar )
Same as `FindScrollbar` but returns null if not found
```

```squirrel
global struct ScrollbarExt {
  array<void functionref( int x, int y)> callbacks // movement callbacks attached to this scrollbar
  //int originalX // original position before the scrollbar has been moved. You shouldn't need to change this // REMOVED
  //int originalY // ^ // REMOVED
  //int originalHeight // max height the scrollbar will move // REMOVED
  //int originalWidth // max vert the scrollbar will move // REMOVED
  var scrollbar // the nested panel
  var cover // the cover used for selecting a scrollbar
  var movementCapture // the mouse capture
  var button // the white backdrop when moving the scrollbar
  var panel // the black backdrop of the scrollbar
  bool horizontal // controls the direction in which the scrollbar is movable
}
```

I don't think deregistrations are needed.

## Usage

To add a scrollbar to your menu, use a element configuration like this:

```
TestSliderPanel3
{
    ControlName    CNestedPanel // SLIDERS NEED TO BE A NESTED PANEL
    classname        NS_Scrollbar // NS_Scrollbar_h for horizontal scrollbar

    controlSettingsFile    "resource/ui/menus/panels/scrollbar.res" // this is the configuration part. 
    wide    50   // dimensions in which the scrollbar can be moved in
    tall    500
    
    pin_to_sibling    SIBLING
    pin_corner_to_sibling     CENTER
    pin_to_sibling_corner     CENTER
}
```

## Example

You can mess with the demo I showcased in the video with this mod:
[bong.InGameProfiles.zip](https://github.com/R2Northstar/NorthstarMods/files/9601726/bong.InGameProfiles.zip)
To open the menu, click the "Profiles" footer next to the mods one.
([old](https://github.com/R2Northstar/NorthstarMods/files/9595171/bong.InGameProfiles.zip))
