### PR TITLE
Use `getrandom()` instead of random int from player array

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/gamemodes/_gamemode_inf.gnut
@@ -54,7 +54,7 @@ void function SelectFirstInfectedDelayed()
 		return
 	}
 
-	entity infected = players[ RandomInt( players.len() ) ]
+	entity infected = players.getrandom()
 
 	InfectPlayer( infected )
 	RespawnInfected( infected )


### PR DESCRIPTION
Use `getrandom()` instead of random int from player array to select infected

