### PR TITLE
Quickfix in wrong attacker receiving progression stat updates

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
@@ -587,7 +587,7 @@ void function HandleKillStats( entity victim, entity attacker, var damageInfo )
 			string source = DamageSourceIDToString( attackerInfo.damageSourceId )
 
 			if ( IsValidStatItemString( source ) )
-				Stats_IncrementStat( attacker, "weapon_kill_stats", "assistsTotal", source, 1.0 )
+				Stats_IncrementStat( attackerInfo.attacker, "weapon_kill_stats", "assistsTotal", source, 1.0 )
 		}
 	}
 


### PR DESCRIPTION
Currently when assisting players with Titan kills the Assist Stat Tracking is still tracking to attacker, this took me a while to notice only because recently I resetted my whole persistent data to ensure everything is tracking properly for progression, and this popped in.