### PR TITLE
Fix integer functionality for modsettings

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_mod_settings.nut
@@ -949,6 +949,7 @@ void function SendTextPanelChanges( var textPanel )
 					ThrowInvalidValue( "This setting is an integer, and only accepts whole numbers." )
 					Hud_SetText( textPanel, GetConVarString( c.conVar ) )
 				}
+				break
 			case "bool":
 				if ( newSetting != "0" && newSetting != "1" )
 				{


### PR DESCRIPTION
This has been a longstanding and somehow unnoticed issue with modsettings, where a missing `break` statement caused all integer inputs to be registered as booleans and would not accept any values other than `0` or `1`.