### PR TITLE
Clean Team Score After Player Disconnecting in FFA

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
@@ -6,6 +6,9 @@ void function FFA_Init()
 	ScoreEvent_SetupEarnMeterValuesForMixedModes()
 
 	AddCallback_OnPlayerKilled( OnPlayerKilled )
+
+	// modified for northstar
+	AddCallback_OnClientConnected( OnClientConnected )
 }
 
 void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
@@ -18,10 +21,16 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 	}
 }
 
+// modified for northstar
+void function OnClientConnected( entity player )
+{
+	thread FFAPlayerScoreThink( player ) // good to have this! instead of DisconnectCallback this could handle a null player
+}
+
 void function FFAPlayerScoreThink( entity player )
 {
 	int team = player.GetTeam()
 
 	player.WaitSignal( "OnDestroy" ) // this can handle disconnecting
-	AddTeamScore( team, -GameRules_GetTeamScore( team ) )
+	AddTeamScore( team, -GameRules_GetTeamScore( team ))
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
@@ -1,26 +1,11 @@
 global function FFA_Init
 
-// modified: for saving player's score in ffa, don't let mid-game joined players get illegal scores
-struct FFAScoreStruct
-{
-	int team
-	int score
-}
-
-struct
-{
-	table<string, FFAScoreStruct> ffaPlayerScoreTable // use player's uid!
-} file
-
 void function FFA_Init()
 {
 	ClassicMP_ForceDisableEpilogue( true )
 	ScoreEvent_SetupEarnMeterValuesForMixedModes()
 
 	AddCallback_OnPlayerKilled( OnPlayerKilled )
-
-	// modified for northstar
-	AddCallback_OnClientConnected( OnClientConnected )
 }
 
 void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
@@ -30,41 +15,13 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 		AddTeamScore( attacker.GetTeam(), 1 )
 		// why isn't this PGS_SCORE? odd game
 		attacker.AddToPlayerGameStat( PGS_ASSAULT_SCORE, 1 )
-
-		// modified for northstar
-		string uid = attacker.GetUID()
-		file.ffaPlayerScoreTable[ uid ].score += 1
 	}
-}
-
-// modified for northstar
-void function OnClientConnected( entity player )
-{
-	string uid = player.GetUID()
-	FFAScoreStruct emptyStruct
-	if ( !( uid in file.ffaPlayerScoreTable ) )
-		file.ffaPlayerScoreTable[ uid ] <- emptyStruct // init a empty struct
-	file.ffaPlayerScoreTable[ uid ].score = 0 // start from 0
-
-	thread FFAPlayerScoreThink( player ) // good to have this! instead of DisconnectCallback this could handle a null player
 }
 
 void function FFAPlayerScoreThink( entity player )
 {
-	string uid = player.GetUID()
-	file.ffaPlayerScoreTable[ uid ].team = player.GetTeam()
-
-	OnThreadEnd(
-		function(): ( uid )
-		{
-			// take score from this team
-			int team = file.ffaPlayerScoreTable[ uid ].team
-			int score = file.ffaPlayerScoreTable[ uid ].score
-
-			AddTeamScore( team, -score )
-			delete file.ffaPlayerScoreTable[ uid ] // delete existing struct
-		}
-	)
+	int team = player.GetTeam()
 
 	player.WaitSignal( "OnDestroy" ) // this can handle disconnecting
+	AddTeamScore( team, -GameRules_GetTeamScore( team ) )
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
@@ -1,11 +1,26 @@
 global function FFA_Init
 
+// modified: for saving player's score in ffa, don't let mid-game joined players get illegal scores
+struct FFAScoreStruct
+{
+	int team
+	int score
+}
+
+struct
+{
+	table<string, FFAScoreStruct> ffaPlayerScoreTable // use player's uid!
+} file
+
 void function FFA_Init()
 {
 	ClassicMP_ForceDisableEpilogue( true )
 	ScoreEvent_SetupEarnMeterValuesForMixedModes()
 
 	AddCallback_OnPlayerKilled( OnPlayerKilled )
+
+	// modified for northstar
+	AddCallback_OnClientConnected( OnClientConnected )
 }
 
 void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
@@ -15,5 +30,39 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 		AddTeamScore( attacker.GetTeam(), 1 )
 		// why isn't this PGS_SCORE? odd game
 		attacker.AddToPlayerGameStat( PGS_ASSAULT_SCORE, 1 )
+
+		// modified for northstar
+		string uid = attacker.GetUID()
+		file.ffaPlayerScoreTable[ uid ].score += 1
 	}
+}
+
+// modified for northstar
+void function OnClientConnected( entity player )
+{
+	string uid = player.GetUID()
+	FFAScoreStruct emptyStruct
+	if ( !( uid in file.ffaPlayerScoreTable ) ) // first connecting?
+		file.ffaPlayerScoreTable[ uid ] <- emptyStruct // init a empty struct
+
+	thread FFAPlayerScoreThink( player ) // good to have this! instead of DisconnectCallback this could handle a null player
+}
+
+void function FFAPlayerScoreThink( entity player )
+{
+	string uid = player.GetUID()
+	file.ffaPlayerScoreTable[ uid ].team = player.GetTeam()
+
+	OnThreadEnd(
+		function(): ( uid )
+		{
+			// take score from this team
+			int team = file.ffaPlayerScoreTable[ uid ].team
+			int score = file.ffaPlayerScoreTable[ uid ].score
+
+			AddTeamScore( team, -score )
+		}
+	)
+
+	player.WaitSignal( "OnDestroy" ) // this can handle disconnecting
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
@@ -42,7 +42,7 @@ void function OnClientConnected( entity player )
 {
 	string uid = player.GetUID()
 	FFAScoreStruct emptyStruct
-	if ( !( uid in file.ffaPlayerScoreTable ) ) // first connecting?
+	if ( !( uid in file.ffaPlayerScoreTable ) )
 		file.ffaPlayerScoreTable[ uid ] <- emptyStruct // init a empty struct
 
 	thread FFAPlayerScoreThink( player ) // good to have this! instead of DisconnectCallback this could handle a null player
@@ -61,6 +61,7 @@ void function FFAPlayerScoreThink( entity player )
 			int score = file.ffaPlayerScoreTable[ uid ].score
 
 			AddTeamScore( team, -score )
+			delete file.ffaPlayerScoreTable[ uid ] // delete existing struct
 		}
 	)
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
@@ -32,5 +32,5 @@ void function FFAPlayerScoreThink( entity player )
 	int team = player.GetTeam()
 
 	player.WaitSignal( "OnDestroy" ) // this can handle disconnecting
-	AddTeamScore( team, -GameRules_GetTeamScore( team ))
+	AddTeamScore( team, -GameRules_GetTeamScore( team ) )
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
@@ -44,7 +44,7 @@ void function OnClientConnected( entity player )
 	FFAScoreStruct emptyStruct
 	if ( !( uid in file.ffaPlayerScoreTable ) )
 		file.ffaPlayerScoreTable[ uid ] <- emptyStruct // init a empty struct
-	file.ffaPlayerScoreTable[ uid ] = 0 // start from 0
+	file.ffaPlayerScoreTable[ uid ].score = 0 // start from 0
 
 	thread FFAPlayerScoreThink( player ) // good to have this! instead of DisconnectCallback this could handle a null player
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ffa.nut
@@ -44,6 +44,7 @@ void function OnClientConnected( entity player )
 	FFAScoreStruct emptyStruct
 	if ( !( uid in file.ffaPlayerScoreTable ) )
 		file.ffaPlayerScoreTable[ uid ] <- emptyStruct // init a empty struct
+	file.ffaPlayerScoreTable[ uid ] = 0 // start from 0
 
 	thread FFAPlayerScoreThink( player ) // good to have this! instead of DisconnectCallback this could handle a null player
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/item_inventory/sv_item_inventory.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/item_inventory/sv_item_inventory.gnut
@@ -8,6 +8,7 @@ global function PlayerInventory_EndCriticalSectionForWeaponOnEndFrame
 global function PlayerInventory_PushInventoryItem
 global function PlayerInventory_PushInventoryItemByBurnRef
 global function PlayerInventory_PopInventoryItem
+global function PlayerInventory_TakeAllInventoryItems
 global function PlayerInventory_CountBurnRef
 
 struct
@@ -138,6 +139,14 @@ void function PlayerInventory_PopInventoryItem( entity player )
 		}
 	}
 
+	return
+}
+
+void function PlayerInventory_TakeAllInventoryItems( entity player )
+{
+	file.playerInventoryStacks[ player ].clear()
+	waitthread PlayerInventory_TakeInventoryItem( player )
+	player.SetPlayerNetInt( "itemInventoryCount", 0 )
 	return
 }
 


### PR DESCRIPTION
Fixes #400
Player's team score will be cleaned after they disconnecting, so later joiners won't have trouble start from 0 score