### PR TITLE
Add translation status indicator badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ Issues in this repository should be created if they are related to these domains
 - `Northstar.Coop` - Soon™.
 - `Northstar.Custom` - Northstar custom content.
 - `Northstar.CustomServer` - Server config files and scripts necessary for multiplayer.
+
+### Translating
+
+Translations can be submitted via [weblate](https://translate.harmony.tf/projects/northstar/client/).
+
+<a href="https://translate.harmony.tf/engage/northstar/">
+<img src="https://translate.harmony.tf/widgets/northstar/-/client/multi-auto.svg" alt="Translation status" />
+</a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # NorthstarMods
+<a href="https://translate.harmony.tf/engage/northstar/">
+<img src="https://translate.harmony.tf/widgets/northstar/-/client/svg-badge.svg" alt="Translation status" />
+</a>
 
 [Squirrel](http://www.squirrel-lang.org/squirreldoc/reference/index.html) scripts used to recreate server-side gamelogic and add [custom content](https://r2northstar.gitbook.io/r2northstar-wiki/using-northstar/gamemodes) to the game. 
 


### PR DESCRIPTION
Adds badge showing current translation status.

Change is only in README so no testing should be necessary (unless with testing you mean looking at rich diff and verifying that it renders, lol)

Rendered:

![image](https://github.com/R2Northstar/NorthstarMods/assets/40122905/3cf241fb-33b1-4f0c-b031-068eb43085f3)

~~Sorta closes https://github.com/R2Northstar/Northstar/issues/343~~