### PR TITLE
Don't mark items as new if progression is disabled

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_items.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_items.nut
@@ -10231,6 +10231,10 @@ void function StatUnlock_Unlocked( entity player, string itemRef, string parentR
 	if ( IsItemNew( player, itemRef, parentRef ) )
 		return
 
+	// early out if the player has progression disabled
+	if ( !ProgressionEnabledForPlayer( player ) )
+		return
+
 	int refGuid = file.itemRefToGuid[itemRef]
 	int parentRefGuid = parentRef == "" ? 0 : file.itemRefToGuid[parentRef]
 


### PR DESCRIPTION
closes #741 

also doesn't show the challenge completion notifications in game as a nice side effect

To test disable progression and then "unlock" something (complete a weapon challenge or something)