### PR TITLE
Rework Scorelimit Checks

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -250,6 +250,7 @@ void function GameStateEnter_Playing_Threaded()
 		else // scoring check
 		{
 			int winningTeam = GetWinningTeamWithFFASupport()
+			int scoreLimit
 			if ( IsRoundBased() )
 				scoreLimit = GameMode_GetRoundScoreLimit( GAMETYPE )
 			else


### PR DESCRIPTION
- Move winner checks in `AddTeamScore()` to `GameStateEnter_Playing_Threaded()`
- Fix `AddTeamScore()`, so team score won't go over limit

Changing this is because if we `SetWinner()` right after changing team score and some network variable, the gamestate will stuck( eg.  in bounty hunt, depositing bonus to win will stuck )
