### PR TITLE
Separate Loadout Functions From Respawn Functions in Custom Gamemodes

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_arena.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_arena.gnut
@@ -24,7 +24,7 @@ void function GameModeArena_Init()
 
 	ClassicMP_SetCustomIntro( GameModeArena_BuyPhaseSetup, 30.0 )
 	AddCallback_EntitiesDidLoad( CreateBoostStores )
-	AddCallback_OnPlayerRespawned( SetupArenaLoadoutForPlayer )
+	AddCallback_OnPlayerGetsNewPilotLoadout( SetupArenaLoadoutForPlayer ) // should never set up loadout in respawn function
 }
 
 // intro / buy phase
@@ -165,10 +165,8 @@ void function DamageLeavingPlayers( vector imcOrigin, vector militiaOrigin )
 	}
 }
 
-void function SetupArenaLoadoutForPlayer( entity player )
+void function SetupArenaLoadoutForPlayer( entity player, PilotLoadoutDef playerLoadout )
 {
-	PilotLoadoutDef playerLoadout = clone GetActivePilotLoadout( player )
-
 	if ( GetGameState() == eGameState.Prematch ) // buy phase
 	{
 		playerLoadout.primary = ""

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_chamber.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_chamber.nut
@@ -11,15 +11,9 @@ void function GamemodeChamber_Init()
 	Riff_ForceBoostAvailability( eBoostAvailability.Disabled )
 	ClassicMP_ForceDisableEpilogue( true )
 
-	AddCallback_OnClientConnected( ChamberInitPlayer )
 	AddCallback_OnPlayerKilled( ChamberOnPlayerKilled )
-	AddCallback_OnPlayerRespawned( UpdateLoadout )
-
-}
-
-void function ChamberInitPlayer( entity player )
-{
-	UpdateLoadout( player )
+	//AddCallback_OnPlayerRespawned( UpdateLoadout ) // should never set up loadout in respawn function
+	AddCallback_OnPlayerGetsNewPilotLoadout( OnPlayerGetsNewPilotLoadout )
 }
 
 int function GetChamberWingmanN(){
@@ -71,6 +65,11 @@ void function ChamberOnPlayerKilled( entity victim, entity attacker, var damageI
 		}
 		SetRoundWinningKillReplayAttacker(attacker)
 	}
+}
+
+void function OnPlayerGetsNewPilotLoadout( entity player, PilotLoadoutDef p )
+{
+	UpdateLoadout( player )
 }
 
 void function UpdateLoadout( entity player )

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_gg.gnut
@@ -11,7 +11,8 @@ void function GamemodeGG_Init()
 	Riff_ForceTitanAvailability( eTitanAvailability.Never )
 	Riff_ForceBoostAvailability( eBoostAvailability.Disabled )
 
-	AddCallback_OnPlayerRespawned( OnPlayerRespawned )
+	AddCallback_OnPlayerRespawned( OnPlayerRespawned ) // should never set up loadout in respawn function
+	AddCallback_OnPlayerGetsNewPilotLoadout( OnPlayerGetsNewPilotLoadout )
 	AddCallback_OnPlayerKilled( OnPlayerKilled )
 	AddCallback_OnClientDisconnected( OnPlayerDisconnected )
 
@@ -36,7 +37,7 @@ void function OnPlayerDisconnected(entity player)
 
 void function OnPlayerRespawned( entity player )
 {
-	UpdateLoadout( player )
+	// should never set up loadout in respawn function
 	thread OnPlayerRespawned_Threaded( player )
 }
 
@@ -47,6 +48,11 @@ void function OnPlayerRespawned_Threaded( entity player )
 	WaitFrame()
 	if ( IsValid( player ) )
 		PlayerEarnMeter_SetMode( player, eEarnMeterMode.DISABLED )
+}
+
+void function OnPlayerGetsNewPilotLoadout( entity player, PilotLoadoutDef p )
+{
+	UpdateLoadout( player )
 }
 
 void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_hs.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_hs.gnut
@@ -23,7 +23,8 @@ void function GamemodeHideAndSeek_Init()
 	ClassicMP_SetCustomIntro( GamemodeHideAndSeekIntroSetup, 0.0 )
 	ClassicMP_ForceDisableEpilogue( true )
 	
-	AddCallback_OnPlayerRespawned( SetupHideAndSeekPlayer )
+	AddCallback_OnPlayerRespawned( SetupHideAndSeekPlayer ) // should never set up loadout in respawn function
+	AddCallback_OnPlayerGetsNewPilotLoadout( HideAndSeekPlayerLoadout )
 	AddCallback_OnPlayerKilled( TryNotifyLastPlayerAlive )
 	AddSpawnCallback( "info_intermission", SetIntermissionCam )
 	AddSpawnCallback( "info_spawnpoint_droppod_start", AddDroppodSpawn )
@@ -151,20 +152,11 @@ void function GlobalSeekerIntroThread()
 
 void function SetupHideAndSeekPlayer( entity player )
 {
-	foreach ( entity weapon in player.GetMainWeapons() )
-		player.TakeWeapon( weapon.GetWeaponClassName() )
-	
-	player.TakeWeapon( player.GetOffhandWeapon( OFFHAND_ORDNANCE ).GetWeaponClassName() )
-	
-	player.GiveWeapon( "mp_weapon_rocket_launcher" )
-	player.SetActiveWeaponByName( "mp_weapon_rocket_launcher" )
-
+	// should never set up loadout in respawn function
 	Highlight_SetFriendlyHighlight( player, "sp_friendly_pilot" )
 
 	if ( player.GetTeam() == HIDEANDSEEK_TEAM_HIDER )
 	{
-		player.TakeWeapon( player.GetMeleeWeapon().GetWeaponClassName() )
-	
 		// set visibility flags if we're hiding, so seekers can't see us on intermission cam
 		if ( Time() - file.hidingStartTime < file.hidingTime )
 			player.kv.VisiblityFlags = ENTITY_VISIBLE_TO_FRIENDLY
@@ -173,6 +165,20 @@ void function SetupHideAndSeekPlayer( entity player )
 		Highlight_ClearEnemyHighlight( player )
 		thread PlayHintSoundsForHider( player )
 	}
+}
+
+void function HideAndSeekPlayerLoadout( entity player, PilotLoadoutDef p )
+{
+	foreach ( entity weapon in player.GetMainWeapons() )
+		player.TakeWeapon( weapon.GetWeaponClassName() )
+	
+	player.TakeWeapon( player.GetOffhandWeapon( OFFHAND_ORDNANCE ).GetWeaponClassName() )
+	
+	player.GiveWeapon( "mp_weapon_rocket_launcher" )
+	player.SetActiveWeaponByName( "mp_weapon_rocket_launcher" )
+
+	if ( player.GetTeam() == HIDEANDSEEK_TEAM_HIDER )
+		player.TakeWeapon( player.GetMeleeWeapon().GetWeaponClassName() )
 	else
 		player.TakeWeapon( "mp_weapon_grenade_sonar" ) // seekers should not have pulse blade
 }

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
@@ -19,7 +19,8 @@ void function GamemodeInfection_Init()
 	SetShouldPlayerStartBleedoutFunc( InfectionShouldPlayerStartBleedout )
 	AddCallback_OnClientConnected( InfectionInitPlayer )
 	AddCallback_OnPlayerKilled( InfectionOnPlayerKilled )
-	AddCallback_OnPlayerRespawned( RespawnInfected )
+	AddCallback_OnPlayerRespawned( RespawnInfected ) // should never set up loadout in respawn function
+	AddCallback_OnPlayerGetsNewPilotLoadout( InfectionPlayerLoadout )
 	AddCallback_GameStateEnter( eGameState.Playing, SelectFirstInfected )
 
 	SetTimeoutWinnerDecisionFunc( TimeoutCheckSurvivors )
@@ -49,6 +50,7 @@ void function SelectFirstInfectedDelayed()
 
 	InfectPlayer( infected )
 	RespawnInfected( infected )
+	InfectedLoadout( infected )
 }
 
 void function InfectionOnPlayerKilled( entity victim, entity attacker, var damageInfo )
@@ -102,6 +104,23 @@ void function RespawnInfected( entity player )
 		file.playersToNotifyOfInfection.remove( file.playersToNotifyOfInfection.find( player ) )
 	}
 
+	// should never set up loadout in respawn function
+	// stats for infected
+	StimPlayer( player, 9999.9 ) // can't do endless since we don't get the visual effect in endless
+
+	thread PlayInfectedSounds( player )
+}
+
+void function InfectionPlayerLoadout( entity player, PilotLoadoutDef p )
+{
+	InfectedLoadout( player )
+}
+
+void function InfectedLoadout( entity player )
+{
+	if ( player.GetTeam() != INFECTION_TEAM_INFECTED )
+		return
+
 	// set camo to pond scum
 	player.SetSkin( 1 )
 	player.SetCamo( 110 )
@@ -109,10 +128,7 @@ void function RespawnInfected( entity player )
 	// if human, remove helmet bodygroup, human models have some weird bloody white thing underneath their helmet that works well for this, imo
 	if ( !player.IsMechanical() )
 		player.SetBodygroup( player.FindBodyGroup( "head" ), 1 )
-
-	// stats for infected
-	StimPlayer( player, 9999.9 ) // can't do endless since we don't get the visual effect in endless
-
+	
 	// scale health with num of infected, with 50 as base health
 	player.SetMaxHealth( ( GetPlayerArrayOfTeam( INFECTION_TEAM_SURVIVOR ).len() + 1 ) * 10 )
 
@@ -122,7 +138,7 @@ void function RespawnInfected( entity player )
 
 	foreach ( entity weapon in player.GetOffhandWeapons() )
 		player.TakeWeaponNow( weapon.GetWeaponClassName() )
-
+	
 	// TEMP: give archer so player so player has a weapon which lets them use offhands
 	// need to replace this with a custom empty weapon at some point
 	//player.GiveWeapon( "mp_weapon_rocket_launcher" )
@@ -130,7 +146,6 @@ void function RespawnInfected( entity player )
 	player.GiveOffhandWeapon( "melee_pilot_emptyhanded", OFFHAND_MELEE )
 
 	thread GiveAirAccel(player)
-	thread PlayInfectedSounds( player )
 }
 
 void function GiveAirAccel(entity player)

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
@@ -138,7 +138,6 @@ void function InfectedLoadout( entity player )
 
 	foreach ( entity weapon in player.GetOffhandWeapons() )
 		player.TakeWeaponNow( weapon.GetWeaponClassName() )
-	
 	// TEMP: give archer so player so player has a weapon which lets them use offhands
 	// need to replace this with a custom empty weapon at some point
 	//player.GiveWeapon( "mp_weapon_rocket_launcher" )

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
@@ -138,7 +138,7 @@ void function InfectedLoadout( entity player )
 
 	foreach ( entity weapon in player.GetOffhandWeapons() )
 		player.TakeWeaponNow( weapon.GetWeaponClassName() )
-		
+
 	// TEMP: give archer so player so player has a weapon which lets them use offhands
 	// need to replace this with a custom empty weapon at some point
 	//player.GiveWeapon( "mp_weapon_rocket_launcher" )

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
@@ -138,6 +138,7 @@ void function InfectedLoadout( entity player )
 
 	foreach ( entity weapon in player.GetOffhandWeapons() )
 		player.TakeWeaponNow( weapon.GetWeaponClassName() )
+		
 	// TEMP: give archer so player so player has a weapon which lets them use offhands
 	// need to replace this with a custom empty weapon at some point
 	//player.GiveWeapon( "mp_weapon_rocket_launcher" )

--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_sns.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_sns.gnut
@@ -26,7 +26,8 @@ void function SNS_Init()
 	Riff_ForceBoostAvailability( eBoostAvailability.Disabled )
 
 	AddCallback_OnPlayerKilled( OnPlayerKilled )
-	AddCallback_OnPlayerRespawned( OnPlayerRespawned )
+	AddCallback_OnPlayerRespawned( OnPlayerRespawned ) // should never set up loadout in respawn function
+	AddCallback_OnPlayerGetsNewPilotLoadout( OnPlayerGetsNewPilotLoadout )
 	AddCallback_OnClientDisconnected(OnPlayerDisconnected)
 	AddCallback_GameStateEnter( eGameState.WinnerDetermined, OnWinnerDetermined )
 
@@ -128,6 +129,24 @@ void function OnWinnerDetermined()
 
 void function OnPlayerRespawned( entity player )
 {
+	// should never set up loadout in respawn function
+	if (player == GetWinningPlayer())
+		SetHighlight( player )
+
+	thread OnPlayerRespawned_Threaded( player )
+}
+
+void function OnPlayerRespawned_Threaded( entity player )
+{
+	// bit of a hack, need to rework earnmeter code to have better support for completely disabling it
+	// rn though this just waits for earnmeter code to set the mode before we set it back
+	WaitFrame()
+	if ( IsValid( player ) )
+		PlayerEarnMeter_SetMode( player, eEarnMeterMode.DISABLED )
+}
+
+void function OnPlayerGetsNewPilotLoadout( entity player, PilotLoadoutDef p )
+{
 	foreach ( entity weapon in player.GetMainWeapons() )
 		player.TakeWeaponNow( weapon.GetWeaponClassName() )
 	
@@ -143,20 +162,6 @@ void function OnPlayerRespawned( entity player )
 	player.GiveOffhandWeapon( "melee_pilot_emptyhanded", OFFHAND_MELEE )
 	player.GiveOffhandWeapon( file.offhand_weapon, OFFHAND_RIGHT )
 	player.GiveOffhandWeapon( "mp_weapon_grenade_sonar", OFFHAND_LEFT )
-
-	if (player == GetWinningPlayer())
-		SetHighlight( player )
-
-	thread OnPlayerRespawned_Threaded( player )
-}
-
-void function OnPlayerRespawned_Threaded( entity player )
-{
-	// bit of a hack, need to rework earnmeter code to have better support for completely disabling it
-	// rn though this just waits for earnmeter code to set the mode before we set it back
-	WaitFrame()
-	if ( IsValid( player ) )
-		PlayerEarnMeter_SetMode( player, eEarnMeterMode.DISABLED )
 }
 
 entity function GetWinningPlayer() 


### PR DESCRIPTION
Required by https://github.com/R2Northstar/NorthstarMods/pull/567
Separent custom loadout functions from respawn fucntion, so fixed grace period won't mess up their loadout