### PR TITLE
Changed TriggerConnectToServerCallbacks to take in an optional server for which the callback was triggered

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -1274,10 +1274,16 @@ void function RemoveConnectToServerCallback( void functionref( ServerInfo ) call
 	file.connectCallbacks.fastremovebyvalue( callback )
 }
 
-void function TriggerConnectToServerCallbacks()
+void function TriggerConnectToServerCallbacks( ServerInfo ornull targetServer = null )
 {
+	ServerInfo server;
+	if (targetServer == null)
+	{
+		targetServer = file.lastSelectedServer
+	}
+
 	foreach( callback in file.connectCallbacks )
 	{
-		callback( file.lastSelectedServer )
+		callback( expect ServerInfo( targetServer ) )
 	}
 }


### PR DESCRIPTION
Changed `TriggerConnectToServerCallbacks` to take in an optional server for which the callback was triggered.
This should not break any existing behavior and fix an issue with my autoJoin mod.
Before this change the function just assumes the server it's connecting to is the server currently selected in the server browser.
Now the server that is sent to the callbacks is the server given in the function's new argument, unless that argument isn't provided. If it isn't provided, it will default to the server currently selected in the server browser.