### PR TITLE
Fix chat messages when dead

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
@@ -23,7 +23,7 @@ struct {
 
 void function OnReceivedMessage(ClClient_MessageStruct localMessage) {
 
-    if ( IsWatchingReplay() && ( GetLocalClientPlayer() != localMessage.player ) )
+    if ( IsWatchingReplay() && localMessage.player == null )
         return
 
     if (localMessage.player != null)

--- a/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/_custom_codecallbacks_client.gnut
@@ -23,7 +23,7 @@ struct {
 
 void function OnReceivedMessage(ClClient_MessageStruct localMessage) {
 
-    if ( IsWatchingReplay() )
+    if ( IsWatchingReplay() && ( GetLocalClientPlayer() != localMessage.player ) )
         return
 
     if (localMessage.player != null)


### PR DESCRIPTION
Fixes a bug, where chat messages were not send to your local chat, when you typed them while dead 

Closes #572