### PR TITLE
Set FW specific convar values via cfg file

### DIFF
--- a/Northstar.Custom/mod/cfg/server/cleanup_gamemode_fw.cfg
+++ b/Northstar.Custom/mod/cfg/server/cleanup_gamemode_fw.cfg
@@ -1,0 +1,3 @@
+// reset cvars that fortwar set
+cvar_reset sv_max_props_multiplayer
+cvar_reset sv_max_prop_data_dwords_multiplayer

--- a/Northstar.Custom/mod/cfg/server/setup_gamemode_fw.cfg
+++ b/Northstar.Custom/mod/cfg/server/setup_gamemode_fw.cfg
@@ -1,0 +1,4 @@
+// setup engine for fortwar
+// this has to run before server initialisation, so it can't be in gamemode script
+sv_max_props_multiplayer 1250000
+sv_max_prop_data_dwords_multiplayer 2500000

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fw.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fw.nut
@@ -131,10 +131,6 @@ void function GamemodeFW_Init()
 	ScoreEvent_SetupEarnMeterValuesForMixedModes()
 	SetRecalculateTitanReplacementPointCallback(FW_ReCalculateTitanReplacementPoint)
 	SetRequestTitanAllowedCallback(FW_RequestTitanAllowed)
-
-	// so many things in battle, this is required to avoid crash!
-	ServerCommand( "sv_max_props_multiplayer 200000" )
-	ServerCommand( "sv_max_prop_data_dwords_multiplayer 300000" )
 }
 
 


### PR DESCRIPTION
Squirrel scripts set the value too late, so they do not get updated until after map rotation.

Requires

- [ ] https://github.com/R2Northstar/NorthstarLauncher/pull/398

Fixes https://github.com/R2Northstar/Northstar/issues/414