### PR TITLE
Award titan assist stats based on titan soul damage history

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
@@ -571,9 +571,11 @@ void function HandleKillStats( entity victim, entity attacker, var damageInfo )
 	// assistsTotal ( weapon_kill_stats )
 	// note: eww
 	table<int, bool> alreadyAssisted
-	foreach( DamageHistoryStruct attackerInfo in victim.e.recentDamageHistory )
+	// titans store their recentDamageHistory in the soul
+	entity assistVictim = ( victim.IsTitan() && IsValid( victim.GetTitanSoul() ) ) ? victim.GetTitanSoul() : victim 
+	foreach( DamageHistoryStruct attackerInfo in assistVictim.e.recentDamageHistory )
 	{
-		if ( !IsValid( attackerInfo.attacker ) || !attackerInfo.attacker.IsPlayer() || attackerInfo.attacker == victim )
+		if ( !IsValid( attackerInfo.attacker ) || !attackerInfo.attacker.IsPlayer() || attackerInfo.attacker == assistVictim )
 			continue
 
 		bool exists = attackerInfo.attacker.GetEncodedEHandle() in alreadyAssisted ? true : false


### PR DESCRIPTION
Change split from #744

> Titans stores damage history in their Soul component, not the NPC itself, probably due to how game handles pilot/auto-titan interaction with the Titan entities.

This means that we weren't awarding assist stats properly for titan assists