### PR TITLE
Fix attrition freezing and killing servers sometimes

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_aitdm.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_aitdm.nut
@@ -460,7 +460,18 @@ void function SquadHandler( array<entity> guys )
 		// Get point and send our whole squad to it
 		points = GetNPCArrayOfEnemies( team )
 		if ( points.len() == 0 ) // can't find any points here
+		{
+			// Have to wait some amount of time before continuing
+			// because if we don't the server will continue checking this
+			// forever, aren't loops fun?
+			// This definitely didn't waste ~8 hours of my time reverting various
+			// launcher PRs before finding this mods PR that caused servers to
+			// freeze forever before having their process killed by the dedi watchdog
+			// without any logging. If anyone reads this, PLEASE add logging to your scripts
+			// for when weird edge cases happen, it can literally only help debugging. -Spoon
+			WaitFrame()
 			continue
+		}
 			
 		point = points[ RandomInt( points.len() ) ].GetOrigin()
 		


### PR DESCRIPTION
More specifically, it happened when all enemy NPCs were dead and an NPC squad tried to find somewhere to attack. They wouldn't find any valid places to attack, so naturally you just `continue` in the loop and try again next time... except you forgot to wait any amount of time before trying again, so it's just going to try again in that same frame, forever.

Regression caused by #626 and rly should've been caught in testing or code review tbh

Closes https://github.com/R2Northstar/Northstar/issues/483