### PR TITLE
[FD] Add Indicator for Reaper's Spawnpoints 

### DIFF
--- a/Northstar.Custom/mod.json
+++ b/Northstar.Custom/mod.json
@@ -429,6 +429,16 @@
 		{
 			"Path":  "sh_northstar_http_requests.gnut",
 			"RunOn": "CLIENT || SERVER || UI"
+		},
+		{
+			"Path": "gamemodes/sh_gamemode_fd_custom.nut",
+			"RunOn": "( CLIENT || SERVER ) && MP",
+			"ClientCallback": {
+				"Before": "SHGamemodeFD_Custom_Init"
+			},
+			"ServerCallback": {
+				"Before": "SHGamemodeFD_Custom_Init"
+			}
 		}
 	],
 

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/sh_gamemode_fd_custom.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/sh_gamemode_fd_custom.nut
@@ -1,0 +1,7 @@
+// this script only exists to add more features about fd
+global function SHGamemodeFD_Custom_Init
+
+void function SHGamemodeFD_Custom_Init()
+{
+	AddPrivateMatchModeSettingEnum( "#PL_fd", "fd_reaper_indicator", [ "#SETTING_DISABLED", "#SETTING_ENABLED" ], "0" )
+}

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd_events.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd_events.nut
@@ -729,6 +729,7 @@ void function waitUntilLessThanAmountAliveEventWeighted( SmokeEvent smokeEvent, 
 void function spawnSuperSpectre( SmokeEvent smokeEvent, SpawnEvent spawnEvent, FlowControlEvent flowControlEvent, SoundEvent soundEvent )
 {
 	PingMinimap( spawnEvent.origin.x, spawnEvent.origin.y, 4, 600, 150, 0 )
+	thread Reaper_Spawnpoint( spawnEvent.origin, TEAM_IMC, 6.0 ) // reaper takes ~1.2s to warpfall
 	wait 4.7
 
 	entity npc = CreateSuperSpectre( TEAM_IMC, spawnEvent.origin, spawnEvent.angles )
@@ -747,6 +748,7 @@ void function spawnSuperSpectre( SmokeEvent smokeEvent, SpawnEvent spawnEvent, F
 void function spawnSuperSpectreWithMinion( SmokeEvent smokeEvent, SpawnEvent spawnEvent, FlowControlEvent flowControlEvent, SoundEvent soundEvent )
 {
 	PingMinimap( spawnEvent.origin.x, spawnEvent.origin.y, 4, 600, 150, 0 )
+	thread Reaper_Spawnpoint( spawnEvent.origin, TEAM_IMC, 6.0 ) // reaper takes ~1.2s to warpfall
 	wait 4.7
 
 	entity npc = CreateSuperSpectre( TEAM_IMC, spawnEvent.origin,spawnEvent.angles )
@@ -761,6 +763,24 @@ void function spawnSuperSpectreWithMinion( SmokeEvent smokeEvent, SpawnEvent spa
 	npc.WaitSignal( "WarpfallComplete" )
 	thread ReaperMinionLauncherThink( npc )
 
+}
+
+// taken from _ai_gamemodes.gnut
+void function Reaper_Spawnpoint( vector origin, int team, float impactTime )
+{
+	vector surfaceNormal = < 0, 0, 1 >
+
+	int index = GetParticleSystemIndex( $"P_ar_titan_droppoint" )
+
+	entity effectEnemy = StartParticleEffectInWorld_ReturnEntity( index, origin, surfaceNormal )
+	effectEnemy.EndSignal( "OnDestroy" )
+	SetTeam( effectEnemy, team )
+	EffectSetControlPointVector( effectEnemy, 1, < 255,99,0 > )
+	effectEnemy.kv.VisibilityFlags = ENTITY_VISIBLE_TO_ENEMY
+	effectEnemy.DisableHibernation() // prevent it from fading out
+
+	wait impactTime
+	EffectStop( effectEnemy )
 }
 
 void function spawnDroppodGrunts( SmokeEvent smokeEvent, SpawnEvent spawnEvent, FlowControlEvent flowControlEvent, SoundEvent soundEvent )

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd_events.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd_events.nut
@@ -777,7 +777,7 @@ void function Reaper_Spawnpoint( vector origin, int team, float impactTime )
 	entity effectEnemy = StartParticleEffectInWorld_ReturnEntity( index, origin, surfaceNormal )
 	effectEnemy.EndSignal( "OnDestroy" )
 	SetTeam( effectEnemy, team )
-	EffectSetControlPointVector( effectEnemy, 1, < 255,99,0 > )
+	EffectSetControlPointVector( effectEnemy, 1, ENEMY_COLOR_FX )
 	effectEnemy.kv.VisibilityFlags = ENTITY_VISIBLE_TO_ENEMY
 	effectEnemy.DisableHibernation() // prevent it from fading out
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd_events.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_fd_events.nut
@@ -729,7 +729,8 @@ void function waitUntilLessThanAmountAliveEventWeighted( SmokeEvent smokeEvent, 
 void function spawnSuperSpectre( SmokeEvent smokeEvent, SpawnEvent spawnEvent, FlowControlEvent flowControlEvent, SoundEvent soundEvent )
 {
 	PingMinimap( spawnEvent.origin.x, spawnEvent.origin.y, 4, 600, 150, 0 )
-	thread Reaper_Spawnpoint( spawnEvent.origin, TEAM_IMC, 6.0 ) // reaper takes ~1.2s to warpfall
+	if ( GetCurrentPlaylistVarInt( "fd_reaper_indicator", 0 ) == 1 )
+		thread Reaper_Spawnpoint( spawnEvent.origin, TEAM_IMC, 6.0 ) // reaper takes ~1.2s to warpfall
 	wait 4.7
 
 	entity npc = CreateSuperSpectre( TEAM_IMC, spawnEvent.origin, spawnEvent.angles )
@@ -748,7 +749,8 @@ void function spawnSuperSpectre( SmokeEvent smokeEvent, SpawnEvent spawnEvent, F
 void function spawnSuperSpectreWithMinion( SmokeEvent smokeEvent, SpawnEvent spawnEvent, FlowControlEvent flowControlEvent, SoundEvent soundEvent )
 {
 	PingMinimap( spawnEvent.origin.x, spawnEvent.origin.y, 4, 600, 150, 0 )
-	thread Reaper_Spawnpoint( spawnEvent.origin, TEAM_IMC, 6.0 ) // reaper takes ~1.2s to warpfall
+	if ( GetCurrentPlaylistVarInt( "fd_reaper_indicator", 0 ) == 1 )
+		thread Reaper_Spawnpoint( spawnEvent.origin, TEAM_IMC, 6.0 ) // reaper takes ~1.2s to warpfall
 	wait 4.7
 
 	entity npc = CreateSuperSpectre( TEAM_IMC, spawnEvent.origin,spawnEvent.angles )


### PR DESCRIPTION
Add a titanfall indicator to mark reaper's spawnpoint, same as AITDM does. Mostly prevents player from being crashed by reapers
3.25 Edited: Due it's not vanilla behavior, it's disabled by default, turned on through the playlistvar `fd_reaper_indicator`