### PR TITLE
restore hud_takesshots functionality to automatically take screenshots of scoreboard

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/client/cl_gamestate.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_gamestate.gnut
@@ -1105,7 +1105,17 @@ void function DisplayPostMatchTop3()
 			RuiSetBool( rui, "isFriendly" + i, localTeam == players[i].GetTeam() )
 		}
 	}
+	
+	if ( GetConVarBool( "hud_takesshots" ) )
+		thread TakeScoreboardScreenshot_Delayed()
 }
+
+void function TakeScoreboardScreenshot_Delayed()
+{
+	wait 1.5
+	GetLocalClientPlayer().ClientCommand( "jpeg" )
+}
+
 
 
 float function GetGameStartTime()

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_gamestate.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_gamestate.gnut
@@ -1116,8 +1116,6 @@ void function TakeScoreboardScreenshot_Delayed()
 	GetLocalClientPlayer().ClientCommand( "jpeg" )
 }
 
-
-
 float function GetGameStartTime()
 {
 	return expect float( level.nv.gameStartTime.tofloat() )


### PR DESCRIPTION
as the cvar hud_takesshots was unrestricted in https://github.com/R2Northstar/NorthstarLauncher/pull/294, this pr reimplements its functionality, by automatically running the `jpeg` screenshot command when the postmatch scoreboard is displayed when the convar is enabled