### PR TITLE
Bump mods version to `1.19.0`

### DIFF
--- a/Northstar.Client/mod.json
+++ b/Northstar.Client/mod.json
@@ -1,7 +1,7 @@
 {
 	"Name": "Northstar.Client",
 	"Description": "Various ui and client changes to fix bugs and add better support for mods",
-	"Version": "1.16.0",
+	"Version": "1.19.0",
 	"LoadPriority": 0,
 	"InitScript": "cl_northstar_client_init.nut",
 	"ConVars": [

--- a/Northstar.Custom/mod.json
+++ b/Northstar.Custom/mod.json
@@ -1,7 +1,7 @@
 {
 	"Name": "Northstar.Custom",
 	"Description": "Custom content for Northstar: extra weapons, gamemodes, etc.",
-	"Version": "1.16.0",
+	"Version": "1.19.0",
 	"LoadPriority": 1,
 	"RequiredOnClient": true,
 	"ConVars": [

--- a/Northstar.CustomServers/mod.json
+++ b/Northstar.CustomServers/mod.json
@@ -1,7 +1,7 @@
 {
 	"Name": "Northstar.CustomServers",
 	"Description": "Attempts to recreate the behaviour of vanilla Titanfall 2 servers, as well as changing some scripts to allow better support for mods",
-	"Version": "1.16.0",
+	"Version": "1.19.0",
 	"LoadPriority": 0,
 	"ConVars": [
 		{


### PR DESCRIPTION
Bumps the version number in `mod.json` files to `1.19.0`.

(yes we should just add a special case for `dev` or `0.0.0` in launcher, if you complain, you are now obligated to do it :>)