### PR TITLE
Make dropships immune to titan step damage

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
@@ -628,6 +628,10 @@ void function SetRecalculateRespawnAsTitanStartPointCallback( entity functionref
 
 bool function ShouldEntTakeDamage_SPMP( entity ent, var damageInfo )
 {
+	// dropships are immune to being crushed
+	if ( ( IsDropship( ent ) || IsEvacDropship( ent ) ) && DamageInfo_GetCustomDamageType( damageInfo ) & DF_TITAN_STEP )
+		return false
+
 	return true
 }
 


### PR DESCRIPTION
closes #364

Currently dropships take damage from titans stepping on them, this prevents that