### PR TITLE
Fix server crash from demigod setting health over max health.

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
@@ -2132,9 +2132,7 @@ void function EntityDemigod_TryAdjustDamageInfo( entity ent, var damageInfo )
 	{
 		// Prevent going over max health to avoid a server crash.
 		int newHealth = bottomLimit + 1
-		newHealth = ent.GetMaxHealth() < newHealth ? ent.GetMaxHealth() : newHealth
-
-		ent.SetHealth( newHealth )
+		ent.SetHealth( ent.GetMaxHealth() < newHealth ? ent.GetMaxHealth() : newHealth )
 	}
 
 	int health = ent.GetHealth()

--- a/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
@@ -2127,8 +2127,15 @@ void function EntityDemigod_TryAdjustDamageInfo( entity ent, var damageInfo )
 		return
 
 	int bottomLimit = 5
+	//Set it up so that you at least take 1 damage, for hit indicators etc to trigger
 	if ( ent.GetHealth() <= bottomLimit )
-		ent.SetHealth( bottomLimit + 1 ) //Set it up so that you at least take 1 damage, for hit indicators etc to trigger
+	{
+		// Prevent going over max health to avoid a server crash.
+		int newHealth = bottomLimit + 1
+		newHealth = ent.GetMaxHealth() < newHealth ? ent.GetMaxHealth() : newHealth
+
+		ent.SetHealth( newHealth )
+	}
 
 	int health = ent.GetHealth()
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
@@ -2127,7 +2127,7 @@ void function EntityDemigod_TryAdjustDamageInfo( entity ent, var damageInfo )
 		return
 
 	int bottomLimit = 5
-	//Set it up so that you at least take 1 damage, for hit indicators etc to trigger
+	// Set it up so that you at least take 1 damage, for hit indicators etc to trigger
 	if ( ent.GetHealth() <= bottomLimit )
 	{
 		// Prevent going over max health to avoid a server crash.


### PR DESCRIPTION
```squirrel
[22:31:22] [info] [SERVER SCRIPT] pilot weapon3 skin/camo 1 81
[22:31:22] [info] [SERVER SCRIPT] SCRIPT ERROR: [SERVER] SetHealth: Can't set health on entity to 6, max health is 1.
[22:31:22] [info] [SERVER SCRIPT]  -> ent.SetHealth( bottomLimit + 1 ) //Set it up so that you at least take 1 damage, for hit indicators etc to trigger
[22:31:22] [info] [SERVER SCRIPT]
CALLSTACK
*FUNCTION [EntityDemigod_TryAdjustDamageInfo()] _utility.gnut line [2131]
*FUNCTION [Wallrun_PlayerTookDamage()] pilot/class_wallrun.gnut line [54]
*FUNCTION [PlayerTookDamage()] mp/_codecallbacks.gnut line [754]
*FUNCTION [CodeCallback_DamagePlayerOrNPC()] mp/_codecallbacks.gnut line [300]
```