### PR TITLE
Fix Final Death Not Showing in Live Fire/Fastball/other round based modes

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
@@ -342,7 +342,7 @@ void function PostDeathThread_MP( entity player, var damageInfo ) // based on ga
 	else
 		player.SetObserverTarget( null )
 	
-	if ( ( GamePlayingOrSuddenDeath() || GetGameState() == eGameState.Epilogue ) && !file.playerDeathsHidden )
+	if ( ( GamePlayingOrSuddenDeath() || GetGameState() == eGameState.Epilogue || GetGameState() == eGameState.WinnerDetermined ) && !file.playerDeathsHidden )
 		player.AddToPlayerGameStat( PGS_DEATHS, 1 )
 	
 	if ( !file.playerDeathsHidden )


### PR DESCRIPTION
<!-- 
WHEN OPENING A PULL REQUEST KEEP IN MIND:
-> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
-> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)

-> For fixes, description on how to reproduce the bug are appreciated and help your PR get merged faster
-> For features, description on how to use or a sample mod that makes use of the feature is appreciated and will help your PR get merged faster

-> Please use a sensible title for your pull request

-> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).

-> If you made multiple independent changes, please make a new PR for each one. This prevents your PR being blocked from merging by one of the changes you made.

Note that commit messages in PRs will generally be squashed to keep commit history clean.
-->

The regression was introduced in #72 and applied to all round-based gamemodes
Fixes the "Whatever fixed end of round survivors still receiving a death on the scoreboard when round ends, also introduced a bug where the last player killed doesn't receive a death either now." issue made by @GeckoEidechse in #132

Tested in Live Fire and Fastball, also tested in Attrition to make sure it didn't break anything else.
Clearing entities on round end or game end still does not add deaths to scoreboard and everything functions as intended.