### PR TITLE
Remove unnecessary root table setting and make functions global

### DIFF
--- a/Northstar.Client/mod.json
+++ b/Northstar.Client/mod.json
@@ -46,10 +46,7 @@
 	"Scripts": [
 		{
 			"Path": "_custom_codecallbacks_client.gnut",
-			"RunOn": "CLIENT",
-			"ClientCallback": {
-				"Before": "NSSetupChathooksClient"
-			}
+			"RunOn": "CLIENT"
 		},
 		{
 			"Path": "client/cl_chat.gnut",

--- a/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
@@ -1,7 +1,10 @@
 untyped
 
 global function AddCallback_OnReceivedSayTextMessage
-global function NSSetupChathooksClient
+
+// this is global due to squirrel bridge v3 making native not be able to find non-global funcs properly
+// temp fix (surely it will get replaced), do not use this function please (although there isnt rly a downside to it?)
+global function CHudChat_ProcessMessageStartThread
 
 global struct ClClient_MessageStruct {
 	string message
@@ -134,8 +137,4 @@ void function CHudChat_OnReceivedSayTextMessageCallback(int fromPlayerIndex, str
 void function AddCallback_OnReceivedSayTextMessage( ClClient_MessageStruct functionref (ClClient_MessageStruct) callbackFunc )
 {
 	NsCustomCallbacksClient.OnReceivedSayTextMessageCallbacks.append(callbackFunc)
-}
-
-void function NSSetupChathooksClient() {
-    getroottable().rawset("CHudChat_ProcessMessageStartThread", CHudChat_ProcessMessageStartThread)
 }

--- a/Northstar.CustomServers/mod.json
+++ b/Northstar.CustomServers/mod.json
@@ -101,10 +101,7 @@
 		},
 		{
 			"Path": "sh_server_to_client_stringcommands.gnut",
-			"RunOn": "CLIENT || SERVER",
-			"ClientCallback": {
-				"After": "ServerToClientStringCommands_Init"
-			}
+			"RunOn": "CLIENT || SERVER"
 		},
 		{
 			"Path": "gamemodes/_gamemode_fra.nut",

--- a/Northstar.CustomServers/mod.json
+++ b/Northstar.CustomServers/mod.json
@@ -58,10 +58,7 @@
 	"Scripts": [
 		{
 			"Path": "_custom_codecallbacks.gnut",
-			"RunOn": "SERVER",
-			"ServerCallback": {
-				"Before": "NSSetupChathooksServer"
-			}
+			"RunOn": "SERVER"
 		},
 		{
 			"Path": "_northstar_cheatcommands.nut",

--- a/Northstar.CustomServers/mod/scripts/vscripts/_custom_codecallbacks.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_custom_codecallbacks.gnut
@@ -1,7 +1,10 @@
 untyped
 
 global function AddCallback_OnReceivedSayTextMessage
-global function NSSetupChathooksServer
+
+// this is global due to squirrel bridge v3 making native not be able to find non-global funcs properly
+// temp fix (surely it will get replaced), do not use this function please
+global function CServerGameDLL_ProcessMessageStartThread
 
 global struct ClServer_MessageStruct {
 	string message
@@ -52,8 +55,4 @@ void function CServerGameDLL_OnReceivedSayTextMessageCallback(int playerIndex, s
 void function AddCallback_OnReceivedSayTextMessage( ClServer_MessageStruct functionref (ClServer_MessageStruct) callbackFunc )
 {
 	NsCustomCallbacks.OnReceivedSayTextMessageCallbacks.append(callbackFunc)
-}
-
-void function NSSetupChathooksServer() {
-	getroottable().rawset("CServerGameDLL_ProcessMessageStartThread", CServerGameDLL_ProcessMessageStartThread)
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_server_to_client_stringcommands.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_server_to_client_stringcommands.gnut
@@ -14,11 +14,6 @@ struct {
 	table< string, array< void functionref( array<string> args ) > > callbacks
 } file
 
-void function ServerToClientStringCommands_Init()
-{
-	getroottable().rawset( "NSClientCodeCallback_RecievedServerToClientStringCommand", NSClientCodeCallback_RecievedServerToClientStringCommand )
-}
-
 void function AddServerToClientStringCommandCallback( string command, void functionref( array<string> args ) callback )
 {
 	if ( !( command in file.callbacks ) )

--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_server_to_client_stringcommands.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_server_to_client_stringcommands.gnut
@@ -1,6 +1,4 @@
 #if CLIENT
-global function ServerToClientStringCommands_Init
-
 global function AddServerToClientStringCommandCallback
 global function NSClientCodeCallback_RecievedServerToClientStringCommand
 #endif


### PR DESCRIPTION
This is a consequence of https://github.com/R2Northstar/NorthstarLauncher/pull/310 making changes to how squirrel functions are called.

Ideally we don't need to make the functions global, but it will have to do for now. Without the functions being global, native cannot find them to call.

The old way we did calling squirrel functions used root table setting to allow native to access the functions, this is no longer the case, so those have been removed.

Fixes an issue with server chat messages not being processed correctly (@Erlite)