### PR TITLE
Fix calling `TitanEject` without arguments crashing server

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/titan/class_titan.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/titan/class_titan.gnut
@@ -68,7 +68,8 @@ bool function ClientCommand_TitanEject( entity player, array<string> args )
 	if ( !PlayerCanEject( player ) )
 		return true
 
-	// this makes it not crash // told gecko this fix 3 months ago
+	// check array length before accessing index to avoid oob access
+	// prevents crashing a server by just calling `TitanEject` without arguments
     	if( args.len() < 1 ) 
         	return true
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/titan/class_titan.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/titan/class_titan.gnut
@@ -68,6 +68,10 @@ bool function ClientCommand_TitanEject( entity player, array<string> args )
 	if ( !PlayerCanEject( player ) )
 		return true
 
+	// this makes it not crash // told gecko this fix 3 months ago
+    if( args.len() < 1 ) 
+        return true
+
 	int ejectPressCount = args[ 0 ].tointeger()
 	if ( ejectPressCount < 3 )
 		return true

--- a/Northstar.CustomServers/mod/scripts/vscripts/titan/class_titan.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/titan/class_titan.gnut
@@ -69,8 +69,8 @@ bool function ClientCommand_TitanEject( entity player, array<string> args )
 		return true
 
 	// this makes it not crash // told gecko this fix 3 months ago
-    if( args.len() < 1 ) 
-        return true
+    	if( args.len() < 1 ) 
+        	return true
 
 	int ejectPressCount = args[ 0 ].tointeger()
 	if ( ejectPressCount < 3 )


### PR DESCRIPTION
This fixes being able to crash a server by sending `TitanEject` user command without arguments to server while the client is inside a Titan.

Closes #533 

so i had this ready 3 months ago and @GeckoEidechse just rembered it so uh here u go

![image](https://user-images.githubusercontent.com/47725553/205671565-a5b5102a-0e1c-473d-92d0-07bfad4bad87.png)
(gecko not rembering my fix for a server crash exploit (he forgor 💀))

![image](https://user-images.githubusercontent.com/47725553/205671804-522efdfa-d34c-420b-ba5c-f221f3b553be.png)
(how i epically fixed this serious business exploit)

obligatory cat post: 
![image](https://user-images.githubusercontent.com/47725553/205671745-469731b5-f746-448f-9af7-8da8b46eca7d.png)
