### PR TITLE
[FD] Properly initialise mp_thaw.nut

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_thaw.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_thaw.nut
@@ -1,3 +1,5 @@
+global function CodeCallback_MapInit
+
 void function CodeCallback_MapInit()
 {
 	// Load Frontier Defense Data


### PR DESCRIPTION
`CodeCallback_MapInit` was never being ran on mp_thaw, meaning `initFrontierDefenseData` was never being ran, meaning no wave data