### PR TITLE
Fix crash when calling for invalid loadout index

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_loadouts_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_loadouts_mp.gnut
@@ -195,7 +195,7 @@ bool function ClientCommandCallback_SwapSecondaryAndWeapon3PersistentLoadoutData
 	int index = args[0].tointeger()
 	
 	if ( !IsValidPilotLoadoutIndex(index) )
-		index = 0
+		return false
 
 	PilotLoadoutDef loadout = GetPilotLoadoutFromPersistentData( player, index )
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/_loadouts_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_loadouts_mp.gnut
@@ -193,6 +193,10 @@ bool function ClientCommandCallback_SwapSecondaryAndWeapon3PersistentLoadoutData
 	
 	// get loadout
 	int index = args[0].tointeger()
+	
+	if ( !IsValidPilotLoadoutIndex(index) )
+		index = 0
+
 	PilotLoadoutDef loadout = GetPilotLoadoutFromPersistentData( player, index )
 
 	// swap loadouts


### PR DESCRIPTION
<!-- 
WHEN OPENING A PULL REQUEST KEEP IN MIND:
-> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
-> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)

-> For fixes, description on how to reproduce the bug are appreciated and help your PR get merged faster
-> For features, description on how to use or a sample mod that makes use of the feature is appreciated and will help your PR get merged faster

-> Please use a sensible title for your pull request

-> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).

-> If you made multiple independent changes, please make a new PR for each one. This prevents your PR being blocked from merging by one of the changes you made.

Note that commit messages in PRs will generally be squashed to keep commit history clean.
-->

Requesting for invalid loadout index using `SwapSecondaryAndWeapon3PersistentLoadoutData` will cause a crash. This PR just adds a check to reset the loadout index.
