### PR TITLE
Add support for entity final damage callbacks

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_codecallbacks_common.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_codecallbacks_common.gnut
@@ -123,6 +123,13 @@ void function CodeCallback_DamageEntity( entity ent, var damageInfo )
 		printt( "    after class damage final callbacks:", DamageInfo_GetDamage( damageInfo ) )
 	#endif
 
+	foreach ( callbackFunc in ent.e.entFinalDamageCallbacks )
+		callbackFunc( ent, damageInfo )
+
+	#if VERBOSE_DAMAGE_PRINTOUTS
+		printt( "    after AddEntityCallback_OnFinalDamaged callbacks:", DamageInfo_GetDamage( damageInfo ) )
+	#endif
+
 	// make destructible vehicles take more damage from DF_EXPLOSION damage type
 	if ( "isDestructibleVehicle" in ent.s && DamageInfo_GetCustomDamageType( damageInfo ) & DF_EXPLOSION )
 	{

--- a/Northstar.CustomServers/mod/scripts/vscripts/_codecallbacks_common.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_codecallbacks_common.gnut
@@ -46,6 +46,8 @@ global function CodeCallback_OnEntityChangedTeam
 
 global function AddEntityCallback_OnDamaged
 global function RemoveEntityCallback_OnDamaged
+global function AddEntityCallback_OnFinalDamaged
+global function RemoveEntityCallback_OnFinalDamaged
 global function AddEntityCallback_OnPostDamaged
 global function RemoveEntityCallback_OnPostDamaged
 global function AddEntityCallback_OnKilled
@@ -566,7 +568,26 @@ void function RemoveEntityCallback_OnDamaged( entity ent, void functionref( enti
 	Assert( index != -1, "Requested DamageCallback " + string( callbackFunc ) + " to be removed not found! " )
 	ent.e.entDamageCallbacks.fastremove( index )
 
-	if ( ent.e.entDamageCallbacks.len() == 0 && ent.e.entPostDamageCallbacks.len() == 0 )
+	if ( ent.e.entDamageCallbacks.len() == 0 && ent.e.entFinalDamageCallbacks.len() == 0 && ent.e.entPostDamageCallbacks.len() == 0 )
+		ent.SetDamageNotifications( false )
+}
+
+void function AddEntityCallback_OnFinalDamaged( entity ent, void functionref( entity ent, var damageInfo ) callbackFunc )
+{
+	Assert( !ent.e.entFinalDamageCallbacks.contains( callbackFunc ), "Already added " + string( callbackFunc ) + " to entity" )
+
+	ent.SetDamageNotifications( true )
+	ent.e.entFinalDamageCallbacks.append( callbackFunc )
+}
+
+void function RemoveEntityCallback_OnFinalDamaged( entity ent, void functionref( entity ent, var damageInfo ) callbackFunc )
+{
+	int index = ent.e.entFinalDamageCallbacks.find( callbackFunc )
+
+	Assert( index != -1, "Requested FinalDamageCallback " + string( callbackFunc ) + " to be removed not found! " )
+	ent.e.entFinalDamageCallbacks.fastremove( index )
+
+	if ( ent.e.entFinalDamageCallbacks.len() == 0 && ent.e.entPostDamageCallbacks.len() == 0 && ent.e.entDamageCallbacks.len() == 0 )
 		ent.SetDamageNotifications( false )
 }
 
@@ -585,7 +606,7 @@ void function RemoveEntityCallback_OnPostDamaged( entity ent, void functionref( 
 	Assert( index != -1, "Requested PostDamageCallback " + string( callbackFunc ) + " to be removed not found! " )
 	ent.e.entPostDamageCallbacks.fastremove( index )
 
-	if ( ent.e.entPostDamageCallbacks.len() == 0 && ent.e.entDamageCallbacks.len() == 0 )
+	if ( ent.e.entPostDamageCallbacks.len() == 0 && ent.e.entDamageCallbacks.len() == 0 && ent.e.entFinalDamageCallbacks.len() == 0 )
 		ent.SetDamageNotifications( false )
 }
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/_codecallbacks_common.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_codecallbacks_common.gnut
@@ -589,10 +589,7 @@ void function AddEntityCallback_OnFinalDamaged( entity ent, void functionref( en
 
 void function RemoveEntityCallback_OnFinalDamaged( entity ent, void functionref( entity ent, var damageInfo ) callbackFunc )
 {
-	int index = ent.e.entFinalDamageCallbacks.find( callbackFunc )
-
-	Assert( index != -1, "Requested FinalDamageCallback " + string( callbackFunc ) + " to be removed not found! " )
-	ent.e.entFinalDamageCallbacks.fastremove( index )
+	ent.e.entFinalDamageCallbacks.fastremovebyvalue( callbackFunc )
 
 	if ( ent.e.entFinalDamageCallbacks.len() == 0 && ent.e.entPostDamageCallbacks.len() == 0 && ent.e.entDamageCallbacks.len() == 0 )
 		ent.SetDamageNotifications( false )

--- a/Northstar.CustomServers/mod/scripts/vscripts/_entitystructs.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_entitystructs.gnut
@@ -232,6 +232,7 @@ global struct ServerEntityStruct
 	SpawnPointData spawnPointData
 
 	array<void functionref( entity ent, var damageInfo )> entDamageCallbacks
+	array<void functionref( entity ent, var damageInfo )> entFinalDamageCallbacks
 	array<void functionref( entity ent, var damageInfo )> entPostDamageCallbacks
 	array<void functionref( entity titan, entity attacker )> entSegmentLostCallbacks
 	array<void functionref( entity ent, var damageInfo, float actualShieldDamage )> entPostShieldDamageCallbacks

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_codecallbacks.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_codecallbacks.gnut
@@ -283,9 +283,30 @@ void function CodeCallback_DamagePlayerOrNPC( entity ent, var damageInfo )
 		return
 
 	RunClassDamageFinalCallbacks( ent, damageInfo )
+
+	if ( DamageInfo_GetDamage( damageInfo ) == 0 )
+		return
+	foreach ( callbackFunc in ent.e.entDamageCallbacks )
+	{
+		callbackFunc( ent, damageInfo )
+	}
+
 	#if VERBOSE_DAMAGE_PRINTOUTS
 		printt( "    after class damage final callbacks:", DamageInfo_GetDamage( damageInfo ) )
 	#endif
+	if ( DamageInfo_GetDamage( damageInfo ) == 0 )
+		return
+
+	// Added via AddEntityCallback_OnFinalDamaged
+	foreach ( callbackFunc in ent.e.entFinalDamageCallbacks )
+	{
+		callbackFunc( ent, damageInfo )
+	}
+
+	#if VERBOSE_DAMAGE_PRINTOUTS
+		printt( "    afterAddEntityCallback_OnFinalDamaged callbacks:", DamageInfo_GetDamage( damageInfo ) )
+	#endif
+
 	if ( DamageInfo_GetDamage( damageInfo ) == 0 )
 		return
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_codecallbacks.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_codecallbacks.gnut
@@ -286,10 +286,6 @@ void function CodeCallback_DamagePlayerOrNPC( entity ent, var damageInfo )
 
 	if ( DamageInfo_GetDamage( damageInfo ) == 0 )
 		return
-	foreach ( callbackFunc in ent.e.entDamageCallbacks )
-	{
-		callbackFunc( ent, damageInfo )
-	}
 
 	#if VERBOSE_DAMAGE_PRINTOUTS
 		printt( "    after class damage final callbacks:", DamageInfo_GetDamage( damageInfo ) )

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_codecallbacks.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_codecallbacks.gnut
@@ -284,9 +284,6 @@ void function CodeCallback_DamagePlayerOrNPC( entity ent, var damageInfo )
 
 	RunClassDamageFinalCallbacks( ent, damageInfo )
 
-	if ( DamageInfo_GetDamage( damageInfo ) == 0 )
-		return
-
 	#if VERBOSE_DAMAGE_PRINTOUTS
 		printt( "    after class damage final callbacks:", DamageInfo_GetDamage( damageInfo ) )
 	#endif


### PR DESCRIPTION
Adds FinalDamageCallbacks to entities.

Final damage callbacks exist for classes and are only used for multiplicative changes to damage to avoid issues where a later damage callback adds/subtracts a flat amount. This is why, for instance, Sword Block uses a final damage callback, as otherwise Railgun's charge damage ignores the damage reduction (as the Railgun callback is added after). Entities don't have these callbacks currently.

Primarily adding this to support better Frontier War harvester damage callback code, but usable elsewhere.