### PR TITLE
Update check-loc-encoding checkout action

### DIFF
--- a/.github/workflows/encoding.yml
+++ b/.github/workflows/encoding.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check localization files encoding
         run: |
           files=$(ls Northstar.Client/mod/resource/northstar_client_localisation_*.txt)


### PR DESCRIPTION
Fixes Node.js 12 deprecation.
