### PR TITLE
[FW] Enable Turrets By Default

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fw.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fw.nut
@@ -125,7 +125,7 @@ void function GamemodeFW_Init()
 	AddCallback_GameStateEnter( eGameState.Playing, OnFWGamePlaying )
 
 	AddSpawnCallback( "item_powerup", FWAddPowerUpIcon )
-	AddSpawnCallback( "npc_turret_mega", FWTurretHighlight )
+	AddSpawnCallback( "npc_turret_mega", OnFWTurretSpawned )
 
 	AddCallback_OnClientConnected( OnFWPlayerConnected )
 	AddCallback_PlayerClassChanged( OnFWPlayerClassChanged )
@@ -582,9 +582,6 @@ void function LoadEntities()
 					// create turret, spawn with no team and set it after game starts
 					entity turret = CreateNPC( "npc_turret_mega", TEAM_UNASSIGNED, info_target.GetOrigin(), info_target.GetAngles() )
 					SetSpawnOption_AISettings( turret, "npc_turret_mega_fortwar" )
-					SetDefaultMPEnemyHighlight( turret ) // for sonar highlights to work
-					Highlight_SetFriendlyHighlight( turret, "fw_friendly" )
-					AddEntityCallback_OnDamaged( turret, OnMegaTurretDamaged )
 					DispatchSpawn( turret )
 
 					turretsite.turret = turret
@@ -1384,8 +1381,11 @@ void function FWAreaThreatLevelThink_Threaded()
 ///// TURRET FUNCTIONS /////
 ////////////////////////////
 
-void function FWTurretHighlight( entity turret )
+void function OnFWTurretSpawned( entity turret )
 {
+	turret.EnableTurret() // always enabled
+	SetDefaultMPEnemyHighlight( turret ) // for sonar highlights to work
+	AddEntityCallback_OnDamaged( turret, OnMegaTurretDamaged )
     thread FWTurretHighlightThink( turret )
 }
 
@@ -1393,6 +1393,7 @@ void function FWTurretHighlight( entity turret )
 void function FWTurretHighlightThink( entity turret )
 {
     turret.EndSignal( "OnDestroy" )
+	WaitFrame()
     Highlight_SetFriendlyHighlight( turret, "fw_friendly" )
 
     turret.WaitSignal( "OnDeath" )
@@ -1407,8 +1408,6 @@ entity function FW_ReplaceMegaTurret( entity perviousTurret )
 
 	entity turret = CreateNPC( "npc_turret_mega", perviousTurret.GetTeam(), perviousTurret.GetOrigin(), perviousTurret.GetAngles() )
 	SetSpawnOption_AISettings( turret, "npc_turret_mega_fortwar" )
-	SetDefaultMPEnemyHighlight( turret ) // for sonar highlights to work
-	AddEntityCallback_OnDamaged( turret, OnMegaTurretDamaged )
 	DispatchSpawn( turret )
 
 	// apply settings to new turret, must up on date

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fw.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fw.nut
@@ -1386,18 +1386,18 @@ void function OnFWTurretSpawned( entity turret )
 	turret.EnableTurret() // always enabled
 	SetDefaultMPEnemyHighlight( turret ) // for sonar highlights to work
 	AddEntityCallback_OnDamaged( turret, OnMegaTurretDamaged )
-    thread FWTurretHighlightThink( turret )
+	thread FWTurretHighlightThink( turret )
 }
 
 // this will clear turret's highlight upon their death, for notifying players to fix them
 void function FWTurretHighlightThink( entity turret )
 {
-    turret.EndSignal( "OnDestroy" )
+	turret.EndSignal( "OnDestroy" )
 	WaitFrame()
-    Highlight_SetFriendlyHighlight( turret, "fw_friendly" )
+	Highlight_SetFriendlyHighlight( turret, "fw_friendly" )
 
-    turret.WaitSignal( "OnDeath" )
-    Highlight_ClearFriendlyHighlight( turret )
+	turret.WaitSignal( "OnDeath" )
+	Highlight_ClearFriendlyHighlight( turret )
 }
 
 // for battery_port, replace the turret with new one

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fw.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_fw.nut
@@ -1393,8 +1393,8 @@ void function OnFWTurretSpawned( entity turret )
 void function FWTurretHighlightThink( entity turret )
 {
 	turret.EndSignal( "OnDestroy" )
-	WaitFrame()
-	Highlight_SetFriendlyHighlight( turret, "fw_friendly" )
+	WaitFrame() // wait a frame for other turret spawn options to set up
+	Highlight_SetFriendlyHighlight( turret, "fw_friendly" ) // initialize the highlight, they will show upon player's next respawn
 
 	turret.WaitSignal( "OnDeath" )
 	Highlight_ClearFriendlyHighlight( turret )


### PR DESCRIPTION
Current FW mega turrets're diabled until they first seeing an enemy, make them unable to be damaged at start, which is confusing