### PR TITLE
Add validity check to `SaveStatsPeriodically_Threaded`

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
@@ -1035,9 +1035,11 @@ void function SaveStatsPeriodically_Threaded()
 	while( true )
 	{
 		foreach( entity player in GetPlayerArray() )
+		{
 			if ( !IsValid( player ) )
 				continue
 			Stats_SaveAllStats( player )
+		}
 		wait 5
 	}
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
@@ -1036,9 +1036,8 @@ void function SaveStatsPeriodically_Threaded()
 	{
 		foreach( entity player in GetPlayerArray() )
 		{
-			if ( !IsValid( player ) )
-				continue
-			Stats_SaveAllStats( player )
+			if ( IsValid( player ) )
+				Stats_SaveAllStats( player )
 		}
 		wait 5
 	}

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
@@ -1035,6 +1035,8 @@ void function SaveStatsPeriodically_Threaded()
 	while( true )
 	{
 		foreach( entity player in GetPlayerArray() )
+			if ( !IsValid( player ) )
+				continue
 			Stats_SaveAllStats( player )
 		wait 5
 	}


### PR DESCRIPTION
Simply adds an `IsValid` check into the `foreach` player loop in `SaveStatsPeriodically_Threaded`.

In short, this is causing crashes for the same reason as #767, but far more rarely, as this loop only executes every five seconds, and a player must disconnect at the exact same time it runs. Still, I've had it happen.

```
[19:55:53] [NORTHSTAR] [info] Player player disconnected: "You were disconnected due to being AFK"
[19:55:53] [NORTHSTAR] [info] Player player disconnected: "You were disconnected due to being AFK"
[19:55:53] [NORTHSTAR] [warn] attempted to write pdata of size 0!
[19:55:53] [SCRIPT SV] [info] SCRIPT ERROR: [SERVER] Persistent data not available.
[19:55:53] [SCRIPT SV] [info]  -> player.SetPersistentVar( key, expect float( player.GetPersistentVar( key ) ) + val )
[19:55:53] [SCRIPT SV] [info]
CALLSTACK
*FUNCTION [Stats_SaveAllStats()] mp/_stats.nut line [93]
*FUNCTION [SaveStatsPeriodically_Threaded()] mp/_stats.nut line [1041]

[19:55:53] [SCRIPT SV] [info] LOCALS
[@ITERATOR@] 5
[val] 8.3329941844568e-005
[key] "timeStats.dead"
[player] ENTITY (player player [9] (player "player" at <-4847.97 -975.969 328.046>))
[this] TABLE
[@ITERATOR@] 9
[player] ENTITY (player player [9] (player "player" at <-4847.97 -975.969 328.046>))
[@INDEX@] 8
[this] TABLE

DIAGPRINTS


abnormal program termination
```

It may be prudent to look into modifying `GetPlayerArray` rather than adding these fixes... Though for now I've modded these two in on my servers, and it has drastically reduced crashes.
