### PR TITLE
Force Server to Follow Loadout Rules

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_loadouts.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_loadouts.nut
@@ -414,15 +414,10 @@ function SetPersistentLoadoutValue( entity player, string loadoutType, int loado
 	ValidateSkinAndCamoIndexesAsAPair( player, loadoutType, loadoutIndex, loadoutProperty, value ) //Skin and camo properties need to be set correctly as a pair
 
 	#if HAS_THREAT_SCOPE_SLOT_LOCK
-		// this is a fixed check, for handling most situations
-		string attachmentRef = GetPersistentLoadoutValue( player, "pilot", loadoutIndex, "primaryAttachment" )
-		if ( attachmentRef == "threat_scope" )
+		if ( loadoutProperty.tolower() == "primaryattachment" && value == "threat_scope" )
+		{
 			SetPlayerPersistentVarWithoutValidation( player, loadoutType, loadoutIndex, "primaryMod2", "" )
-
-		//if ( loadoutProperty.tolower() == "primaryattachment" && value == "threat_scope" )
-		//{
-		//	SetPlayerPersistentVarWithoutValidation( player, loadoutType, loadoutIndex, "primaryMod2", "" )
-		//}
+		}
 	#endif
 
 	// TEMP client model update method
@@ -703,10 +698,18 @@ bool function FailsLoadoutValidationCheck( entity player, string loadoutType, in
 		return true
 
 	// this is an extra check, for players may edit their loadout with client-side scripts and breaks the loadout rules
-	// if player modified their proscreen to other mods, we falls this check
+	// if player modify their proscreen to other mods, we fall this check
 	if ( loadoutProperty.find( "Mod3" ) )
 	{
 		if ( value != "pro_screen" )
+			return true
+	}
+
+	// if player unlock the threat scope limit, we fall this check
+	if ( loadoutProperty.find( "Mod2" ) )
+	{
+		string attachmentRef = GetPersistentLoadoutValue( player, "pilot", loadoutIndex, "primaryAttachment" )
+		if ( attachmentRef == "threat_scope" )
 			return true
 	}
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_loadouts.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_loadouts.nut
@@ -705,6 +705,7 @@ bool function FailsLoadoutValidationCheck( entity player, string loadoutType, in
 			return true
 	}
 
+	#if HAS_THREAT_SCOPE_SLOT_LOCK
 	// if player unlock the threat scope limit, we fall this check
 	if ( loadoutProperty == "primaryMod2" )
 	{
@@ -712,6 +713,7 @@ bool function FailsLoadoutValidationCheck( entity player, string loadoutType, in
 		if ( attachmentRef == "threat_scope" )
 			return true
 	}
+	#endif
 
 	//printt( "End FailsLoadoutValidationCheck" )
 	return false

--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_loadouts.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_loadouts.nut
@@ -3700,6 +3700,19 @@ string function Loadouts_GetSetFileForRequestedClass( entity player )
 // GetDefaultPilotLoadout() should never be returning overridden loadouts because it is used in many places to correct or reset persistent loadout data
 void function UpdateDerivedPilotLoadoutData( PilotLoadoutDef loadout, bool doOverrideCallback = true )
 {
+	// this is an extra check, for players may edit their loadout with client-side scripts and breaks the loadout rules
+	#if HAS_THREAT_SCOPE_SLOT_LOCK
+		if ( loadout.primaryAttachment == "threat_scope" ) // if player is using threat scope as attachment
+			loadout.primaryMod2 = "" // remove the second mod
+	#endif
+	// if player modified their proscreen to other mods, we remove it, this can also handle non-proscreen conditions
+	if ( loadout.primaryMod3 != "pro_screen" )
+		loadout.primaryMod3 = ""
+	if ( loadout.secondaryMod3 != "pro_screen" )
+		loadout.secondaryMod3 = ""
+	if ( loadout.weapon3Mod3 != "pro_screen" )
+		loadout.weapon3Mod3 = ""
+
 	loadout.setFile 			= GetSuitAndGenderBasedSetFile( loadout.suit, loadout.race )
 	loadout.special				= GetSuitBasedTactical( loadout.suit )
 	loadout.primaryAttachments	= [ loadout.primaryAttachment ]

--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_loadouts.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_loadouts.nut
@@ -706,7 +706,7 @@ bool function FailsLoadoutValidationCheck( entity player, string loadoutType, in
 	}
 
 	// if player unlock the threat scope limit, we fall this check
-	if ( loadoutProperty.find( "Mod2" ) )
+	if ( loadoutProperty == "primaryMod2" )
 	{
 		string attachmentRef = GetPersistentLoadoutValue( player, "pilot", loadoutIndex, "primaryAttachment" )
 		if ( attachmentRef == "threat_scope" )


### PR DESCRIPTION
Players are able to modify their loadout and turn `pro_screen` slot into other mods, also allowing them to equip `threat_scope` without losing a mod.
This pull request add a check on server-side to prevent players from doing these
![image](https://user-images.githubusercontent.com/56738369/219962148-a8a1b4ba-e578-417a-abec-48671bc6a1b7.png)
