### PR TITLE
Rise Intro Fix

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_rise.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_rise.nut
@@ -1,1 +1,7 @@
-//fuck
+untyped
+global function CodeCallback_MapInit
+
+void function CodeCallback_MapInit()
+{
+	ClassicMP_SetLevelIntro( ClassicMP_DefaultNoIntro_Setup, ClassicMP_DefaultNoIntro_GetLength() )
+}


### PR DESCRIPTION
Rise( mp_rise ) should not use a dropship intro same as CrashSite and LF maps. Same as vanilla
![Desktop Screenshot 2023 02 20 - 00 49 45 85](https://user-images.githubusercontent.com/56738369/219962506-be1ab9c7-eea7-4fe0-97c8-de0a1f9eeac3.png)
