### PR TITLE
Stop logging invalid map/mode exception in progression

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
@@ -264,7 +264,7 @@ void function Stats_IncrementStat( entity player, string statCategory, string st
 		// persistence string, we can't save the persistence so we have to just return
 		if ( str != saveVar )
 		{
-			printt( ex )
+			//printt( ex, str, GetMapName(), mode ) // commented because people don't like it when i print errors to the console
 			return
 		}
 	}

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
@@ -264,7 +264,7 @@ void function Stats_IncrementStat( entity player, string statCategory, string st
 		// persistence string, we can't save the persistence so we have to just return
 		if ( str != saveVar )
 		{
-			//printt( ex, str, GetMapName(), mode ) // commented because people don't like it when i print errors to the console
+			//printt( ex, str, GetMapName(), mode ) // Commented out due to spamming logs on invalid modes (e.g. Gun Game, Infection, ...)
 			return
 		}
 	}


### PR DESCRIPTION
Some game modes like Gun Game or Infection are not considered valid yet, causing the warning message to be spammed in the logs.

Necessary work should be done to add the modes to the list of valid modes. Until we will just comment out the print statement in order to prevent log spam.

closes #749 

no, this doesn't need code review, nor does it need testing. its literally commenting out a print statement