### PR TITLE
Fix restricting Aegis Rank reset functionality to MP

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
@@ -1556,7 +1556,6 @@ void function RecalculateHighestTitanFDLevel( entity player )
 	player.SetPersistentVar( "fdStats.highestTitanFDLevel", highestAegis )
 }
 
-#if MP
 string function GetTitanRefForLoadoutIndex( entity player, int loadoutIndex )
 {
 	TitanLoadoutDef loadout = GetTitanLoadoutFromPersistentData( player, loadoutIndex )

--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
@@ -1542,6 +1542,7 @@ array<string> function GetAvailableTitanRefs( entity player )
 
 /// Gets the highest Titan FD level and stores it in the corresponding persistent var.
 /// * `player` - The player entity to perform the action on
+#if MP
 void function RecalculateHighestTitanFDLevel( entity player )
 {
 	int enumCount = PersistenceGetEnumCount( "titanClasses" )


### PR DESCRIPTION
I actually forgot to move up the MP check to prevent the Aegis Rank Reset function to be restricted to MP only, trying to play the campaign without that restriction doesn't let the game load the maps.