### PR TITLE
Fix a crash with IsPetTitan

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_utility_shared.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_utility_shared.nut
@@ -1601,6 +1601,9 @@ float function GetPulseFrac( rate = 1, startTime = 0 )
 bool function IsPetTitan( titan )
 {
 	Assert( titan.IsTitan() )
+	
+	if ( !titan.GetTitanSoul() )
+		return false
 
 	return titan.GetTitanSoul().GetBossPlayer()	!= null
 }


### PR DESCRIPTION
if `titan.GetTitanSoul()` returned null (non-pet NPC titan for example) this function would crash when it really shouldn't.