### PR TITLE
Treat `.gnut` files as `.nut` for syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 /Northstar.Client/mod/resource/northstar_client_localisation_*.txt text diff working-tree-encoding=UTF-16LE-BOM
+
+# Highlight `.gnut` like `.nut` files
+*.gnut linguist-language=Squirrel


### PR DESCRIPTION
Their syntax is functionally the same anyway

No testing needed as this only modifies `.gitattributes` which has nothing to do with the game.