### PR TITLE
Use string convar flags

### DIFF
--- a/Northstar.Client/mod.json
+++ b/Northstar.Client/mod.json
@@ -36,12 +36,12 @@
 		{
 			"Name": "modlist_show_convars",
 			"DefaultValue": "0",
-			"Flags": 16777216
+			"Flags": "ARCHIVE_PLAYERPROFILE"
 		},
 		{
 			"Name": "modlist_reverse",
 			"DefaultValue": "0",
-			"Flags": 16777216
+			"Flags": "ARCHIVE_PLAYERPROFILE"
 		}
 	],
 	"Scripts": [

--- a/Northstar.CustomServers/mod.json
+++ b/Northstar.CustomServers/mod.json
@@ -20,7 +20,7 @@
 		{
 			"Name": "ns_allow_spectators",
 			"DefaultValue": "0",
-			"Flags": 8192
+			"Flags": "REPLICATED"
 		},
 		{
 			"Name": "ns_private_match_last_mode",


### PR DESCRIPTION
Uses string names for convars (been supported since refactor but not yet used) rather than magic numbers

Spliced out from #530

I did NOT test this as I do not have access to a setup that is able to run Titanfall2 right now. That being said. The changes were taken from #530 which was confirmed working in testing.