### PR TITLE
Add validity check to `HandleDistanceAndTimeStats_Threaded`, to prevent crash

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
@@ -931,44 +931,47 @@ void function HandleDistanceAndTimeStats_Threaded()
 		// track distance stats
 		foreach ( entity player in GetPlayerArray() )
 		{
-			if ( player.p.lastPosForDistanceStatValid )
+			if ( IsValid(player) )
 			{
-				// not 100% sure on using Distance2D over Distance tbh
-				float distInches = Distance2D( player.p.lastPosForDistanceStat, player.GetOrigin() )
-				float distMiles = distInches / 63360.0
-
-				// more generic distance stats
-				Stats_IncrementStat( player, "distance_stats", "total", "", distMiles )
-				if ( player.IsTitan() )
+				if ( player.p.lastPosForDistanceStatValid )
 				{
-					Stats_IncrementStat( player, "distance_stats", "asTitan_" + GetTitanCharacterName( player ), "", distMiles )
-					Stats_IncrementStat( player, "distance_stats", "asTitan", "", distMiles )
-				}
-				else
-					Stats_IncrementStat( player, "distance_stats", "asPilot", "", distMiles )
+					// not 100% sure on using Distance2D over Distance tbh
+					float distInches = Distance2D( player.p.lastPosForDistanceStat, player.GetOrigin() )
+					float distMiles = distInches / 63360.0
 
-
-				string state = ""
-				// specific distance stats
-				if ( player.IsWallRunning() )
-					state = "wallrunning"
-				else if ( PlayerIsRodeoingTitan( player ) )
-				{
-					if ( player.GetTitanSoulBeingRodeoed().GetTeam() == player.GetTeam() )
-						state = "onFriendlyTitan"
+					// more generic distance stats
+					Stats_IncrementStat( player, "distance_stats", "total", "", distMiles )
+					if ( player.IsTitan() )
+					{
+						Stats_IncrementStat( player, "distance_stats", "asTitan_" + GetTitanCharacterName( player ), "", distMiles )
+						Stats_IncrementStat( player, "distance_stats", "asTitan", "", distMiles )
+					}
 					else
-						state = "onEnemyTitan"
+						Stats_IncrementStat( player, "distance_stats", "asPilot", "", distMiles )
+
+
+					string state = ""
+					// specific distance stats
+					if ( player.IsWallRunning() )
+						state = "wallrunning"
+					else if ( PlayerIsRodeoingTitan( player ) )
+					{
+						if ( player.GetTitanSoulBeingRodeoed().GetTeam() == player.GetTeam() )
+							state = "onFriendlyTitan"
+						else
+							state = "onEnemyTitan"
+					}
+					else if ( player.IsZiplining() )
+						state = "ziplining"
+					else if ( !player.IsOnGround() )
+						state = "inAir"
+
+					if ( state != "" )
+						Stats_IncrementStat( player, "distance_stats", state, "", distMiles )
 				}
-				else if ( player.IsZiplining() )
-					state = "ziplining"
-				else if ( !player.IsOnGround() )
-					state = "inAir"
 
-				if ( state != "" )
-					Stats_IncrementStat( player, "distance_stats", state, "", distMiles )
+				player.p.lastPosForDistanceStat = player.GetOrigin()
 			}
-
-			player.p.lastPosForDistanceStat = player.GetOrigin()
 		}
 
 		float timeSeconds = Time() - lastTickTime

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
@@ -931,47 +931,47 @@ void function HandleDistanceAndTimeStats_Threaded()
 		// track distance stats
 		foreach ( entity player in GetPlayerArray() )
 		{
-			if ( IsValid(player) )
+			if ( !IsValid( player ) )
+				continue
+				
+			if ( player.p.lastPosForDistanceStatValid )
 			{
-				if ( player.p.lastPosForDistanceStatValid )
+				// not 100% sure on using Distance2D over Distance tbh
+				float distInches = Distance2D( player.p.lastPosForDistanceStat, player.GetOrigin() )
+				float distMiles = distInches / 63360.0
+
+				// more generic distance stats
+				Stats_IncrementStat( player, "distance_stats", "total", "", distMiles )
+				if ( player.IsTitan() )
 				{
-					// not 100% sure on using Distance2D over Distance tbh
-					float distInches = Distance2D( player.p.lastPosForDistanceStat, player.GetOrigin() )
-					float distMiles = distInches / 63360.0
-
-					// more generic distance stats
-					Stats_IncrementStat( player, "distance_stats", "total", "", distMiles )
-					if ( player.IsTitan() )
-					{
-						Stats_IncrementStat( player, "distance_stats", "asTitan_" + GetTitanCharacterName( player ), "", distMiles )
-						Stats_IncrementStat( player, "distance_stats", "asTitan", "", distMiles )
-					}
-					else
-						Stats_IncrementStat( player, "distance_stats", "asPilot", "", distMiles )
-
-
-					string state = ""
-					// specific distance stats
-					if ( player.IsWallRunning() )
-						state = "wallrunning"
-					else if ( PlayerIsRodeoingTitan( player ) )
-					{
-						if ( player.GetTitanSoulBeingRodeoed().GetTeam() == player.GetTeam() )
-							state = "onFriendlyTitan"
-						else
-							state = "onEnemyTitan"
-					}
-					else if ( player.IsZiplining() )
-						state = "ziplining"
-					else if ( !player.IsOnGround() )
-						state = "inAir"
-
-					if ( state != "" )
-						Stats_IncrementStat( player, "distance_stats", state, "", distMiles )
+					Stats_IncrementStat( player, "distance_stats", "asTitan_" + GetTitanCharacterName( player ), "", distMiles )
+					Stats_IncrementStat( player, "distance_stats", "asTitan", "", distMiles )
 				}
+				else
+					Stats_IncrementStat( player, "distance_stats", "asPilot", "", distMiles )
 
-				player.p.lastPosForDistanceStat = player.GetOrigin()
+
+				string state = ""
+				// specific distance stats
+				if ( player.IsWallRunning() )
+					state = "wallrunning"
+				else if ( PlayerIsRodeoingTitan( player ) )
+				{
+					if ( player.GetTitanSoulBeingRodeoed().GetTeam() == player.GetTeam() )
+						state = "onFriendlyTitan"
+					else
+						state = "onEnemyTitan"
+				}
+				else if ( player.IsZiplining() )
+					state = "ziplining"
+				else if ( !player.IsOnGround() )
+					state = "inAir"
+
+				if ( state != "" )
+					Stats_IncrementStat( player, "distance_stats", state, "", distMiles )
 			}
+
+			player.p.lastPosForDistanceStat = player.GetOrigin()
 		}
 
 		float timeSeconds = Time() - lastTickTime


### PR DESCRIPTION
Simply adds an `IsValid` check into the `foreach player` loop in `HandleDistanceAndTimeStats_Threaded`.

My servers have been crashing on line `941` of the file as described in #766

Currently testing this fix as a mod, and normally this crash would happen within a couple hours no matter what. One server instance is going on seven hours of matches with no crashes as of yet, but more time would be good. Will report back.