### PR TITLE
Add Client Side Callback Hooks

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/client/cl_obituary.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_obituary.gnut
@@ -1,0 +1,618 @@
+untyped
+
+global function ClObituary_Init
+
+global function Obituary_Print
+global function Obituary_Print_Generic
+global function Obituary
+global function Obituary_GetEntityInfo
+global function Obituary_Print_Localized
+global function Obituary_SetEnabled
+global function Obituary_SetIndexOffset
+
+global function ServerCallback_SquadLeaderBonus
+global function ServerCallback_SquadLeaderDoubleXP
+
+// S2.ClientKillCallback
+global function AddCallback_OnPlayerKilled
+global function AddCallback_OnEntityKilled
+
+global struct ObituaryCallbackParams
+{
+	entity victim
+	entity attacker
+	int damageSourceId
+	int scriptDamageType
+	bool victimIsOwnedTitan
+}
+/////////////////
+
+const NUM_OBITUARY_LINES = 4		// cant change arbitrarily, need to have matching entries in the .res file
+const obituaryTextBoxWidth = 500
+const obituaryTextBoxHeight = 20
+const defaultCharacterWidth = 5
+
+struct ObituaryData
+{
+	float startTime
+	var	rui
+}
+
+
+struct
+{
+	array<ObituaryData>		obituaryQueue = []
+	bool obituariesEnabled = true
+	int indexOffest = 0
+
+	// NS - Taken from https://github.com/S2ymi/R2NS-ClientKillCallback
+	// The difference between entity and player callbacks is just wether or not it triggers on any entity death or only on actual player deaths
+	// Generally speaking, you'll mostly want to use AddCallback_OnPlayerKilled to prevent unnecessary function calls
+	array< void functionref( ObituaryCallbackParams ) > onPlayerKilledClientCallbacks
+	array< void functionref( ObituaryCallbackParams ) > onEntityKilledClientCallbacks
+	/////////////////
+} file
+
+struct ObitEntityInfo
+{
+	string displayName = ""
+	vector displayColor = OBITUARY_COLOR_WEAPON
+	string petDisplayName = ""
+}
+
+global struct ObitStringData
+{
+	string attackerName = ""
+	string attackerPetName = ""
+	string victimName = ""
+	string victimPetName = ""
+	string weaponLocalizedName = ""
+	string attackerLocalizedString = "#OBIT_PLAYER_STRING"
+	string victimLocalizedString = "#OBIT_PLAYER_STRING"
+	string weaponLocalizedString = "#OBIT_BRACKETED_STRING"
+}
+
+// NS - Taken from https://github.com/S2ymi/R2NS-ClientKillCallback
+void function AddCallback_OnPlayerKilled( void functionref( ObituaryCallbackParams ) callback )
+{
+	Assert( !file.onPlayerKilledClientCallbacks.contains( callback ), "Already added " + string( callbackFunc ) + " with AddCallback_OnPlayerKilled"  )
+	file.onPlayerKilledClientCallbacks.append( callback )
+}
+
+void function AddCallback_OnEntityKilled( void functionref( ObituaryCallbackParams ) callback )
+{
+	Assert( !file.onEntityKilledClientCallbacks.contains( callback ), "Already added " + string( callbackFunc ) + " with AddCallback_OnEntityKilled"  )
+	file.onEntityKilledClientCallbacks.append( callback )
+}
+/////////////////
+
+function ClObituary_Init()
+{
+
+}
+
+void function EntitiesDidLoad()
+{
+}
+
+void function ServerCallback_SquadLeaderBonus( int playerEHandle )
+{
+	entity pilot = GetEntityFromEncodedEHandle( playerEHandle )
+
+	if ( !IsValid( pilot ) )
+		return
+
+	if ( !pilot.IsPlayer() )
+		return
+
+	if ( pilot == GetLocalClientPlayer() )
+		Obituary_Print_Generic( "#OBIT_SQUAD_LEADER_BONUS_YOU", pilot.GetPlayerName(), TEAM_COLOR_FRIENDLY, <255, 255, 255> )
+	else
+		Obituary_Print_Generic( "#OBIT_SQUAD_LEADER_BONUS", pilot.GetPlayerName(), TEAM_COLOR_FRIENDLY, <255, 255, 255> )
+}
+
+void function ServerCallback_SquadLeaderDoubleXP()
+{
+	AnnouncementData announcement = Announcement_Create( "#SQUAD_LEADER_BONUS_ANNOUNCE" )
+	bool displayNow = InitializeAnnouncement_ShouldDisplayNow( announcement, "#SQUAD_LEADER_BONUS_ANNOUNCE", "#SQUAD_LEADER_BONUS_ANNOUNCE_DESC", TEAM_COLOR_YOU )
+	announcement.announcementStyle = ANNOUNCEMENT_STYLE_SWEEP
+	announcement.icon = $"rui/menu/common/dbl_xp_icon"
+	announcement.iconAspect = <1, 1, 0>
+	announcement.soundAlias = SFX_HUD_ANNOUNCE_QUICK
+	announcement.duration = 4.0
+
+	if ( displayNow )
+		thread AnnouncementMessage_Display( GetLocalClientPlayer(), announcement )
+}
+
+ObitEntityInfo function Obituary_GetEntityInfo( entity ent, bool victimIsOwnedTitan = false, damageSourceId = null )
+{
+	ObitEntityInfo info
+
+	if ( IsValid( ent ) )
+	{
+		AttackerDisplayNameStruct names = GetAttackerDisplayNamesFromClassname( ent, victimIsOwnedTitan )
+		info.displayName = names.attackerName
+		info.petDisplayName = names.attackerPetName
+
+		entity localPlayer = GetLocalClientPlayer()
+
+		info.displayColor = localPlayer.GetTeam() == ent.GetTeam() ? OBITUARY_COLOR_FRIENDLY : OBITUARY_COLOR_ENEMY
+
+		if ( !IsWatchingReplay() )
+		{
+			local entBoss = ent.GetBossPlayer()
+			if ( !IsPrivateMatch() && ((ent.IsPlayer() && IsPartyMember( ent )) || ((entBoss != null) && IsPartyMember( entBoss ))) )
+				info.displayColor = OBITUARY_COLOR_PARTY
+
+			if ( ent == localPlayer )
+				info.displayColor = OBITUARY_COLOR_LOCALPLAYER
+			else if ( !ent.IsPlayer() && (entBoss == localPlayer) )
+				info.displayColor = OBITUARY_COLOR_LOCALPLAYER
+		}
+	}
+	else if ( damageSourceId != null )
+	{
+		string name = GetAttackerDisplayNamesDamageSourceId( damageSourceId )
+		info.displayColor = OBITUARY_COLOR_ENEMY // Since we can't know if it's an enemy of friendly lets assume enemy.
+		info.displayName = name
+	}
+
+	return info
+}
+
+function Obituary( entity attacker, string attackerClass, entity victim, int scriptDamageType, int damageSourceId, bool isHeadShot, bool victimIsOwnedTitan = false, bool forceDisplay = false )
+{
+	if ( IsSingleplayer() )
+		return
+
+	// NS - Taken from https://github.com/S2ymi/R2NS-ClientKillCallback
+	foreach( callback in file.onEntityKilledClientCallbacks ){
+		ObituaryCallbackParams params
+		params.victim = victim
+		params.attacker = attacker
+		params.damageSourceId = damageSourceId
+		params.scriptDamageType = scriptDamageType
+		params.victimIsOwnedTitan = victimIsOwnedTitan
+
+		callback( params )
+	}
+	/////////////////
+
+	if ( GetConVarInt( "hud_setting_showObituary" ) == 0 )
+		return
+
+	if ( !forceDisplay )
+	{
+		if ( victim.IsPlayer() )
+		{
+			// Players
+			if ( !OBITUARY_ENABLED_PLAYERS )
+				return
+		}
+		else if ( victim.IsTitan() )
+		{
+			// NPC Titans
+			if ( !OBITUARY_ENABLED_NPC_TITANS )
+				return
+		}
+		else
+		{
+			// NPC
+			if ( !OBITUARY_ENABLED_NPC )
+				return
+		}
+	}
+
+	if ( damageSourceId == eDamageSourceId.round_end )
+		return
+
+	/*******************************************/
+	/* GET INFORMATION ABOUT ENTITIES INVOLVED */
+	/*******************************************/
+
+	ObitEntityInfo attackerInfo = Obituary_GetEntityInfo( attacker, false, damageSourceId )
+	ObitEntityInfo victimInfo = Obituary_GetEntityInfo( victim, victimIsOwnedTitan, damageSourceId )
+	bool isDeathSuicide = IsSuicide( attacker, victim, damageSourceId )
+
+	// Don't show NPC suicides, also makes titan eject deaths not show up which is good
+	if ( isDeathSuicide && victim.IsNPC() )
+		return
+
+	string sourceDisplayName = ""
+	//if ( isDeathSuicide )
+	//	damageSourceId = damagedef_suicide
+
+	//sourceDisplayName = DamageDef_GetObituary( damageSourceId ) <- replace with this when all damageSourceIds are converted
+
+	sourceDisplayName = GetObitFromDamageSourceID( damageSourceId )
+
+	/********************************************/
+	/* PRINT DEBUG INFO IF SOMETHING GOES WRONG */
+	/********************************************/
+
+	bool printDebugInfo = false
+	local debugSourceDisplayName = sourceDisplayName
+
+	if ( sourceDisplayName == "" )
+	{
+		debugSourceDisplayName = GetObitFromDamageSourceID( eDamageSourceId.damagedef_unknownBugIt )
+		printDebugInfo = true
+	}
+
+	if ( attackerInfo.displayName == "" )
+	{
+		printDebugInfo = true
+	}
+
+	if ( victimInfo.displayName == "" )
+	{
+		printDebugInfo = true
+	}
+
+	if ( printDebugInfo )
+	{
+		printt( "------------------------------------------" )
+		printt( " FULL OBITUARY INFO COULD NOT BE RESOLVED " )
+		printt( "    attacker:", attacker )
+		if ( IsValid( attacker ) )
+		{
+			printt( "    attacker classname:", attacker.GetClassName() )
+			local attackerOwner = attacker.GetOwner()
+			printt( "    attackerOwner:", attackerOwner )
+			if ( IsValid( attackerOwner ) )
+				printt( "    attackerOwner classname:", attackerOwner.GetClassName() )
+		}
+		printt( "    victim:", victim )
+		if ( IsValid( victim ) )
+		{
+			printt( "    victim classname:", victim.GetClassName() )
+			local victimOwner = victim.GetOwner()
+			printt( "    victimOwner:", victimOwner )
+			if ( IsValid( victimOwner ) )
+				printt( "    victimOwner classname:", victimOwner.GetClassName() )
+		}
+		printt( "    scriptDamageType:", scriptDamageType )
+		printt( "    damageSourceId:", damageSourceId )
+		printt( "    sourceDisplayName:", debugSourceDisplayName )
+		printt( "------------------------------------------" )
+	}
+
+	/**************************/
+	/* PRINT THE OBIT MESSAGE */
+	/**************************/
+
+	if ( isDeathSuicide )
+	{
+		attackerInfo.displayName = ""
+		attackerInfo.displayColor = victimInfo.displayColor
+	}
+
+	local weaponIcon = null
+	if ( isHeadShot )
+		weaponIcon = $"vgui/HUD/obituary_headshot"
+
+	vector obitColor
+	if ( scriptDamageType & DF_BURN_CARD_WEAPON )
+		obitColor = OBITUARY_COLOR_BURN_WEAPON
+	else
+		obitColor = OBITUARY_COLOR_WEAPON
+
+	string attackerString
+	string weaponString
+	string victimString
+
+	if ( attackerInfo.petDisplayName != "" )
+	{
+		attackerString = Localize( "#OBIT_PLAYER_CONTROLLED_AI_STRING", attackerInfo.displayName, Localize( attackerInfo.petDisplayName ) )
+	}
+	else
+	{
+		attackerString = Localize( "#OBIT_PLAYER_STRING", attackerInfo.displayName )
+	}
+
+	if ( victimInfo.petDisplayName != "" )
+	{
+		victimString = Localize( "#OBIT_PLAYER_CONTROLLED_AI_STRING", victimInfo.displayName, Localize( victimInfo.petDisplayName ) )
+	}
+	else
+	{
+		victimString = Localize( "#OBIT_PLAYER_STRING", victimInfo.displayName )
+	}
+
+	string localizedObit = Localize( "#OBIT_ENT_WEAPON_ENT", attackerString, Localize( sourceDisplayName ), victimString )
+
+	bool displayBackground = attacker == GetLocalClientPlayer() || victim == GetLocalClientPlayer()
+
+	float backgroundAlpha = (attacker == GetLocalClientPlayer() || victim == GetLocalClientPlayer()) ? 0.5 : 0.0
+	vector backgroundColor = <0, 0, 0>
+	//bool displayBackground = false
+
+	//if ( attacker.IsPlayer() )
+	//	attackerInfo.displayColor = <255, 255, 255>
+	//else if ( victim.IsPlayer() )
+	//	attackerInfo.displayColor = <255, 255, 255>
+	//
+	Obituary_Print_Localized( localizedObit, attackerInfo.displayColor, victimInfo.displayColor, <255, 255, 255>, backgroundColor, backgroundAlpha )
+
+	// NS - Taken from https://github.com/S2ymi/R2NS-ClientKillCallback
+	foreach( callback in file.onPlayerKilledClientCallbacks ){
+		ObituaryCallbackParams params
+		params.victim = victim
+		params.attacker = attacker
+		params.damageSourceId = damageSourceId
+		params.scriptDamageType = scriptDamageType
+		params.victimIsOwnedTitan = victimIsOwnedTitan
+
+		callback( params )
+	}
+	/////////////////
+}
+
+
+void function Obituary_Print( string attackerDisplayName, string weaponDisplayName, string victimDisplayName, vector attackerColor, vector weaponColor, vector victimColor, weaponIcon = null, string attackerPetDisplayName = "", string victimPetDisplayName = "" )
+{
+	#if DEV
+		if ( split( attackerDisplayName, "(" ).len() )
+			attackerDisplayName = split( attackerDisplayName, "(" )[0]
+
+		if ( split( victimDisplayName, "(" ).len() )
+			victimDisplayName = split( victimDisplayName, "(" )[0]
+	#endif
+
+	ObitStringData obitStringData
+
+	Assert( typeof( weaponDisplayName ) == "string" )
+
+	obitStringData.attackerName = attackerDisplayName
+	obitStringData.attackerPetName = attackerPetDisplayName
+	obitStringData.victimName = victimDisplayName
+	obitStringData.victimPetName = victimPetDisplayName
+	obitStringData.weaponLocalizedName = weaponDisplayName
+	obitStringData.weaponLocalizedString = "#OBIT_BRACKETED_STRING"
+
+	string attackerString
+	string weaponString
+	string victimString
+
+	if ( attackerPetDisplayName != "" )
+	{
+		obitStringData.attackerLocalizedString = "#OBIT_PLAYER_CONTROLLED_AI_STRING"
+		attackerString = Localize( "#OBIT_PLAYER_CONTROLLED_AI_STRING", attackerDisplayName, Localize( attackerPetDisplayName ) )
+	}
+	else
+	{
+		obitStringData.attackerLocalizedString = "#OBIT_PLAYER_STRING"
+		attackerString = Localize( "#OBIT_PLAYER_STRING", attackerDisplayName )
+	}
+
+	if ( victimPetDisplayName != "" )
+	{
+		obitStringData.victimLocalizedString = "#OBIT_PLAYER_CONTROLLED_AI_STRING"
+		victimString = Localize( "#OBIT_PLAYER_CONTROLLED_AI_STRING", victimDisplayName, Localize( victimPetDisplayName ) )
+	}
+	else
+	{
+		obitStringData.victimLocalizedString = "#OBIT_PLAYER_STRING"
+		victimString = Localize( "#OBIT_PLAYER_STRING", attackerDisplayName )
+	}
+
+	string localizedObit = Localize( "#OBIT_ENT_WEAPON_ENT", attackerString, Localize( weaponDisplayName ), victimString )
+
+	AddObituary( obitStringData, attackerColor, victimColor )
+
+//	#OBIT_PLAYER_CONTROLLED_AI_STRING
+//	#OBIT_BRACKETED_STRING
+
+////		"A's B"
+//		file.obituaryLines[ next ].attacker.SetText( "#OBIT_PLAYER_CONTROLLED_AI_STRING", attackerDisplayName, obituaryData.attackerPetDisplayName  )
+//	else
+//		file.obituaryLines[ next ].attacker.SetText( obituaryData.attackerDisplayName )
+//
+//	if ( obituaryData.victimPetDisplayName != "" )
+//		//		"A's B"
+//		file.obituaryLines[ next ].victim.SetText( "#OBIT_PLAYER_CONTROLLED_AI_STRING", obituaryData.victimDisplayName, obituaryData.victimPetDisplayName )
+//	else
+//		file.obituaryLines[ next ].victim.SetText( obituaryData.victimDisplayName )
+//	file.obituaryLines[ next ].victim.SetColor( ColorStringToArray( expect string( obituaryData.victimColor ) ) )
+//
+////	eventText = format( "Killed by `1%s`0", attackerTypeText )
+////	string obitString = "`1" + attackerDisplayName + "`0 " + obituaryData.weaponDisplayName
+//
+//	PrintTable( obituaryData )
+
+//	thread HandleObituaryOverflow( obituaryData )
+}
+
+
+void function Obituary_Print_Localized( string localizedPrint, vector altColor1 = <255, 255, 255>, vector altColor2 = <255, 255, 255>, vector altColor3 = <255, 255, 255>, vector backgroundColor = <255, 255, 255>, float backgroundAlpha = 0.0 )
+{
+	if ( !file.obituariesEnabled )
+		return
+
+	var rui = CreateCockpitRui( $"ui/obituary_crawl_localized.rpak" )
+	RuiSetGameTime( rui, "startTime", Time() )
+	RuiSetGameTime( rui, "updateTime", Time() )
+	RuiSetFloat( rui, "duration", OBITUARY_DURATION )
+
+	RuiSetString( rui, "obitString", localizedPrint )
+
+	RuiSetFloat3( rui, "string1Color", altColor1 / 255.0 )
+	RuiSetFloat3( rui, "string2Color", altColor2 / 255.0 )
+	RuiSetFloat3( rui, "string3Color", altColor3 / 255.0 )
+
+	RuiSetFloat3( rui, "backgroundColor", backgroundColor / 255.0 )
+	RuiSetFloat( rui, "backgroundAlpha", backgroundAlpha )
+
+	ObituaryData newObituary
+	newObituary.rui = rui
+	newObituary.startTime = Time()
+	file.obituaryQueue.insert( 0, newObituary )
+
+	UpdateObituaryQueue()
+}
+
+
+void function Obituary_Print_Generic( string localizedEvent, string entityName, vector eventColor, vector nameColor )
+{
+	if ( !file.obituariesEnabled )
+		return
+
+	var rui = CreateCockpitRui( $"ui/obituary_crawl_generic.rpak" )
+	RuiSetGameTime( rui, "startTime", Time() )
+	RuiSetGameTime( rui, "updateTime", Time() )
+	RuiSetFloat( rui, "duration", OBITUARY_DURATION )
+
+	RuiSetString( rui, "localizedString", localizedEvent )
+	RuiSetString( rui, "entityName", entityName )
+
+	RuiSetFloat3( rui, "string1Color", eventColor / 255.0 )
+	RuiSetFloat3( rui, "string2Color", nameColor / 255.0 )
+
+	ObituaryData newObituary
+	newObituary.rui = rui
+	newObituary.startTime = Time()
+	file.obituaryQueue.insert( 0, newObituary )
+
+	UpdateObituaryQueue()
+}
+
+
+void function UpdateObituaryQueue()
+{
+	for ( int index = file.obituaryQueue.len() - 1; index >= 0; index-- )
+	{
+		ObituaryData obitData = file.obituaryQueue[index]
+
+		if ( Time() - obitData.startTime >= OBITUARY_DURATION || index > 6 )
+		{
+			RuiDestroy( obitData.rui )
+			file.obituaryQueue.remove( index )
+			continue
+		}
+
+		RuiSetInt( obitData.rui, "offset", index + file.indexOffest )
+		RuiSetGameTime( obitData.rui, "updateTime", Time() )
+	}
+}
+
+void function AddObituary( ObitStringData obitStringData, vector string1Color, vector string2Color )
+{
+	if ( !file.obituariesEnabled )
+		return
+
+	//	var rui = RuiCreate( $"ui/obituary_crawl.rpak", clGlobal.topoFullScreen, RUI_DRAW_HUD, 0 )
+	var rui = CreateCockpitRui( $"ui/obituary_crawl.rpak" )
+	RuiSetGameTime( rui, "startTime", Time() )
+	RuiSetGameTime( rui, "updateTime", Time() )
+	RuiSetFloat( rui, "duration", OBITUARY_DURATION )
+
+	string attackerName = ""
+	string attackerPetName = ""
+	string victimName = ""
+	string victimPetName = ""
+	string attackerLocalizedString = "#OBIT_PLAYER_STRING"
+	string victimLocalizedString = "#OBIT_PLAYER_STRING"
+	string weaponLocalizedString = "#OBIT_BRACKETED_STRING"
+
+	// Trying to track down a code assert where the third argument to RuiSetString is somehow null.
+	Assert( typeof( obitStringData.attackerName ) == "string" )
+	Assert( typeof( obitStringData.attackerPetName ) == "string" )
+	Assert( typeof( obitStringData.attackerLocalizedString ) == "string" )
+	Assert( typeof( obitStringData.victimName ) == "string" )
+	Assert( typeof( obitStringData.victimPetName ) == "string" )
+	Assert( typeof( obitStringData.victimLocalizedString ) == "string" )
+	Assert( typeof( obitStringData.weaponLocalizedName ) == "string" )
+	Assert( typeof( obitStringData.weaponLocalizedString ) == "string" )
+
+	RuiSetString( rui, "attackerName", obitStringData.attackerName )
+	if ( obitStringData.attackerPetName.len() )
+	{
+		RuiSetString( rui, "attackerPetName", obitStringData.attackerPetName )
+		RuiSetBool( rui, "hasAttackerPetName", true )
+	}
+	RuiSetString( rui, "attackerLocalizedString", obitStringData.attackerLocalizedString )
+	RuiSetString( rui, "victimName", obitStringData.victimName )
+	if ( obitStringData.victimPetName.len() )
+	{
+		RuiSetString( rui, "victimPetName", obitStringData.victimPetName )
+		RuiSetBool( rui, "hasVictimPetName", true )
+	}
+	RuiSetString( rui, "victimLocalizedString", obitStringData.victimLocalizedString )
+	Assert( typeof( obitStringData.weaponLocalizedName ) == "string" )
+	RuiSetString( rui, "weaponLocalizedName", obitStringData.weaponLocalizedName )
+	RuiSetString( rui, "weaponLocalizedString", obitStringData.weaponLocalizedString )
+	RuiSetFloat3( rui, "string1Color", string1Color / 255.0 )
+	RuiSetFloat3( rui, "string2Color", string2Color / 255.0 )
+
+	ObituaryData newObituary
+	newObituary.rui = rui
+	newObituary.startTime = Time()
+	file.obituaryQueue.insert( 0, newObituary )
+
+	UpdateObituaryQueue()
+}
+
+/*
+function Obituary_Display( obituaryData )
+{
+	local next = obituaryData.indexToUse
+	BumpDownExistingObituaries()
+
+	if ( split( obituaryData.attackerDisplayName, "(" ).len() )
+		obituaryData.attackerDisplayName = split( obituaryData.attackerDisplayName, "(" )[0]
+
+	if ( split( obituaryData.victimDisplayName, "(" ).len() )
+		obituaryData.victimDisplayName = split( obituaryData.victimDisplayName, "(" )[0]
+
+
+	if ( obituaryData.attackerPetDisplayName != "" )
+		file.obituaryLines[ next ].attacker.SetText( "#OBIT_PLAYER_CONTROLLED_AI_STRING", obituaryData.attackerDisplayName, obituaryData.attackerPetDisplayName  )
+	else
+		file.obituaryLines[ next ].attacker.SetText( obituaryData.attackerDisplayName )
+	file.obituaryLines[ next ].attacker.SetColor( ColorStringToArray( expect string( obituaryData.attackerColor ) ) )
+
+	file.obituaryLines[ next ].weapon.SetText( "#OBIT_BRACKETED_STRING", obituaryData.weaponDisplayName, null, null, null, null )
+	file.obituaryLines[ next ].weapon.SetColor( ColorStringToArray( expect string( obituaryData.weaponColor ) ) )
+
+	if ( obituaryData.victimPetDisplayName != "" )
+		file.obituaryLines[ next ].victim.SetText( "#OBIT_PLAYER_CONTROLLED_AI_STRING", obituaryData.victimDisplayName, obituaryData.victimPetDisplayName )
+	else
+		file.obituaryLines[ next ].victim.SetText( obituaryData.victimDisplayName )
+	file.obituaryLines[ next ].victim.SetColor( ColorStringToArray( expect string( obituaryData.victimColor ) ) )
+
+	if ( obituaryData.weaponIcon )
+	{
+		file.obituaryLines[ next ].icon.SetImage( obituaryData.weaponIcon )
+		file.obituaryLines[ next ].icon.SetSize( file.obituaryLines[ next ].victim.GetHeight(), file.obituaryLines[ next ].victim.GetHeight() )
+	}
+	else
+	{
+		file.obituaryLines[ next ].icon.SetWidth( 0 )
+	}
+
+	file.obituaryLines[ next ].victim.ReturnToBasePos()
+
+	foreach ( elem in file.obituaryLines[ next ]	)
+	{
+		elem.SetAlpha( 128 )
+		elem.FadeOverTimeDelayed( 0, OBITUARY_FADE_OUT_DURATION, OBITUARY_DURATION )
+		elem.Show()
+	}
+
+	// increment which hud elems to use next time
+	file.nextObituaryIndexToUse++
+	if ( file.nextObituaryIndexToUse >= NUM_OBITUARY_LINES )
+		file.nextObituaryIndexToUse = 0
+}
+*/
+
+void function Obituary_SetEnabled( bool state )
+{
+	file.obituariesEnabled = state
+}
+
+void function Obituary_SetIndexOffset( int offset )
+{
+	file.indexOffest = offset
+}

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_player.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_player.gnut
@@ -82,7 +82,7 @@ struct {
 	// int hitGroup
 	// entity weapon
 	// float distanceFromAttackOrigin
-	array< void functionref( PlayerDidDamageParams ) onLocalPlayerDidDamageCallbacks
+	array< void functionref( PlayerDidDamageParams ) > onLocalPlayerDidDamageCallbacks
 } file
 
 struct BloodDecalParams
@@ -941,6 +941,7 @@ void function ClientCodeCallback_PlayerDidDamage( PlayerDidDamageParams params )
 	{
 		callback( params )
 	}
+	///////////////////////
 }
 
 void function PlayHitSound( entity victim, entity attacker, int damageFlags, bool isCritShot, bool victimIsHeavyArmor, bool isKillShot, int hitGroup )

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_player.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_player.gnut
@@ -1,0 +1,2768 @@
+untyped
+
+global function ClPlayer_Init
+
+global function PlayIt
+global function JumpRandomlyForever
+
+global function AddCallback_OnLocalPlayerDidDamage
+global function ClientCodeCallback_PlayerDidDamage
+global function ClientCodeCallback_PlayerSpawned
+//global function ClientCodeCallback_OnHudReloadScheme
+global function ClientCodeCallback_HUDThink
+global function Player_AddPlayer
+global function Player_AddClient
+global function PlayerConnectedOrDisconnected
+global function ServerCallback_GameModeAnnouncement
+global function MainHud_InitScoreBars
+
+global function ServerCallback_PlayerConnectedOrDisconnected
+global function ClientCodeCallback_PlayerDisconnected
+global function ServerCallback_PlayerChangedTeams
+global function ClientCodeCallback_OnModelChanged
+global function ServerCallback_RodeoerEjectWarning
+global function ServerCallback_PlayScreenFXWarpJump
+global function PlayShieldBreakEffect
+global function PlayShieldActivateEffect
+global function HandleDoomedState
+global function RewardReadyMessage
+global function TitanReadyMessage
+global function CoreReadyMessage
+
+global function ServerCallback_RewardReadyMessage
+global function ServerCallback_TitanReadyMessage
+
+global function OnClientPlayerAlive
+global function OnClientPlayerDying
+global function PlayPlayerDeathSound
+global function StopPlayerDeathSound
+
+global function ServerCallback_ShowNextSpawnMessage
+global function GetWaveSpawnTime
+global function ServerCallback_HideNextSpawnMessage
+
+global function ClientCodeCallback_OnHealthChanged
+global function ClientCodeCallback_OnCrosshairCurrentTargetChanged
+global function Pressed_TitanNextMode
+global function ClientCodeCallback_OnGib
+global function ClientPilotSpawned
+global function AddCallback_OnPlayerDisconnected
+
+global function IsPlayerEliminated
+
+global function ServerCallback_GiveMatchLossProtection
+global function ServerCallback_OnEntityKilled
+global function ServerCallback_OnTitanKilled
+
+global function ShouldShowSpawnAsTitanHint
+global function ServerCallback_SetAssistInformation
+
+global function GetShieldEffectCurrentColor
+global function ClientPlayerClassChanged
+
+#if DEV
+global function BloodSprayDecals_Toggle
+#endif
+
+const float DEFAULT_GAMEMODE_ANNOUNCEMENT_DURATION = 5.0
+
+struct {
+	var orbitalstrike_tracer = null
+	var law_missile_tracer = null
+	float nextSpawnTime = 0.0
+	entity lastEarnedReward // primarily used to check if we should still show the reward message after a delay
+
+	// NS - function passes an instance of PlayerDidDamageParams to the callback functions
+	// PlayerDidDamageParams has the following properties:
+	//	vector damagePosition
+	// int hitBox
+	// int damageType
+	// float damageAmount
+	// int damageFlags
+	// int hitGroup
+	// entity weapon
+	// float distanceFromAttackOrigin
+	array< void functionref( PlayerDidDamageParams ) onLocalPlayerDidDamageCallbacks
+} file
+
+struct BloodDecalParams
+{
+	float traceDist
+	float secondaryTraceDist
+	asset fxType
+	asset secondaryFxType
+}
+
+void function ClPlayer_Init()
+{
+	ClPilotJumpjet_Init()
+	ClDamageIndicator_Init()
+
+	ClPlayer_Common_Precache()
+
+	RegisterSignal( "OnAnimationDone" )
+	RegisterSignal( "OnAnimationInterrupted" )
+	RegisterSignal( "OnBleedingOut" )
+	RegisterSignal( "PanelAlphaOverTime" )
+	RegisterSignal( "LocalClientPlayerRespawned" )
+	RegisterSignal( "OnClientPlayerAlive" )
+	RegisterSignal( "OnClientPlayerDying" )
+	RegisterSignal( "StopAlertCore" )
+	RegisterSignal( "OnSpectatorMode" )
+	RegisterSignal( "HealthChanged" )
+
+	FlagInit( "DamageDistancePrint" )
+	FlagInit( "EnableTitanModeChange", true )
+	FlagInit( "EnableBloodSprayDecals", true )
+
+	level.vduOpen <- false
+	level.canSpawnAsTitan <- false
+	level.grenadeIndicatorEnabled <- true
+	level.clientsLastKiller <- null
+
+	AddCreateCallback( "player", SetupPlayerAnimEvents )
+	AddCreateCallback( "player", MpClientPlayerInit )
+
+	AddCreateCallback( "first_person_proxy", SetupFirstPersonProxyEvents )
+	AddCreateCallback( "predicted_first_person_proxy", SetupFirstPersonProxyEvents )
+
+	AddCreateCallback( "player", EnableDoDeathCallback )
+	AddCreateCallback( "npc_titan", EnableDoDeathCallback )
+
+	AddCreateCallback( "titan_soul", CreateCallback_TitanSoul )
+
+	AddCallback_OnPlayerLifeStateChanged( PlayerADSDof )
+
+	file.orbitalstrike_tracer = PrecacheParticleSystem( $"Rocket_Smoke_Large" )
+	//DEBUG Remove when bug is fixed.
+	file.law_missile_tracer = PrecacheParticleSystem( $"wpn_orbital_rocket_tracer" )
+
+	level.menuHideGroups <- {}
+
+	level.spawnAsTitanSelected <- false
+
+	AddPlayerFunc( Player_AddPlayer )
+}
+
+entity function FindEnemyRodeoParent( entity player )
+{
+	entity ent = player.GetParent()
+	if ( ent == null )
+		return null
+
+	if ( !ent.IsTitan() )
+		return null
+
+	if ( ent == player.GetPetTitan() )
+		return null
+
+	if ( ent.GetTeam() == player.GetTeam() )
+		return null
+
+	return ent
+}
+
+void function MpClientPlayerInit( entity player )
+{
+	player.ClientCommand( "save_enable 0" )
+}
+
+void function ClientCodeCallback_PlayerSpawned( entity player )
+{
+	if ( !IsValid( player ) )
+		return
+
+	if ( IsMenuLevel() )
+		return
+
+	ClearCrosshairPriority( crosshairPriorityLevel.ROUND_WINNING_KILL_REPLAY )
+
+	if ( !level.clientScriptInitialized )
+		return
+
+	// exists on server and client. Clear it when you respawn.
+	ClearRecentDamageHistory( player )
+	DamageHistoryStruct blankDamageHistory
+	clGlobal.lastDamageHistory = blankDamageHistory
+
+	if ( player == GetLocalViewPlayer() )
+	{
+		foreach ( callbackFunc in clGlobal.onLocalViewPlayerSpawnedCallbacks )
+		{
+			callbackFunc( player )
+		}
+	}
+
+	if ( player == GetLocalClientPlayer() )
+	{
+		player.cv.lastSpawnTime = Time()
+		player.cv.roundSpawnCount++
+
+		foreach ( callbackFunc in clGlobal.onLocalClientPlayerSpawnedCallbacks )
+		{
+			thread callbackFunc( player )
+		}
+	}
+
+	if ( player.IsTitan() )
+		return
+
+	if ( player.GetPlayerClass() == level.pilotClass )
+	{
+		thread ClientPilotSpawned( player )
+	}
+}
+
+
+void function ServerCallback_TitanReadyMessage()
+{
+	//thread TitanReadyMessage( 1.5, false ) //Delay was necessary at some point in time according to Brent, might no longer be true?
+	thread TitanReadyMessage( 0.0, false )
+}
+
+
+void function ServerCallback_RewardReadyMessage( float timeSinceLastRespawn )
+{
+	if ( timeSinceLastRespawn < 1.0 )
+		thread RewardReadyMessage( 6.0, false )
+	else
+		thread RewardReadyMessage( 0.0, false )
+}
+
+
+void function RewardReadyMessage( float delay = 0.0, bool isQuick = false )
+{
+	if ( delay > 0.0 )
+		wait delay
+
+	if ( !GamePlayingOrSuddenDeath() )
+		return
+
+	entity player = GetLocalClientPlayer()
+	if ( !IsAlive( player ) || IsSpectating() || IsWatchingKillReplay() )
+		return
+
+	if ( player.ContextAction_IsMeleeExecution() )
+		return
+
+	entity weapon = player.GetOffhandWeapon( OFFHAND_INVENTORY )
+	if ( !IsValid( weapon ) )
+		return
+
+	file.lastEarnedReward = weapon
+
+	if ( player.IsTitan() )
+	{
+		EmitSoundOnEntity( player, "HUD_Boost_Card_Earned_1P" )
+
+		string rewardReadyMessage = expect string( GetWeaponInfoFileKeyField_WithMods_Global( weapon.GetWeaponClassName(), weapon.GetMods(), "readymessage" ) )
+		string rewardReadyHint = expect string( GetWeaponInfoFileKeyField_WithMods_Global( weapon.GetWeaponClassName(), weapon.GetMods(), "readyhint" ) )
+		asset rewardIcon = GetWeaponInfoFileKeyFieldAsset_WithMods_Global( weapon.GetWeaponClassName(), weapon.GetMods(), "hud_icon" )
+
+		AnnouncementData announcement = CreateAnnouncementMessageQuick( player, rewardReadyMessage, rewardReadyHint, <1, 0.5, 0>, rewardIcon )
+		announcement.displayConditionCallback = LastEarnedRewardStillValid
+		AnnouncementFromClass( player, announcement )
+	}
+	else
+	{
+		EmitSoundOnEntity( player, "HUD_Boost_Card_Earned_1P" )
+
+		string rewardReadyMessage = expect string( GetWeaponInfoFileKeyField_WithMods_Global( weapon.GetWeaponClassName(), weapon.GetMods(), "readymessage" ) )
+		string rewardReadyHint = expect string( GetWeaponInfoFileKeyField_WithMods_Global( weapon.GetWeaponClassName(), weapon.GetMods(), "readyhint" ) )
+		asset rewardIcon = GetWeaponInfoFileKeyFieldAsset_WithMods_Global( weapon.GetWeaponClassName(), weapon.GetMods(), "hud_icon" )
+
+		AnnouncementData announcement = CreateAnnouncementMessageQuick( player, rewardReadyMessage, rewardReadyHint, <1, 0.5, 0>, rewardIcon )
+		announcement.displayConditionCallback = LastEarnedRewardStillValid
+		AnnouncementFromClass( player, announcement )
+	}
+}
+
+void function TitanReadyMessage( float delay = 0.0, bool isQuick = false )
+{
+	if ( delay > 0.0 )
+		wait delay
+
+	if ( !GamePlayingOrSuddenDeath() )
+		return
+
+	entity player = GetLocalClientPlayer()
+	if ( !IsAlive( player ) || IsSpectating() || IsWatchingKillReplay() )
+		return
+
+	if ( player.ContextAction_IsMeleeExecution() )
+		return
+
+	if ( Riff_TitanAvailability() == eTitanAvailability.Never )
+		return
+
+	if ( !IsTitanAvailable( player ) &&
+					(Riff_TitanAvailability() == eTitanAvailability.Custom)
+			)
+		return
+
+	int loadoutIndex = GetPersistentSpawnLoadoutIndex( player, "titan" )
+	TitanLoadoutDef loadout = GetTitanLoadoutFromPersistentData( player, loadoutIndex )
+
+	string titanReadyMessage = GetTitanReadyMessageFromSetFile( loadout.setFile )
+	string titanReadyHint = GetTitanReadyHintFromSetFile( loadout.setFile )
+
+	AnnouncementData announcement = CreateAnnouncementMessageQuick( player, titanReadyMessage, titanReadyHint, TEAM_COLOR_YOU, $"rui/hud/titanfall_marker_arrow_ready" )
+	announcement.displayConditionCallback = ConditionNoTitan
+	AnnouncementFromClass( player, announcement )
+
+	#if FACTION_DIALOGUE_ENABLED
+		if ( !isQuick || CoinFlip() )
+			PlayFactionDialogueOnLocalClientPlayer( "mp_titanReady" ) //Playing here as opposed to on the server since delay is normally not 0
+	#endif
+
+	if ( PlayerEarnMeter_GetMode( player ) == eEarnMeterMode.DEFAULT ) //Help stop spamming "Your Titan is Ready"
+	{
+		Cl_EarnMeter_SetLastHintTime( Time() )
+	}
+}
+
+
+function CoreReadyMessage( entity player, bool isQuick = false )
+{
+	if ( !GamePlayingOrSuddenDeath() )
+		return
+
+	if ( !IsAlive( player ) )
+		return
+
+	if ( GetDoomedState( player ) )
+		return
+
+	if ( !player.IsTitan() )
+		return
+
+	entity weapon = player.GetOffhandWeapon( OFFHAND_EQUIPMENT )
+
+	string coreOnlineMessage = expect string( weapon.GetWeaponInfoFileKeyField( "readymessage" ) )
+	string coreOnlineHint = expect string( weapon.GetWeaponInfoFileKeyField( "readyhint" ) )
+
+	if ( isQuick )
+	{
+		AnnouncementData announcement = CreateAnnouncementMessageQuick( player, coreOnlineMessage, coreOnlineHint, TEAM_COLOR_YOU )
+		announcement.displayConditionCallback = ConditionPlayerIsTitan
+		AnnouncementFromClass( player, announcement )
+	}
+	else
+	{
+		AnnouncementData announcement = CreateAnnouncementMessage( player, coreOnlineMessage, coreOnlineHint, TEAM_COLOR_YOU )
+		announcement.displayConditionCallback = ConditionPlayerIsTitan
+		announcement.subText = coreOnlineHint
+		AnnouncementFromClass( player, announcement )
+	}
+}
+
+
+bool function ConditionPlayerIsTitan()
+{
+	entity player = GetLocalClientPlayer()
+	if ( !IsAlive( player ) )
+		return false
+
+	return player.IsTitan()
+}
+
+
+bool function ConditionPlayerIsNotTitan()
+{
+	entity player = GetLocalClientPlayer()
+	if ( !IsAlive( player ) )
+		return false
+
+	return !player.IsTitan()
+}
+
+bool function LastEarnedRewardStillValid()
+{
+	entity player = GetLocalClientPlayer()
+	if ( !IsAlive( player ) )
+		return false
+
+	entity weapon = player.GetOffhandWeapon( OFFHAND_INVENTORY )
+	if ( !IsValid( weapon ) )
+		return false
+
+	return weapon == file.lastEarnedReward
+}
+
+
+bool function ConditionNoTitan()
+{
+	entity player = GetLocalClientPlayer()
+	if ( !IsAlive( player ) )
+		return false
+
+	if ( IsValid( player.GetPetTitan() ) )
+		return false
+
+	return !player.IsTitan()
+}
+
+
+function ClientPilotSpawned( entity player )
+{
+	player.EndSignal( "SettingsChanged" )
+	player.EndSignal( "OnDestroy" )
+	player.EndSignal( "OnDeath" )
+
+	if ( (player != GetLocalViewPlayer()) )
+		//Turning off for the time being since the front rodeo spot leaves persistent jumpjets in the face of the TItan
+		thread ParentedPlayerJets( player )
+}
+
+void function Player_AddClient( entity player )
+{
+	if ( GetCurrentPlaylistVarInt( "titan_mode_change_allowed", 1 ) )
+		RegisterConCommandTriggeredCallback( "+scriptCommand2", Pressed_TitanNextMode )
+
+	RegisterConCommandTriggeredCallback( "+scriptCommand2", Pressed_RequestTitanfall )
+	RegisterConCommandTriggeredCallback( "+scriptCommand2", Pressed_ActivateMobilityGhost )
+
+	RegisterConCommandTriggeredCallback( "+use", Pressed_OfferRodeoBattery )
+	RegisterConCommandTriggeredCallback( "+use", Pressed_RequestRodeoBattery )
+	RegisterConCommandTriggeredCallback( "+useandreload", Pressed_OfferRodeoBattery )
+	RegisterConCommandTriggeredCallback( "+useandreload", Pressed_RequestRodeoBattery )
+
+	#if MP
+	RegisterConCommandTriggeredCallback( "+use", Pressed_TryNukeGrenade )
+	RegisterConCommandTriggeredCallback( "-use", Released_TryNukeGrenade )
+	RegisterConCommandTriggeredCallback( "+useandreload", Pressed_TryNukeGrenade )
+	RegisterConCommandTriggeredCallback( "-useandreload", Released_TryNukeGrenade )
+	#endif
+
+	Create_DamageIndicatorHUD()
+
+	if ( !IsLobby() )
+	{
+		player.EnableHealthChangedCallback()
+
+		player.cv.deathTime <- 0.0
+		player.cv.lastSpawnTime <- 0.0
+		player.cv.deathOrigin <- <0.0, 0.0, 0.0>
+		player.cv.roundSpawnCount <- 0
+
+		thread CinematicIntroScreen()
+	}
+}
+
+void function Player_AddPlayer( entity player )
+{
+	player.s.weaponUpdateData <- {}
+
+	player.s.trackedAttackers <- {} // for titans
+	player.classChanged = true
+}
+
+function Pressed_RequestTitanfall( entity player )
+{
+	if ( !IsTitanAvailable( player ) )
+		return
+
+	#if DEV
+		printt( player.GetEntIndex(), "Requested replacement Titan from eye pos " + player.EyePosition() + " view angles " + player.EyeAngles() + " player origin " + player.GetOrigin() + " map " + GetMapName() )
+	#endif
+
+	player.ClientCommand( "ClientCommand_RequestTitan" ) //Send client command regardless of whether we can call the titan in or not. Server decides
+	Rumble_Play( "rumble_titanfall_request", {} )
+
+	//
+	//if ( player.cv.announcementActive && player.cv.announcementActive.messageText == "#HUD_TITAN_READY" )
+	//{
+	//	clGlobal.levelEnt.Signal( "AnnoucementPurge" )
+	//}
+	//
+	////PlayMusic( "Music_FR_Militia_TitanFall1" )
+	//EmitSoundOnEntity( player, "titan_callin" )
+	//return
+	//}
+}
+
+function Pressed_TitanNextMode( entity player )
+{
+	if ( player.IsTitan() )
+		return
+
+	if ( IsWatchingReplay() )
+		return
+
+	if ( !IsAlive( player ) )
+		return
+
+	if ( player.IsPhaseShifted() )
+		return
+
+	if ( !IsAlive( player.GetPetTitan() ) )
+		return
+
+	if ( !Flag( "EnableTitanModeChange" ) )
+		return
+
+	// cannot change modes while titan is incoming
+	if ( player.GetHotDropImpactTime() )
+		return
+
+	player.ClientCommand( "TitanNextMode" )
+
+	local newMode = player.GetPetTitanMode() + 1
+	if ( newMode == eNPCTitanMode.MODE_COUNT )
+		newMode = eNPCTitanMode.FOLLOW
+
+	SetAutoTitanModeHudIndicator( player, newMode )
+
+	local guardModeAlias = GenerateTitanOSAlias( player, AUTO_TITAN_GUARD_MODE_DIAG_SUFFIX )
+	local followModeAlias = GenerateTitanOSAlias( player, AUTO_TITAN_FOLLOW_MODE_DIAG_SUFFIX )
+
+	// prevent the sounds from stomping each other if button is pressed rapidly
+	StopSoundOnEntity( player, guardModeAlias )
+	StopSoundOnEntity( player, AUTO_TITAN_GUARD_MODE_SOUND )
+	StopSoundOnEntity( player, followModeAlias )
+	StopSoundOnEntity( player, AUTO_TITAN_FOLLOW_MODE_SOUND )
+
+	if ( newMode == eNPCTitanMode.FOLLOW )
+	{
+		EmitSoundOnEntity( player, followModeAlias )
+		EmitSoundOnEntity( player, AUTO_TITAN_FOLLOW_MODE_SOUND )
+	}
+	else if ( newMode == eNPCTitanMode.STAY )
+	{
+		EmitSoundOnEntity( player, guardModeAlias )
+		EmitSoundOnEntity( player, AUTO_TITAN_GUARD_MODE_SOUND )
+	}
+}
+
+/*
+void function ClientCodeCallback_OnHudReloadScheme()
+{
+}
+*/
+
+void function ClientCodeCallback_HUDThink()
+{
+	PerfStart( PerfIndexClient.ClientCodeCallback_HUDThink )
+
+	entity player = GetLocalViewPlayer()
+
+	if ( !player.p.playerScriptsInitialized )
+	{
+		PerfEnd( PerfIndexClient.ClientCodeCallback_HUDThink )
+		return
+	}
+
+	if ( !IsMenuLevel() )
+	{
+		PerfStart( PerfIndexClient.ClientCodeCallback_HUDThink_4 )
+
+		ClGameState_Think()
+		PerfEnd( PerfIndexClient.ClientCodeCallback_HUDThink_4 )
+
+		PerfStart( PerfIndexClient.ClientCodeCallback_HUDThink_5 )
+		UpdateVoiceHUD()
+		#if PC_PROG
+			UpdateChatHUDVisibility()
+		#endif // PC_PROG
+		PerfEnd( PerfIndexClient.ClientCodeCallback_HUDThink_5 )
+
+		UpdateScreenFade()
+
+		entity clientPlayer = GetLocalClientPlayer()
+		if ( !IsWatchingKillReplay() && clientPlayer.classChanged )
+		{
+			ClientPlayerClassChanged( clientPlayer, clientPlayer.GetPlayerClass() )
+		}
+
+		PerfStart( PerfIndexClient.ClientCodeCallback_HUDThink_6 )
+		SmartAmmo_LockedOntoWarningHUD_Update()
+		WeaponFlyoutThink( player )
+		PerfEnd( PerfIndexClient.ClientCodeCallback_HUDThink_6 )
+	}
+
+	PerfEnd( PerfIndexClient.ClientCodeCallback_HUDThink )
+}
+
+function ClientPlayerClassChanged( entity player, newClass )
+{
+	//printl( "ClientPlayerClassChanged to " + player.GetPlayerClass() )
+	player.classChanged = false
+
+	level.vduOpen = false // vdu goes away when class changes
+
+	Assert( !IsServer() )
+	Assert( newClass, "No class " )
+
+	switch ( newClass )
+	{
+		case "titan":
+			SetStandardAbilityBindingsForTitan( player )
+			SetAbilityBinding( player, 6, "+offhand4", "-offhand4" )	// "+ability 6"
+
+			LinkButtonPair( -1, -1, -1 )
+			break
+
+		case level.pilotClass:
+			SetStandardAbilityBindingsForPilot( player )
+			SetAbilityBinding( player, 6, "+offhand4", "-offhand4" )	// "+ability 6"
+
+			LinkButtonPair( IN_OFFHAND0, IN_OFFHAND1, IN_OFFHAND3 )
+
+			if ( clGlobal.isAnnouncementActive && (clGlobal.activeAnnouncement.messageText == "#HUD_CORE_ONLINE_STRYDER" ||
+							clGlobal.activeAnnouncement.messageText == "#HUD_CORE_ONLINE_ATLAS" ||
+							clGlobal.activeAnnouncement.messageText == "#HUD_CORE_ONLINE_OGRE" ) )
+			{
+				clGlobal.levelEnt.Signal( "AnnoucementPurge" )
+			}
+			break
+
+		case "spectator":
+			LinkButtonPair( -1, -1, -1 )
+			break
+
+		default:
+			Assert( 0, "Unknown class " + newClass )
+	}
+
+	PlayActionMusic()
+}
+
+function ShouldShowSpawnAsTitanHint( entity player )
+{
+	if ( Time() - player.cv.deathTime < GetRespawnButtonCamTime( player ) )
+		return false
+
+	if ( GetGameState() < eGameState.Playing )
+		return false
+
+	if ( GetGameState() == eGameState.SwitchingSides )
+		return false
+
+	return !IsPlayerEliminated( player )
+}
+
+function ServerCallback_PlayerChangedTeams( player_eHandle, oldTeam, newTeam )
+{
+	entity player = GetEntityFromEncodedEHandle( player_eHandle )
+	if ( player == null )
+		return
+	Assert( oldTeam != null )
+	Assert( newTeam != null )
+
+	string playerName = player.GetPlayerNameWithClanTag()
+	vector playerNameColor = OBITUARY_COLOR_ENEMY
+	string teamString = "ENEMY"
+	if ( newTeam == GetLocalViewPlayer().GetTeam() )
+	{
+		playerNameColor = OBITUARY_COLOR_FRIENDLY
+		teamString = "FRIENDLY"
+	}
+
+	Obituary_Print( playerName, "CHANGED TEAMS TO", teamString, playerNameColor, OBITUARY_COLOR_WEAPON, playerNameColor )
+	//"Switching " + player.GetPlayerNameWithClanTag() + " from " + GetTeamStr( team1 ) + " to " + GetTeamStr( team2 )
+}
+
+function ServerCallback_PlayerConnectedOrDisconnected( player_eHandle, state )
+{
+	entity player = GetEntityFromEncodedEHandle( player_eHandle )
+	PlayerConnectedOrDisconnected( player, state )
+
+	if ( !IsLobby() || !IsConnected() )
+		UpdatePlayerStatusCounts()
+}
+
+void function AddCallback_OnPlayerDisconnected( void functionref( entity ) callbackFunc )
+{
+	Assert( !clGlobal.onPlayerDisconnectedFuncs.contains( callbackFunc ), "Already added " + string( callbackFunc ) + " with AddCallback_OnPlayerDisconnected" )
+
+	clGlobal.onPlayerDisconnectedFuncs.append( callbackFunc )
+}
+
+void function ClientCodeCallback_PlayerDisconnected( entity player, string cachedPlayerName )
+{
+	PlayerConnectedOrDisconnected( player, 0, cachedPlayerName )
+
+	if ( ShouldUpdatePlayerStatusCounts() )
+		UpdatePlayerStatusCounts()
+
+	// Added via AddCallback_OnPlayerDisconnected
+	foreach ( callbackFunc in clGlobal.onPlayerDisconnectedFuncs )
+	{
+		callbackFunc( player )
+	}
+}
+
+function ShouldUpdatePlayerStatusCounts()
+{
+	if ( GetGameState() < eGameState.WaitingForPlayers )
+		return false
+
+	if ( !IsLobby() )
+		return true
+
+	if ( !IsConnected() )
+		return true
+
+	return false
+}
+
+function PlayerConnectedOrDisconnected( entity player, state, string disconnectingPlayerName = "" )
+{
+	if ( IsLobby() || GetMapName() == "" )
+		// HACK: If you are disconnecting GetMapName() in IsLobby() will return ""
+		return
+
+	if ( !IsValid( player ) )
+		return
+
+	Assert( state == 0 || state == 1 )
+
+	if ( !IsValid( GetLocalViewPlayer() ) )
+		return
+
+	string playerName
+	if ( state == 0 )
+	{
+		if ( disconnectingPlayerName == "" )
+			return
+
+		playerName = disconnectingPlayerName
+		Assert( typeof( playerName ) == "string" )
+	}
+	else
+	{
+		playerName = player.GetPlayerNameWithClanTag()
+		Assert( typeof( playerName ) == "string" )
+	}
+
+	vector playerNameColor = player.GetTeam() == GetLocalViewPlayer().GetTeam() ? OBITUARY_COLOR_FRIENDLY : OBITUARY_COLOR_ENEMY
+	string connectionString = (state == 0) ? "#MP_PLAYER_DISCONNECTED" : "#MP_PLAYER_CONNECTED"
+
+	Obituary_Print_Generic( connectionString, playerName, <255, 255, 255>, playerNameColor )
+}
+
+void function AddCallback_OnLocalPlayerDidDamage( void functionref( PlayerDidDamageParams ) callbackFunc )
+{
+	Assert( !file.onLocalPlayerDidDamageCallbacks.contains( callbackFunc ), "Already added " + string( callbackFunc ) + " with AddCallback_OnLocalPlayerDidDamage" )
+
+	file.onLocalPlayerDidDamageCallbacks.append( callbackFunc )
+}
+
+void function ClientCodeCallback_PlayerDidDamage( PlayerDidDamageParams params )
+{
+	if ( IsWatchingThirdPersonKillReplay() )
+		return
+
+	entity attacker = GetLocalViewPlayer()
+	if ( !IsValid( attacker ) )
+		return
+
+	entity victim = params.victim
+	if ( !IsValid( victim ) )
+		return
+
+	vector damagePosition = params.damagePosition
+	int hitBox = params.hitBox
+	int damageType = params.damageType
+	float damageAmount = params.damageAmount
+	int damageFlags = params.damageFlags
+	int hitGroup = params.hitGroup
+	entity weapon = params.weapon
+	float distanceFromAttackOrigin = params.distanceFromAttackOrigin
+
+	bool playHitSound = true
+	bool showCrosshairHitIndicator = true
+	bool hitIneffective = false
+	bool victimIsHeavyArmor = false
+	bool isCritShot = (damageType & DF_CRITICAL) ? true : false
+	bool isHeadShot = (damageType & DF_HEADSHOT) ? true : false
+	bool isKillShot = (damageType & DF_KILLSHOT) ? true : false
+	bool isMelee = (damageType & DF_MELEE) ? true : false
+	bool isExplosion = (damageType & DF_EXPLOSION) ? true : false
+	bool isBullet = (damageType & DF_BULLET) ? true : false
+	bool isShotgun = (damageType & DF_SHOTGUN) ? true : false
+	bool isDoomFatality = (damageType & DF_DOOM_FATALITY) ? true : false
+	bool isDoomProtected = ((damageType & DF_DOOM_PROTECTED) && !isDoomFatality) ? true : false
+	victimIsHeavyArmor = victim.GetArmorType() == ARMOR_TYPE_HEAVY
+
+	isDoomFatality = false
+	isDoomProtected = false
+
+	if ( isDoomProtected )
+		RegisterDoomProtectionHintDamage( damageAmount )
+
+	bool playKillSound = isKillShot
+
+	if ( !attacker.IsTitan() )
+	{
+		if ( victimIsHeavyArmor )
+		{
+			showCrosshairHitIndicator = true
+			if ( victim.IsTitan() )
+				hitIneffective = false //!IsHitEffectiveVsTitan( victim, damageType )
+			else
+				hitIneffective = isCritShot || isHeadShot || !IsHitEffectiveVsNonTitan( victim, damageType )
+		}
+		else
+		{
+			switch ( victim.GetSignifierName() )
+			{
+				case "npc_super_spectre":
+					//if ( !( damageType & DF_CRITICAL ) )
+					//	hitIneffective = true
+
+				default:
+					if ( (damageType & DF_BULLET && damageType & DF_MAX_RANGE) )
+						hitIneffective = true
+					break
+			}
+		}
+	}
+	else
+	{
+		if ( victim.IsTitan() && victim.IsPlayer() )
+		{
+			if ( PlayerHasPassive( victim, ePassives.PAS_BERSERKER ) )
+				hitIneffective = true
+		}
+	}
+
+	if ( damageType & DF_MAX_RANGE && damageType & DF_BULLET )
+		// TODO: this is crap; these damage types should just send DF_NO_HITBEEP
+		playHitSound = false
+
+	if ( damageType & DF_TITAN_STEP )
+		// TODO: this is crap; these damage types should just send DF_NO_HITBEEP
+	{
+		playHitSound = false
+		playKillSound = false
+	}
+
+	if ( damageType & DF_MELEE )
+		// TODO: this is crap; these damage types should just send DF_NO_HITBEEP
+	{
+		playHitSound = false
+		playKillSound = false
+	}
+
+	if ( damageType & DF_NO_HITBEEP )
+	{
+		playHitSound = false
+		playKillSound = false
+	}
+
+	if ( damageFlags & DAMAGEFLAG_VICTIM_HAS_VORTEX )
+		showCrosshairHitIndicator = false
+
+	if ( damageType & DF_SHIELD_DAMAGE )
+	{
+		PlayShieldHitEffect( params )
+		showCrosshairHitIndicator = true
+	}
+	else if ( damageAmount <= 0 )
+	{
+		playHitSound = false
+		playKillSound = false
+		showCrosshairHitIndicator = false
+	}
+
+	if ( damageType & DF_NO_INDICATOR )
+	{
+		playHitSound = false
+		playKillSound = false
+		showCrosshairHitIndicator = false
+	}
+
+	if ( isDoomProtected )
+		playHitSound = false
+
+	if ( showCrosshairHitIndicator )
+	{
+		Tracker_PlayerAttackedTarget( attacker, victim )
+
+		//if ( hitIneffective )
+		//	Crosshair_ShowHitIndicator( CROSSHAIR_HIT_INEFFECTIVE )
+		//else
+		//	Crosshair_ShowHitIndicator( CROSSHAIR_HIT_NORMAL )
+		//
+		//if ( (isCritShot || isDoomFatality) && !isDoomProtected )
+		//	Crosshair_ShowHitIndicator( CROSSHAIR_HIT_CRITICAL )
+		//
+		//if ( isHeadShot )
+		//	Crosshair_ShowHitIndicator( CROSSHAIR_HIT_HEADSHOT )
+
+		if ( IsMultiplayer() && !victim.IsTitan() && !victim.IsHologram() )
+			PROTO_HitIndicatorEffect( attacker, victim, damagePosition, isHeadShot, isKillShot )
+
+		if ( isKillShot )
+			KillShotBloodSpray( attacker, victim, damagePosition, isExplosion, isBullet, isShotgun )
+
+		if ( victim.IsTitan() && isKillShot )
+			ClientScreenShake( 8, 10, 1, Vector( 0, 0, 0 ) )
+
+		BloodSprayDecals( attacker, victim, damagePosition, damageAmount, isHeadShot, isKillShot, isMelee, isExplosion, isBullet, isShotgun )
+
+		DamageFlyout( damageAmount, damagePosition, victim, isHeadShot || isCritShot, hitIneffective )
+	}
+
+	bool playedHitSound = false
+	if ( playHitSound )
+	{
+		if ( isHeadShot )
+			playedHitSound = PlayHeadshotConfirmSound( attacker, victim, isKillShot )
+		else if ( playKillSound )
+			playedHitSound = PlayKillshotConfirmSound( attacker, victim, damageType )
+	}
+
+	if ( IsSpectre( victim ) )
+	{
+		if ( isHeadShot )
+			victim.Signal( "SpectreGlowEYEGLOW" )
+	}
+
+	// Play a hit sound effect if we didn't play a kill shot sound, and other conditions are met
+	if ( playHitSound && IsAlive( victim ) && !playedHitSound )
+	{
+		PlayHitSound( victim, attacker, damageFlags, isCritShot, victimIsHeavyArmor, isKillShot, hitGroup )
+	}
+
+	if ( PlayerHasPassive( attacker, ePassives.PAS_SMART_CORE ) && isKillShot )
+	{
+		attacker.p.smartCoreKills++
+	}
+
+	foreach ( callback in clGlobal.onLocalPlayerDidDamageCallback )
+	{
+		callback( attacker, victim, damagePosition, damageType )
+	}
+
+	// NS
+	foreach ( callback in file.onLocalPlayerDidDamageCallbacks )
+	{
+		callback( params )
+	}
+}
+
+void function PlayHitSound( entity victim, entity attacker, int damageFlags, bool isCritShot, bool victimIsHeavyArmor, bool isKillShot, int hitGroup )
+{
+	if ( damageFlags & DAMAGEFLAG_VICTIM_INVINCIBLE )
+	{
+		EmitSoundOnEntity( attacker, "Player.HitbeepInvincible" )
+	}
+	else if ( damageFlags & DAMAGEFLAG_VICTIM_HAS_VORTEX )
+	{
+		EmitSoundOnEntity( attacker, "Player.HitbeepVortex" )
+	}
+	else if ( isCritShot && victimIsHeavyArmor )
+	{
+		EmitSoundOnEntity( attacker, "titan_damage_crit" )
+	}
+	else if ( isCritShot )
+	{
+		EmitSoundOnEntity( attacker, "Player.Hitbeep_crit" )
+	}
+	else
+	{
+		EmitSoundOnEntity( attacker, "Player.Hitbeep" )
+	}
+}
+
+function PROTO_HitIndicatorEffect( entity player, entity victim, vector damagePosition, bool isHeadShot, bool isKillShot )
+{
+	int fxId
+	if ( isKillShot )
+		fxId = GetParticleSystemIndex( $"P_ar_impact_pilot_kill" )
+	else if ( isHeadShot && !isKillShot )
+		return
+	//		fxId = GetParticleSystemIndex( $"P_ar_impact_pilot_headshot" )
+	else
+		return
+	//		fxId = GetParticleSystemIndex( $"P_ar_impact_pilot" )
+
+	vector victimVelocity = victim.GetVelocity()
+	damagePosition += (Length( victimVelocity ) * 0.15) * Normalize( victimVelocity )
+	vector fxOffset = damagePosition - victim.GetOrigin()
+	StartParticleEffectOnEntityWithPos( victim, fxId, FX_PATTACH_ABSORIGIN_FOLLOW, -1, damagePosition - victim.GetOrigin(), <0, 0, 0> )
+}
+
+void function KillShotBloodSpray( entity player, entity victim, vector damagePosition, bool isExplosion, bool isBullet, bool isShotgun )
+{
+	if ( IsSoftenedLocale() )
+		return
+
+	if ( !victim.IsHuman() && !IsProwler( victim ) )
+		return
+
+	if ( victim.IsMechanical() )
+		return
+
+	if ( victim.IsHologram() )
+		return
+
+	if ( !isExplosion && !isBullet && !isShotgun )
+		return
+
+	int fxId = GetParticleSystemIndex( FX_KILLSHOT_BLOODSPRAY )
+
+	vector victimVelocity = victim.GetVelocity()
+	damagePosition += (Length( victimVelocity ) * 0.15) * Normalize( victimVelocity )
+	StartParticleEffectOnEntityWithPos( victim, fxId, FX_PATTACH_ABSORIGIN_FOLLOW, -1, damagePosition - victim.GetOrigin(), <0, 0, 0> )
+}
+
+void function BloodSprayDecals( entity player, entity victim, vector damagePosition, float damageAmount, bool isHeadShot, bool isKillShot, bool isMelee, bool isExplosion, bool isBullet, bool isShotgun )
+{
+	if ( IsSoftenedLocale() || !Flag( "EnableBloodSprayDecals" ) )
+		return
+
+	if ( !victim.IsHuman() && !IsProwler( victim ) )
+		return
+
+	if ( victim.IsMechanical() )
+		return
+
+	if ( victim.IsHologram() )
+		return
+
+	if ( !isMelee && !isExplosion && !isBullet && !isShotgun )
+		return
+
+	// in MP, too expensive to do on every shot
+	if ( IsMultiplayer() && !isKillShot )
+		return
+
+	thread BloodSprayDecals_Think( player, victim, damagePosition, damageAmount, isHeadShot, isKillShot, isMelee, isExplosion, isBullet, isShotgun )
+}
+
+void function BloodSprayDecals_Think( entity player, entity victim, vector damagePosition, float damageAmount, bool isHeadShot, bool isKillShot, bool isMelee, bool isExplosion, bool isBullet, bool isShotgun )
+{
+	player.EndSignal( "OnDestroy" )
+	victim.EndSignal( "OnDestroy" )
+
+	BloodDecalParams params = BloodDecal_GetParams( damageAmount, isHeadShot, isKillShot, isMelee, isExplosion, isBullet, isShotgun )
+	float traceDist = params.traceDist
+	float secondaryTraceDist = params.secondaryTraceDist
+	asset fxType = params.fxType
+	asset secondaryFxType = params.secondaryFxType
+
+	int fxId = GetParticleSystemIndex( fxType )
+
+	// PRIMARY TRACES
+	vector traceStart = damagePosition
+	vector traceFwd = player.GetViewVector()
+
+	if ( isExplosion || isMelee )
+	{
+		// for explosion/melee damage, use chest instead of actual damage position
+		int attachID = victim.LookupAttachment( "CHESTFOCUS" )
+		traceStart = victim.GetAttachmentOrigin( attachID )
+
+		if ( isExplosion )
+			traceFwd = AnglesToForward( victim.GetAngles() ) * -1
+	}
+
+	vector traceEnd = damagePosition + (traceFwd * traceDist)
+	//TraceResults traceResult = TraceLine( traceStart, traceEnd, victim, TRACE_MASK_SHOT, TRACE_COLLISION_GROUP_NONE )
+
+	var deferredTrace_primary = DeferredTraceLineHighDetail( traceStart, traceEnd, victim, TRACE_MASK_SHOT, TRACE_COLLISION_GROUP_NONE )
+
+	while( !IsDeferredTraceFinished( deferredTrace_primary ) )
+		WaitFrame()
+
+	TraceResults traceResult = GetDeferredTraceResult( deferredTrace_primary )
+
+	vector primaryTraceEndPos = traceResult.endPos
+	vector primaryTraceNormal = traceResult.surfaceNormal
+	//DebugDrawLine( traceStart, traceEnd, 255, 150, 0, true, 5 )
+	//DebugDrawSphere( primaryTraceEndPos, 8.0, 255, 0, 0, true, 5 )
+
+	bool doGravitySplat = isMelee ? false : true
+
+	if ( traceResult.fraction < 1.0 )
+	{
+		vector normAng = VectorToAngles( traceResult.surfaceNormal )
+		vector fxAng = AnglesCompose( normAng, < 90, 0, 0 > )
+
+		StartParticleEffectInWorld( fxId, primaryTraceEndPos, fxAng )
+		//DebugDrawAngles( endPos, fxAng, 5 )
+	}
+	else if ( doGravitySplat )
+	{
+		// trace behind the guy on the ground and put a decal there
+		float gravitySplatBackTraceDist = 58.0  // how far behind the guy to put the gravity splat
+		float gravitySplatDownTraceDist = 100.0  // max dist vertically to try to trace and put a gravity splat
+		vector groundTraceStartPos = damagePosition + (traceFwd * gravitySplatBackTraceDist)
+		vector groundTraceEndPos = groundTraceStartPos - <0, 0, 100>
+
+		var deferredTrace_gravitySplat = DeferredTraceLineHighDetail( groundTraceStartPos, groundTraceEndPos, victim, TRACE_MASK_SHOT, TRACE_COLLISION_GROUP_NONE )
+
+		while( !IsDeferredTraceFinished( deferredTrace_gravitySplat ) )
+			WaitFrame()
+
+		TraceResults downTraceResult = GetDeferredTraceResult( deferredTrace_gravitySplat )
+
+		if ( downTraceResult.fraction < 1.0 )
+		{
+			//DebugDrawLine( groundTraceStartPos, downTraceResult.endPos, 255, 150, 0, true, 5 )
+			//DebugDrawSphere( downTraceResult.endPos, 4.0, 255, 0, 0, true, 5 )
+
+			vector normAng = VectorToAngles( downTraceResult.surfaceNormal )
+			vector fxAng = AnglesCompose( normAng, < 90, 0, 0 > )
+
+			//DebugDrawAngles( downTraceResult.endPos, fxAng, 5 )
+
+			StartParticleEffectInWorld( fxId, downTraceResult.endPos, fxAng )
+		}
+	}
+
+	// MP doesn't want secondaries, too expensive
+	if ( IsMultiplayer() )
+		return
+
+	// SECONDARY TRACES
+	array<vector> testVecs = []
+	vector tempAng = VectorToAngles( traceFwd )
+
+	if ( isExplosion )
+	{
+		// for explosions, different & more angles for secondary splatter
+		testVecs.append( AnglesToRight( tempAng ) )
+		testVecs.append( AnglesToRight( tempAng ) * -1 )
+		testVecs.append( traceFwd * -1 )
+		testVecs.append( AnglesToUp( tempAng ) )
+		testVecs.append( AnglesToUp( tempAng ) * -1 )
+	}
+	else
+	{
+		// mostly to cover edge cases involving corners
+		vector traceRight = AnglesToRight( tempAng )
+		vector traceLeft = traceRight * -1
+		vector backLeft = (traceFwd + traceLeft) * 0.5
+		vector backRight = (traceFwd + traceRight) * 0.5
+		testVecs.append( backRight )
+		testVecs.append( backLeft )
+
+		// add blood on the ground for these weapons too
+		if ( isBullet || isShotgun )
+			testVecs.append( AnglesToUp( tempAng ) * -1 )
+	}
+
+	if ( !testVecs.len() )
+		return
+
+	array<var> secondaryDeferredTraces = []
+	foreach ( testVec in testVecs )
+	{
+		vector secondaryTraceEnd = traceStart + (testVec * secondaryTraceDist)
+		var secondaryDeferredTrace = DeferredTraceLineHighDetail( traceStart, secondaryTraceEnd, victim, TRACE_MASK_SHOT, TRACE_COLLISION_GROUP_NONE )
+		secondaryDeferredTraces.append( secondaryDeferredTrace )
+	}
+
+	int secondaryFxId = GetParticleSystemIndex( secondaryFxType )
+
+	float startTime = Time()
+	array<var> processedResults = []
+	while ( processedResults.len() < secondaryDeferredTraces.len() )
+	{
+		WaitFrame()
+
+		foreach ( deferredTrace in secondaryDeferredTraces )
+		{
+			if ( processedResults.contains( deferredTrace ) )
+				continue
+
+			if ( !IsDeferredTraceFinished( deferredTrace ) )
+				continue
+
+			processedResults.append( deferredTrace )
+
+			TraceResults traceResult = GetDeferredTraceResult( deferredTrace )
+
+			if ( traceResult.fraction == 1.0 )
+				continue
+
+			// don't put secondaries on the same wall as the primary
+			vector secondaryTraceNormal = traceResult.surfaceNormal
+			if ( primaryTraceNormal == secondaryTraceNormal )
+				continue
+
+			vector normAng = VectorToAngles( secondaryTraceNormal )
+			vector fxAng = AnglesCompose( normAng, < 90, 0, 0 > )
+
+			vector endPos = traceResult.endPos
+			//DebugDrawSphere( endPos, 4.0, 255, 0, 0, true, 5 )
+			StartParticleEffectInWorld( secondaryFxId, endPos, fxAng )
+		}
+
+		// timeout if traces aren't returning
+		if ( Time() - startTime >= 0.3 )
+			return
+	}
+}
+
+BloodDecalParams function BloodDecal_GetParams( float damageAmount, bool isHeadShot, bool isKillShot, bool isMelee, bool isExplosion, bool isBullet, bool isShotgun )
+{
+	// default: bullet damage
+	float traceDist = 175
+	float secondaryTraceDist = 100
+	asset fxType = FX_BLOODSPRAY_DECAL_SML
+	asset secondaryFxType = FX_BLOODSPRAY_DECAL_SML
+
+	if ( isBullet )
+	{
+		// HACK- shotguns report isBullet also
+		if ( isShotgun )
+		{
+			//if ( isKillShot )
+			//	fxType = FX_BLOODSPRAY_DECAL_LRG
+			//else
+			fxType = FX_BLOODSPRAY_DECAL_MED
+		}
+		else
+		{
+			if ( isKillShot )
+				fxType = FX_BLOODSPRAY_DECAL_MED
+			else
+				fxType = FX_BLOODSPRAY_DECAL_SML
+
+			if ( damageAmount >= 200 )
+			{
+				traceDist = 216
+				fxType = FX_BLOODSPRAY_DECAL_LRG
+				secondaryFxType = FX_BLOODSPRAY_DECAL_MED
+			}
+		}
+	}
+
+	else if ( isExplosion )
+	{
+		secondaryTraceDist = traceDist
+
+		float maxDmg = 100
+		float medDmg = 75
+
+		if ( damageAmount >= maxDmg )
+		{
+			fxType = FX_BLOODSPRAY_DECAL_LRG
+			secondaryFxType = FX_BLOODSPRAY_DECAL_LRG
+		}
+		else if ( damageAmount >= medDmg )
+		{
+			fxType = FX_BLOODSPRAY_DECAL_LRG
+			secondaryFxType = FX_BLOODSPRAY_DECAL_MED
+		}
+		else if ( isKillShot )
+		{
+			fxType = FX_BLOODSPRAY_DECAL_MED
+			secondaryFxType = FX_BLOODSPRAY_DECAL_MED
+		}
+	}
+
+	else if ( isMelee )
+	{
+		traceDist = 96
+
+		if ( isKillShot )
+			fxType = FX_BLOODSPRAY_DECAL_MED
+	}
+
+	// for kills, increase trace distance a bit
+	if ( isKillShot )
+	{
+		traceDist = traceDist + (traceDist * 0.1)
+		secondaryTraceDist = secondaryTraceDist + (secondaryTraceDist * 0.1)
+	}
+
+	BloodDecalParams params
+	params.traceDist = traceDist
+	params.secondaryTraceDist = secondaryTraceDist
+	params.fxType = fxType
+	params.secondaryFxType = secondaryFxType
+	return params
+}
+
+#if DEV
+string function BloodSprayDecals_Toggle()
+{
+	string returnStr = ""
+
+	if ( Flag( "EnableBloodSprayDecals" ) )
+	{
+		FlagClear( "EnableBloodSprayDecals" )
+		returnStr = "Blood spray decals DISABLED"
+	}
+	else
+	{
+		FlagSet( "EnableBloodSprayDecals" )
+		returnStr = "Blood spray decals ENABLED"
+	}
+
+	return returnStr
+}
+#endif
+
+function ServerCallback_RodeoerEjectWarning( soulHandle, ejectTime )
+{
+	entity soul = GetEntityFromEncodedEHandle( soulHandle )
+
+	if ( !IsValid( soul ) )
+		return
+
+	thread TitanEjectHatchSequence( soul, ejectTime )
+}
+
+function TitanEjectHatchSequence( soul, ejectTime )
+{
+	expect entity( soul )
+
+	soul.EndSignal( "OnSoulTransfer" )
+	soul.EndSignal( "OnTitanDeath" )
+	soul.EndSignal( "OnDestroy" )
+
+	local effects = []
+
+	OnThreadEnd(
+		function() : ( effects )
+		{
+			foreach ( effect in effects )
+			{
+				if ( !EffectDoesExist( effect ) )
+					continue
+
+				EffectStop( effect, true, true )
+			}
+		}
+	)
+
+	int boltCount = 6
+	int fxID = GetParticleSystemIndex( $"xo_spark_bolt" )
+
+	for ( int index = 0; index < boltCount; index++ )
+	{
+		entity titan = soul.GetTitan()
+
+		WaitEndFrame() // so OnTitanDeath/Destroy can happen
+
+		if ( !IsAlive( titan ) )
+			return
+
+		if ( !titan.IsTitan() )
+		{
+			printt( "WARNING: " + titan + " is not a Titan!" )
+			return
+		}
+
+		int attachID = titan.LookupAttachment( "HATCH_BOLT" + (index + 1) )
+		//printt( "attachID is " + attachID )
+		vector boltOrgin = titan.GetAttachmentOrigin( attachID )
+		vector boltAngles = titan.GetAttachmentAngles( attachID )
+		vector launchVec = AnglesToForward( boltAngles ) * 500
+
+		CreateClientsideGib( $"models/industrial/bolt_tiny01.mdl", boltOrgin, boltAngles, launchVec, < 0, 0, 0 >, 3.0, 1000.0, 200.0 )
+		int effect = PlayFXOnTag( titan, fxID, attachID )
+		effects.append( effect )
+		EmitSoundOnEntity( titan, "titan_bolt_loose" )
+
+		wait (ejectTime / boltCount)
+	}
+}
+
+void function ServerCallback_OnEntityKilled( attackerEHandle, victimEHandle, int scriptDamageType, damageSourceId )
+{
+	expect int( damageSourceId )
+
+	bool isHeadShot = (scriptDamageType & DF_HEADSHOT) > 0
+
+	entity victim = GetEntityFromEncodedEHandle( victimEHandle )
+	entity attacker = attackerEHandle ? GetHeavyWeightEntityFromEncodedEHandle( attackerEHandle ) : null
+	entity localClientPlayer = GetLocalClientPlayer()
+
+	if ( !IsValid( victim ) )
+		return
+
+	Signal( victim, "OnDeath" )
+
+	if ( victim == localClientPlayer )
+	{
+		victim.cv.deathOrigin = victim.GetOrigin()
+		level.clientsLastKiller = attacker
+	}
+
+	if ( damageSourceId == eDamageSourceId.indoor_inferno )
+	{
+		if ( victim == localClientPlayer )
+			thread PlayerFieryDeath( victim )
+	}
+
+	UpdatePlayerStatusCounts()
+
+	if ( IsValid( attacker ) && attacker.IsPlayer() )
+	{
+		PlayTargetEliminatedTitanVO( attacker, victim )
+
+		if ( attacker == GetLocalViewPlayer() )
+			WeaponFlyoutRefresh() // refreshes to display xp gained from kills
+	}
+	else if ( victim.IsPlayer() )
+	{
+		if ( ("latestAssistTime" in victim.s) && victim.s.latestAssistTime >= Time() - MAX_NPC_KILL_STEAL_PREVENTION_TIME )
+		{
+			attacker = expect entity( victim.s.latestAssistPlayer )
+			damageSourceId = expect int( victim.s.latestAssistDamageSource )
+		}
+	}
+
+	if ( victim.IsPlayer() && victim != attacker )
+	{
+		if ( attacker == localClientPlayer )
+		{
+			thread PlayKillConfirmedSound( "Pilot_Killed_Indicator" )
+		}
+		else if ( IsValid( attacker ) && attacker.IsTitan() )
+		{
+			entity bossPlayer = attacker.GetBossPlayer()
+			if ( bossPlayer && bossPlayer == localClientPlayer )
+				thread PlayKillConfirmedSound( "Pilot_Killed_Indicator" )
+		}
+	}
+	else if ( (IsGrunt( victim ) || IsSpectre( victim )) && attacker == localClientPlayer )
+	{
+		thread PlayKillConfirmedSound( "HUD_Grunt_Killed_Indicator" )
+	}
+
+	//if it's an auto titan, the obit was already printed when doomed
+	if ( (victim.IsTitan()) && (!victim.IsPlayer()) )
+		return
+
+	Obituary( attacker, "", victim, scriptDamageType, damageSourceId, isHeadShot )
+}
+
+
+const float KILL_CONFIRM_DEBOUNCE = 0.025
+void function PlayKillConfirmedSound( string sound )
+{
+	while ( true )
+	{
+		if ( Time() - clGlobal.lastKillConfirmTime > KILL_CONFIRM_DEBOUNCE )
+		{
+			clGlobal.lastKillConfirmTime = Time()
+			EmitSoundOnEntity( GetLocalClientPlayer(), sound )
+			return
+		}
+
+		WaitFrame()
+	}
+}
+
+void function ServerCallback_OnTitanKilled( int attackerEHandle, int victimEHandle, int scriptDamageType, int damageSourceId )
+{
+	//Gets run on every client whenever a titan is doomed by another player
+	bool isHeadShot = false
+	entity attacker = attackerEHandle != -1 ? GetEntityFromEncodedEHandle( attackerEHandle ) : null
+	entity victim = GetEntityFromEncodedEHandle( victimEHandle )
+
+	if ( (!IsValid( victim )) || (!IsValid( attacker )) )
+		return
+
+	//Obit: titans get scored/obits when doomed, so we don't want to just see "Player" in the obit, we want to see "Player's Titan"
+	bool victimIsOwnedTitan = victim.IsPlayer()
+	Obituary( attacker, "", victim, scriptDamageType, damageSourceId, isHeadShot, victimIsOwnedTitan )
+}
+
+function PlayTargetEliminatedTitanVO( attacker, victim )
+{
+	entity localPlayer = GetLocalViewPlayer()
+
+	if ( attacker != localPlayer )
+		return
+
+	if ( !victim.IsPlayer() )
+		return
+
+	if ( victim.IsTitan() )
+	{
+		// a bit more delay for a titan explosion to clear
+		thread TitanCockpit_PlayDialogDelayed( localPlayer, 1.3, "elimTarget" )
+	}
+	else
+	{
+		thread TitanCockpit_PlayDialogDelayed( localPlayer, 0.8, "elimEnemyPilot" )
+	}
+}
+
+function ServerCallback_SetAssistInformation( damageSourceId, attackerEHandle, entityEHandle, assistTime )
+{
+	local ent = GetHeavyWeightEntityFromEncodedEHandle( entityEHandle )
+	if ( !ent )
+		return
+
+	local latestAssistPlayer = GetEntityFromEncodedEHandle ( attackerEHandle )
+	if ( !("latestAssistPlayer" in ent.s) )
+	{
+		ent.s.latestAssistPlayer <- latestAssistPlayer
+		ent.s.latestAssistDamageSource <- damageSourceId
+		ent.s.latestAssistTime <- assistTime
+	}
+	else
+	{
+		ent.s.latestAssistPlayer = latestAssistPlayer
+		ent.s.latestAssistDamageSource = damageSourceId
+		ent.s.latestAssistTime = assistTime
+	}
+}
+
+void function ClientCodeCallback_OnModelChanged( entity ent )
+{
+/*
+	// OnModelChanged gets called for each model change, but gets processed after the model has done all switches
+
+	if ( !IsValid( ent ) )
+		return;
+
+	if ( !("creationCount" in ent.s) )
+		return;
+
+	Assert( ent instanceof C_BaseAnimating );
+*/
+}
+
+
+void function ClientCodeCallback_OnHealthChanged( entity ent, int oldHealth, int newHealth )
+{
+	if ( IsLobby() )
+		return
+
+	entity player = GetLocalViewPlayer()
+	if ( !IsValid( player ) )
+		return
+
+	if ( !IsValid( ent ) )
+		return
+
+	ent.Signal( "HealthChanged", { oldHealth = oldHealth, newHealth = newHealth } )
+}
+
+void function ClientCodeCallback_OnCrosshairCurrentTargetChanged( entity player, entity newTarget )
+{
+	if ( IsLobby() )
+		return;
+	if ( !IsValid( player ) )
+		return
+
+	if ( IsValid( newTarget ) )
+		TryOfferRodeoBatteryHint( newTarget )
+}
+
+void function SetupPlayerAnimEvents( entity player )
+{
+	SetupPlayerJumpJetAnimEvents( player )
+	AddAnimEvent( player, "WallHangAttachDataKnife", WallHangAttachDataKnife )
+}
+
+void function JumpRandomlyForever()
+{
+	for (;; )
+	{
+		if ( IsWatchingReplay() )
+		{
+			wait 1
+			continue
+		}
+
+		entity player = GetLocalClientPlayer()
+		if ( !IsAlive( player ) || player != GetLocalViewPlayer() )
+		{
+			wait 1
+			continue
+		}
+
+		printt( "jump!" )
+		player.ClientCommand( "+jump" )
+		wait 0
+		player.ClientCommand( "-jump" )
+
+		wait RandomFloatRange( 0.2, 1.1 )
+	}
+}
+
+void function RemoteTurretFadeoutAnimEvent( entity ent )
+{
+	entity player = GetLocalViewPlayer()
+	ScreenFade( player, 0, 0, 0, 255, 0.1, 0.25, FFADE_OUT );
+}
+
+void function SetupFirstPersonProxyEvents( entity firstPersonProxy )
+{
+	//printt( "SetupFirstPersonProxyEvents" )
+
+	AddAnimEvent( firstPersonProxy, "mantle_smallmantle", OnSmallMantle )
+	AddAnimEvent( firstPersonProxy, "mantle_mediummantle", OnMediumMantle )
+	AddAnimEvent( firstPersonProxy, "mantle_lowmantle", OnLowMantle )
+	AddAnimEvent( firstPersonProxy, "mantle_extralowmantle", OnExtraLowMantle )
+	AddAnimEvent( firstPersonProxy, "remoteturret_fadeout", RemoteTurretFadeoutAnimEvent )
+}
+
+void function OnSmallMantle( entity firstPersonProxy ) //Was set up in script instead of anim to be able to play quieter sounds with stealth passive. No longer needed, but more work to move inside of anim
+{
+	entity player = GetLocalViewPlayer()
+	EmitSoundOnEntity( firstPersonProxy, "mantle_smallmantle" )
+}
+
+void function OnMediumMantle( entity firstPersonProxy ) //Was set up in script instead of anim to be able to play quieter sounds with stealth passive. No longer needed, but more work to move inside of anim
+{
+	entity player = GetLocalViewPlayer()
+	EmitSoundOnEntity( firstPersonProxy, "mantle_mediummantle" )
+}
+
+void function OnLowMantle( entity firstPersonProxy ) //Was set up in script instead of anim to be able to play quieter sounds with stealth passive. No longer needed, but more work to move inside of anim
+{
+	entity player = GetLocalViewPlayer()
+	EmitSoundOnEntity( firstPersonProxy, "mantle_lowmantle" )
+}
+
+void function OnExtraLowMantle( entity firstPersonProxy ) //Was set up in script instead of anim to be able to play quieter sounds with stealth passive. No longer needed, but more work to move inside of anim
+{
+	entity player = GetLocalViewPlayer()
+	EmitSoundOnEntity( firstPersonProxy, "mantle_extralow" )
+}
+
+void function CreateCallback_TitanSoul( entity ent )
+{
+}
+
+bool function ShouldHideRespawnSelectionText( entity player )
+{
+	if ( player != GetLocalClientPlayer() )
+		return false
+	if ( player.GetPlayerClass() != "spectator" )
+		return false
+	if ( IsWatchingReplay() )
+		return false
+
+	return true
+}
+
+
+
+void function WallHangAttachDataKnife( entity player )
+{
+	int attachIdx = player.LookupAttachment( "l_hand" )
+	if ( attachIdx == 0 )
+		// hack while i wait for the attachment to be fixed
+		return
+
+	entity dataknife = CreateClientSidePropDynamic( player.GetAttachmentOrigin( attachIdx ), player.GetAttachmentAngles( attachIdx ), DATA_KNIFE_MODEL )
+	dataknife.SetParent( player, "l_hand" )
+
+	thread DeleteDataKnifeAfterWallHang( player, dataknife )
+}
+
+void function DeleteDataKnifeAfterWallHang( entity player, entity dataknife )
+{
+	OnThreadEnd(
+		function() : ( dataknife )
+		{
+			if ( IsValid( dataknife ) )
+				dataknife.Kill_Deprecated_UseDestroyInstead()
+		}
+	)
+
+	player.EndSignal( "OnDeath" )
+	player.EndSignal( "OnDestroy" )
+
+	for (;; )
+	{
+		Wait( 0.1 )
+		if ( !player.IsWallHanging() )
+			break
+	}
+}
+
+bool function ClientCodeCallback_OnGib( entity victim, vector attackDir )
+{
+	if ( !victim.IsMechanical() )
+		return SpawnFleshGibs( victim, attackDir )
+
+	return false
+}
+
+bool function SpawnFleshGibs( entity victim, vector attackDir )
+{
+	asset modelName = $"models/gibs/human_gibs.mdl"
+	attackDir = Normalize( attackDir )
+
+	float cullDist = 2048.0
+	if ( "gibDist" in victim.s )
+		cullDist = expect float( victim.s.gibDist )
+
+	vector startOrigin = victim.GetWorldSpaceCenter() + (attackDir * -30)
+
+	vector origin = victim.GetOrigin() + < RandomIntRange( 10, 20 ), RandomIntRange( 10, 20 ), RandomIntRange( 32, 64 ) >
+	vector angles = < 0, 0, 0 >
+	vector flingDir = attackDir * RandomIntRange( 80, 200 )
+
+	int fxID
+	bool isSoftenedLocale = IsSoftenedLocale()
+
+	if ( isSoftenedLocale )
+	{
+		if ( victim.GetModelName() == FLYER_MODEL )
+			fxID = StartParticleEffectOnEntity( victim, GetParticleSystemIndex( $"death_pinkmist_LG_nochunk" ), FX_PATTACH_ABSORIGIN_FOLLOW, 0 )
+		else
+			fxID = StartParticleEffectOnEntity( victim, GetParticleSystemIndex( $"death_pinkmist_nochunk" ), FX_PATTACH_ABSORIGIN_FOLLOW, 0 )
+	}
+	else
+	{
+		if ( victim.GetModelName() == FLYER_MODEL )
+			fxID = StartParticleEffectOnEntity( victim, GetParticleSystemIndex( $"death_pinkmist_LG" ), FX_PATTACH_ABSORIGIN_FOLLOW, 0 )
+		else
+			fxID = StartParticleEffectOnEntity( victim, GetParticleSystemIndex( $"death_pinkmist" ), FX_PATTACH_ABSORIGIN_FOLLOW, 0 )
+	}
+
+	EffectSetControlPointVector( fxID, 1, flingDir )
+
+	if ( isSoftenedLocale )
+		return true
+
+	vector angularVel = < 0, 0, 0 >
+	float lifeTime = 10.0
+	CreateClientsideGibWithBodyGroupGibs( modelName, victim.GetOrigin(), angles, attackDir, angularVel, lifeTime, cullDist, 1024 )
+
+	return true
+}
+
+function ServerCallback_PlayScreenFXWarpJump()
+{
+	if ( IsWatchingReplay() )
+		return false
+
+	thread PlayScreenFXWarpJump( GetLocalClientPlayer() )
+}
+
+void function PlayScreenFXWarpJump( entity clientPlayer )
+{
+	clientPlayer.EndSignal( "OnDeath" )
+	clientPlayer.EndSignal( "OnDestroy" )
+
+	entity player = GetLocalViewPlayer()
+	int index = GetParticleSystemIndex( SCREENFX_WARPJUMP )
+	int indexD = GetParticleSystemIndex( SCREENFX_WARPJUMPDLIGHT )
+	int fxID = StartParticleEffectInWorldWithHandle( index, < 0, 0, 0 >, < 0, 0, 0 > )
+	int fxID2 = -1
+	if ( IsValid( player.GetCockpit() ) )
+	{
+		fxID2 = StartParticleEffectOnEntity( player, indexD, FX_PATTACH_POINT_FOLLOW, player.GetCockpit().LookupAttachment( "CAMERA" ) )
+		EffectSetIsWithCockpit( fxID2, true )
+	}
+
+	OnThreadEnd(
+		function() : ( clientPlayer, fxID, fxID2 )
+		{
+			if ( IsValid( clientPlayer ) && !IsAlive( clientPlayer ) )
+			{
+				EffectStop( fxID, true, false )
+				if ( fxID2 > -1 )
+					EffectStop( fxID2, true, false )
+			}
+		}
+	)
+
+	wait 3.2
+	if ( IsValid( player.GetCockpit() ) )
+		thread TonemappingUpdateAfterWarpJump()
+}
+
+const EXPOSURE_RAMPDOWN_DURATION = 2
+const EXPOSURE_RAMPDOWN_MAX = 20
+const EXPOSURE_RAMPDOWN_MIN = 0
+const MAX_RAMPDOWN_DURATION = 5
+const MAX_RAMPDOWN_MAX = 3
+const MAX_RAMPDOWN_MIN = 1
+
+function TonemappingUpdateAfterWarpJump()
+{
+	// Turn cubemaps black inside drop ship, since it's pretty dark in there anyway and we don't have a great way to take a valid cubemap shot for that location.
+	SetConVarFloat( "mat_envmap_scale", 0 );
+
+	AutoExposureSetMaxExposureMultiplier( 500 ); // allow exposure to actually go bright, even if it's clamped in the level.
+
+	// Start the exposure super bright behind the white FX, and ramp it down quickly to normal.
+	local startTime = Time()
+	while( 1 )
+	{
+		local time = Time() - startTime
+		float factor = GraphCapped( time, 0, EXPOSURE_RAMPDOWN_DURATION, 1, 0 )
+		local toneMapScale = EXPOSURE_RAMPDOWN_MIN + (EXPOSURE_RAMPDOWN_MAX - EXPOSURE_RAMPDOWN_MIN) * factor * factor * factor * factor
+		AutoExposureSetExposureCompensationBias( toneMapScale )
+		AutoExposureSnap()
+		wait  0
+		if ( factor == 0 )
+			break;
+	}
+
+	// Ramp the max exposure multiplier back down to 1 gently
+	startTime = Time()
+	while( 1 )
+	{
+		local time = Time() - startTime
+		float factor = GraphCapped( time, 0, MAX_RAMPDOWN_DURATION, 1, 0 )
+		local scale = MAX_RAMPDOWN_MIN + (MAX_RAMPDOWN_MAX - MAX_RAMPDOWN_MIN) * factor * factor
+		AutoExposureSetMaxExposureMultiplier( scale );
+		wait  0
+		if ( factor == 0 )
+			break;
+	}
+}
+
+function SetPanelAlphaOverTime( panel, alpha, duration )
+{
+	// HACK this should be a code command - Mackey
+	Signal( panel, "PanelAlphaOverTime" )
+	EndSignal( panel, "PanelAlphaOverTime" )
+	EndSignal( panel, "OnDestroy" )
+
+	local startTime = Time()
+	local endTime = startTime + duration
+	local startAlpha = panel.GetPanelAlpha()
+
+	while( Time() <= endTime )
+	{
+		float a = GraphCapped( Time(), startTime, endTime, startAlpha, alpha )
+		panel.SetPanelAlpha( a )
+		WaitFrame()
+	}
+
+	panel.SetPanelAlpha( alpha )
+}
+
+
+
+function HandleDoomedState( entity player, entity titan )
+{
+	bool isDoomed = GetDoomedState( titan )
+	if ( isDoomed )
+	{
+		titan.Signal( "Doomed" )
+
+		if ( HasSoul( titan ) )
+		{
+			entity soul = titan.GetTitanSoul()
+			soul.Signal( "Doomed" )
+		}
+	}
+}
+
+const asset SHIELD_BREAK_FX = $"P_xo_armor_break_CP"
+function PlayShieldBreakEffect( entity ent )
+{
+	entity shieldEnt = ent
+	if ( IsSoul( ent ) )
+	{
+		shieldEnt = ent.GetTitan()
+		if ( !shieldEnt )
+			return
+	}
+
+	float shieldHealthFrac = GetShieldHealthFrac( shieldEnt )
+
+	int shieldBreakFX = GetParticleSystemIndex( SHIELD_BREAK_FX )
+
+	local attachID
+	if ( shieldEnt.IsTitan() )
+		attachID = shieldEnt.LookupAttachment( "exp_torso_main" )
+	else
+		attachID = shieldEnt.LookupAttachment( "ref" ) // TEMP
+
+	local shieldFXHandle = StartParticleEffectOnEntity( shieldEnt, shieldBreakFX, FX_PATTACH_POINT_FOLLOW, attachID )
+	EffectSetControlPointVector( shieldFXHandle, 1, GetShieldEffectCurrentColor( 1 - shieldHealthFrac ) )
+}
+
+function PlayShieldActivateEffect( entity ent )
+{
+	entity shieldEnt = ent
+	if ( IsSoul( ent ) )
+	{
+		shieldEnt = ent.GetTitan()
+		if ( !shieldEnt )
+			return
+	}
+
+	float shieldHealthFrac = GetShieldHealthFrac( shieldEnt )
+
+	int shieldBreakFX = GetParticleSystemIndex( SHIELD_BREAK_FX )
+
+	local attachID
+	if ( shieldEnt.IsTitan() )
+		attachID = shieldEnt.LookupAttachment( "exp_torso_main" )
+	else
+		attachID = shieldEnt.LookupAttachment( "ref" ) // TEMP
+
+	local shieldFXHandle = StartParticleEffectOnEntity( shieldEnt, shieldBreakFX, FX_PATTACH_POINT_FOLLOW, attachID )
+	EffectSetControlPointVector( shieldFXHandle, 1, GetShieldEffectCurrentColor( 1 - shieldHealthFrac ) )
+}
+
+function PlayIt( entity victim )
+{
+	float shieldHealthFrac = GetShieldHealthFrac( victim )
+
+	int shieldbodyFX = GetParticleSystemIndex( SHIELD_BODY_FX )
+	local attachID
+	if ( victim.IsTitan() )
+		attachID = victim.LookupAttachment( "exp_torso_main" )
+	else
+		attachID = victim.LookupAttachment( "ref" ) // TEMP
+
+	local shieldFXHandle = StartParticleEffectOnEntity( victim, shieldbodyFX, FX_PATTACH_POINT_FOLLOW, attachID )
+
+	EffectSetControlPointVector( shieldFXHandle, 1, GetShieldEffectCurrentColor( 1 - shieldHealthFrac ) )
+}
+
+function PlayShieldHitEffect( PlayerDidDamageParams params )
+{
+	entity player = GetLocalViewPlayer()
+	entity victim = params.victim
+	//vector damagePosition = params.damagePosition
+	//int hitBox = params.hitBox
+	//int damageType = params.damageType
+	//float damageAmount = params.damageAmount
+	//int damageFlags = params.damageFlags
+	//int hitGroup = params.hitGroup
+	//entity weapon = params.weapon
+	//float distanceFromAttackOrigin = params.distanceFromAttackOrigin
+
+	//shieldFX <- GetParticleSystemIndex( SHIELD_FX )
+	//StartParticleEffectInWorld( shieldFX, damagePosition, player.GetViewVector() * -1 )
+
+	float shieldHealthFrac = GetShieldHealthFrac( victim )
+
+	int shieldbodyFX = GetParticleSystemIndex( SHIELD_BODY_FX )
+	local attachID
+	if ( victim.IsTitan() )
+		attachID = victim.LookupAttachment( "exp_torso_main" )
+	else
+		attachID = victim.LookupAttachment( "ref" ) // TEMP
+
+	local shieldFXHandle = StartParticleEffectOnEntity( victim, shieldbodyFX, FX_PATTACH_POINT_FOLLOW, attachID )
+
+	EffectSetControlPointVector( shieldFXHandle, 1, GetShieldEffectCurrentColor( 1 - shieldHealthFrac ) )
+}
+
+const table SHIELD_COLOR_CHARGE_FULL = { r = 115, g = 247, b = 255 }    // blue
+const table SHIELD_COLOR_CHARGE_MED  = { r = 200, g = 128, b = 80 } // orange
+const table SHIELD_COLOR_CHARGE_EMPTY = { r = 200, g = 80, b = 80 } // red
+
+const SHIELD_COLOR_CROSSOVERFRAC_FULL2MED    = 0.75  // from zero to this fraction, fade between full and medium charge colors
+const SHIELD_COLOR_CROSSOVERFRAC_MED2EMPTY    = 0.95  // from "full2med" to this fraction, fade between medium and empty charge colors
+
+function GetShieldEffectCurrentColor( shieldHealthFrac )
+{
+	local color1 = SHIELD_COLOR_CHARGE_FULL
+	local color2 = SHIELD_COLOR_CHARGE_MED
+	local color3 = SHIELD_COLOR_CHARGE_EMPTY
+
+	local crossover1 = SHIELD_COLOR_CROSSOVERFRAC_FULL2MED  // from zero to this fraction, fade between color1 and color2
+	local crossover2 = SHIELD_COLOR_CROSSOVERFRAC_MED2EMPTY  // from crossover1 to this fraction, fade between color2 and color3
+
+	local colorVec = < 0, 0, 0 >
+	// 0 = full charge, 1 = no charge remaining
+	if ( shieldHealthFrac < crossover1 )
+	{
+		colorVec.x = Graph( shieldHealthFrac, 0, crossover1, color1.r, color2.r )
+		colorVec.y = Graph( shieldHealthFrac, 0, crossover1, color1.g, color2.g )
+		colorVec.z = Graph( shieldHealthFrac, 0, crossover1, color1.b, color2.b )
+	}
+	else if ( shieldHealthFrac < crossover2 )
+	{
+		colorVec.x = Graph( shieldHealthFrac, crossover1, crossover2, color2.r, color3.r )
+		colorVec.y = Graph( shieldHealthFrac, crossover1, crossover2, color2.g, color3.g )
+		colorVec.z = Graph( shieldHealthFrac, crossover1, crossover2, color2.b, color3.b )
+	}
+	else
+	{
+		// for the last bit of overload timer, keep it max danger color
+		colorVec.x = color3.r
+		colorVec.y = color3.g
+		colorVec.z = color3.b
+	}
+
+	return colorVec
+}
+
+
+
+void function PlayPlayerDeathSound( entity player )
+{
+	if ( IsPlayerEliminated( player ) )
+		EmitSoundOnEntity( player, "player_death_begin_elimination" )
+	else
+		EmitSoundOnEntity( player, "Player_Death_Begin" )
+}
+
+void function StopPlayerDeathSound( entity player )
+{
+	StopSoundOnEntity( player, "Player_Death_Begin" )
+	EmitSoundOnEntity( player, "Player_Death_PrespawnTransition" )
+}
+
+function OnClientPlayerAlive( entity player )
+{
+	player.Signal( "OnClientPlayerAlive" ) // TEMP; this should not be necessary, but IsWatchingKillReplay is wrong
+	player.EndSignal( "OnClientPlayerAlive" )
+
+	UpdateClientHudVisibility( player )
+
+	if ( IsWatchingReplay() )
+		return
+
+	if ( GetGameState() < eGameState.Playing )
+		return
+}
+
+function OnClientPlayerDying( entity player )
+{
+	player.Signal( "OnClientPlayerDying" ) // TEMP; this should not be necessary, but IsWatchingKillReplay is wrong
+	player.EndSignal( "OnClientPlayerDying" )
+
+	entity player = GetLocalClientPlayer()
+	UpdateClientHudVisibility( player )
+//	thread ShowDeathRecap( player )
+
+	if ( IsWatchingReplay() )
+		return
+
+	player.cv.deathTime = Time()
+
+	thread DeathCamCheck( player )
+}
+
+void function ShowDeathRecap( entity player )
+{
+	Assert( player == GetLocalClientPlayer() )
+
+	DisableCallingCardEvents()
+
+	if ( player.e.recentDamageHistory.len() == 0 )
+		return
+
+	DamageHistoryStruct damageHistory = player.e.recentDamageHistory[ 0 ]
+
+	entity attacker = damageHistory.attacker
+
+	if ( !IsValid( attacker ) )
+		return
+
+	EndSignal( attacker, "OnDestroy" )
+
+	if ( !attacker.IsPlayer() )
+		return
+
+	if ( attacker.GetTeam() == player.GetTeam() )
+		return
+
+	wait( 1.0 )
+
+	CallsignEvent( eCallSignEvents.YOU, attacker, Localize( "#DEATH_SCREEN_KILLED_YOU" ) )
+}
+
+void function HideDeathRecap( entity player, var rui )
+{
+	float minDisplayTime = 6.0
+	float startTime = Time()
+
+	waitthread DeathRecapHideDelay( player )
+	wait( 0.5 )
+
+	float elapsedTime = Time() - startTime
+	if ( elapsedTime < minDisplayTime )
+		wait( minDisplayTime - elapsedTime )
+
+	RuiSetBool( rui, "playOutro", true )
+	RuiSetGameTime( rui, "outroStartTime", Time() )
+
+	EnableCallingCardEvents()
+}
+
+void function DeathRecapHideDelay( entity player )
+{
+	EndSignal( clGlobal.levelEnt, "LocalClientPlayerRespawned" )
+	EndSignal( clGlobal.levelEnt, "OnSpectatorMode" )
+
+	WaitForever()
+}
+
+void function DeathCamCheck( entity player )
+{
+	wait GetRespawnButtonCamTime( player )
+}
+
+void function ServerCallback_ShowNextSpawnMessage( float nextSpawnTime )
+{
+	entity player = GetLocalClientPlayer()
+	float camTime = GetRespawnButtonCamTime( player )
+
+	file.nextSpawnTime = nextSpawnTime
+
+	if ( nextSpawnTime > Time() + camTime )
+		thread ShowSpawnDelayMessage( nextSpawnTime )
+}
+
+
+void function ShowSpawnDelayMessage( nextSpawnTime )
+{
+	float waitTime = max( nextSpawnTime - Time(), 0 )
+
+	if ( waitTime < 1.0 )
+		return
+
+	entity player = GetLocalClientPlayer()
+
+	//player.cv.nextSpawnTimeLabel.SetAlpha( 255 )
+	//player.cv.nextSpawnTimeLabel.Show()
+	//player.cv.nextSpawnTimeLabel.SetAutoText( "#GAMEMODE_DEPLOYING_IN_N", HATT_GAME_COUNTDOWN_SECONDS, nextSpawnTime )
+	//
+	//if ( !player.cv.nextSpawnTimeLabel.IsAutoText() )
+	//	player.cv.nextSpawnTimeLabel.EnableAutoText()
+
+	while ( !IsAlive( player ) && waitTime > 0.0 )
+	{
+		waitTime = max( nextSpawnTime - Time(), 0 )
+
+		AddPlayerHint( waitTime, 0.25, $"", "#GAMEMODE_DEPLOYING_IN_N", int( waitTime ) )
+
+		wait 1.0
+	}
+}
+void function ServerCallback_HideNextSpawnMessage()
+{
+	entity player = GetLocalClientPlayer()
+
+	HidePlayerHint( "#GAMEMODE_DEPLOYING_IN_N" )
+}
+
+float function GetWaveSpawnTime()
+{
+	return (file.nextSpawnTime)
+}
+
+bool function IsPlayerEliminated( entity player )
+{
+	return (player.GetPlayerGameStat( PGS_ELIMINATED ) > 0)
+}
+
+function PlayerFieryDeath( player )
+{
+	player.EndSignal( "OnDestroy" )
+	player.EndSignal( "OnClientPlayerAlive" )
+	clGlobal.levelEnt.EndSignal( "OnSpectatorMode" )
+
+	local offset = < 0, 0, 0 >
+	if ( player.IsTitan() )
+		offset = < 0, 0, 96 >
+
+	entity scriptRef = CreatePropDynamic( $"models/dev/empty_model.mdl", player.GetOrigin() + offset, player.GetAngles() )
+	scriptRef.SetParent( player )
+
+	local fxHandle = StartParticleEffectOnEntity( scriptRef, GetParticleSystemIndex( $"P_burn_player" ), FX_PATTACH_ABSORIGIN_FOLLOW, -1 )
+
+	OnThreadEnd(
+		function () : ( fxHandle, scriptRef )
+		{
+			EffectStop( fxHandle, false, false )
+			if ( IsValid( scriptRef ) )
+				scriptRef.Destroy()
+		}
+	)
+	WaitForever()
+}
+
+
+function ServerCallback_GiveMatchLossProtection()
+{
+	clGlobal.showMatchLossProtection = true
+}
+
+void function EnableDoDeathCallback( entity ent )
+{
+	ent.DoDeathCallback( true )
+}
+
+
+
+int function UpdateSubText2ForRiffs( AnnouncementData announcement )
+{
+	array<string> riffTexts = []
+
+	if ( IsPilotEliminationBased() )
+		riffTexts.append( "#GAMESTATE_NO_RESPAWNING" )
+
+	if (  Riff_FloorIsLava() )
+		riffTexts.append( "#GAMEMODE_FLOOR_IS_LAVA_SUBTEXT2" )
+
+	if ( level.nv.minimapState == eMinimapState.Hidden )
+		riffTexts.append( "#GAMESTATE_NO_MINIMAP" )
+
+	if ( level.nv.ammoLimit == eAmmoLimit.Limited )
+		riffTexts.append( "#GAMESTATE_LIMITED_AMMUNITION" )
+
+	if ( level.nv.titanAvailability != eTitanAvailability.Default )
+	{
+		switch ( level.nv.titanAvailability )
+		{
+			case eTitanAvailability.Always:
+				riffTexts.append( "#GAMESTATE_UNLIMITED_TITANS" )
+				break
+			case eTitanAvailability.Once:
+				riffTexts.append( "#GAMESTATE_ONE_TITAN" )
+				break
+			case eTitanAvailability.Never:
+				riffTexts.append( "#GAMESTATE_NO_TITANS" )
+				break
+		}
+	}
+
+	if ( level.nv.allowNPCs != eAllowNPCs.Default )
+	{
+		switch ( level.nv.allowNPCs )
+		{
+			case eAllowNPCs.None:
+				//riffTexts.append( "#GAMESTATE_NO_MINIONS" )
+				break
+
+			case eAllowNPCs.GruntOnly:
+				riffTexts.append( "#GAMESTATE_GRUNTS_ONLY" )
+				break
+
+			case eAllowNPCs.SpectreOnly:
+				riffTexts.append( "#GAMESTATE_SPECTRES_ONLY" )
+				break
+		}
+	}
+
+	float pilotHealthMultiplier = GetCurrentPlaylistVarFloat( "pilot_health_multiplier", 0.0 )
+	if ( pilotHealthMultiplier != 0.0 && pilotHealthMultiplier <= 1.5 )
+		riffTexts.append( "#GAMESTATE_LOW_PILOT_HEALTH" )
+	else if ( pilotHealthMultiplier > 1.5 )
+		riffTexts.append( "#GAMESTATE_HIGH_PILOT_HEALTH" )
+
+	switch ( riffTexts.len() )
+	{
+		case 1:
+			Announcement_SetSubText2( announcement, riffTexts[0] )
+			break
+		case 2:
+			Announcement_SetSubText2( announcement, "#GAMEMODE_ANNOUNCEMENT_SUBTEXT_2", riffTexts[0], riffTexts[1] )
+			break
+		case 3:
+			Announcement_SetSubText2( announcement, "#GAMEMODE_ANNOUNCEMENT_SUBTEXT_3", riffTexts[0], riffTexts[1], riffTexts[2] )
+			break
+		case 4:
+			Announcement_SetSubText2( announcement, "#GAMEMODE_ANNOUNCEMENT_SUBTEXT_4", riffTexts[0], riffTexts[1], riffTexts[2], riffTexts[3] )
+			break
+		case 5:
+			Announcement_SetSubText2( announcement, "#GAMEMODE_ANNOUNCEMENT_SUBTEXT_5", riffTexts[0], riffTexts[1], riffTexts[2], riffTexts[3], riffTexts[4] )
+			break
+
+		default:
+			Announcement_SetSubText2( announcement, "", "" )
+			return 0
+	}
+
+	return riffTexts.len()
+}
+
+
+void function ServerCallback_GameModeAnnouncement()
+{
+	entity player = GetLocalClientPlayer()
+	string gameMode = GameRules_GetGameMode()
+
+	if ( GameMode_GetCustomIntroAnnouncement( gameMode ) != null )
+	{
+		void functionref(entity) func = GameMode_GetCustomIntroAnnouncement( gameMode )
+		func(player)
+		return
+	}
+
+	int team = player.GetTeam()
+
+	local totalDuration = 0.0
+
+	AnnouncementData announcement
+
+	if ( GetGameState() == eGameState.Epilogue )
+	{
+		// never gets hit??
+		announcement = Announcement_Create( "#GAMEMODE_EPILOGUE" )
+	}
+	else
+	{
+		announcement = Announcement_Create( GAMETYPE_TEXT[gameMode] )
+		announcement.announcementStyle = ANNOUNCEMENT_STYLE_BIG
+
+		Announcement_SetIcon( announcement, GAMETYPE_ICON[gameMode] )
+		Announcement_SetSubText( announcement, GAMEDESC_CURRENT )
+
+		if ( GameMode_IsDefined( gameMode ) )
+		{
+			if ( GameMode_GetAttackDesc( gameMode ) != "" && team == level.nv.attackingTeam )
+				Announcement_SetSubText( announcement, GameMode_GetAttackDesc( gameMode ) )
+
+			if ( GameMode_GetDefendDesc( gameMode ) != "" && team != level.nv.attackingTeam )
+				Announcement_SetSubText( announcement, GameMode_GetDefendDesc( gameMode ) )
+		}
+	}
+
+	int numRiffs = UpdateSubText2ForRiffs( announcement )
+	float announcementDuration = numRiffs + DEFAULT_GAMEMODE_ANNOUNCEMENT_DURATION
+	if ( gameMode == COLISEUM )
+		announcementDuration = 2.3 //JFS: Make coliseum announcement disappear with the black bars. Note that the rui fade out sequence time is a floor on how low announcementDuration can be set to
+
+	Announcement_SetDuration( announcement, announcementDuration )
+	totalDuration += announcementDuration
+
+	AnnouncementFromClass( player, announcement ) // TODO: team specific goals
+
+	if ( clGlobal.showMatchLossProtection )
+	{
+		announcementDuration = 2.0
+		totalDuration += announcementDuration
+		delaythread( announcementDuration ) DeathHintDisplay( "#LATE_JOIN_NO_LOSS" )
+	}
+	else if ( clGlobal.canShowLateJoinMessage )
+	{
+		if ( level.nv.matchProgress > 5 || GetRoundsPlayed() > 0 )
+		{
+			announcementDuration = 2.0
+			totalDuration += announcementDuration
+			delaythread( announcementDuration ) DeathHintDisplay( "#LATE_JOIN" )
+		}
+	}
+	clGlobal.showMatchLossProtection = false
+	clGlobal.canShowLateJoinMessage = false
+
+	if (  Riff_FloorIsLava() )
+	{
+		announcementDuration = 10.0
+		totalDuration += announcementDuration
+		//printt( "Total duration delayed for lava announcement: " + totalDuration )
+		delaythread( totalDuration ) PlayConversationToLocalClient( "floor_is_lava_announcement" )
+	}
+}
+
+
+function MainHud_InitScoreBars( vgui, entity player, scoreGroup )
+{
+	local hudScores = {}
+	vgui.s.scoreboardProgressBars <- hudScores
+
+	local panel = vgui.GetPanel()
+
+	hudScores.GameInfoBG 		<- scoreGroup.CreateElement( "GameInfoBG", panel )
+
+	string gameMode = GameRules_GetGameMode()
+	int friendlyTeam = player.GetTeam()
+
+	#if HAS_GAMEMODES
+	if ( IsFFAGame() )
+	{
+		return
+	}
+	#endif
+
+	int enemyTeam = friendlyTeam == TEAM_IMC ? TEAM_MILITIA : TEAM_IMC
+
+	if ( IsRoundBased() )
+	{
+		level.scoreLimit[TEAM_IMC] <- GetRoundScoreLimit_FromPlaylist()
+		level.scoreLimit[TEAM_MILITIA] <- GetRoundScoreLimit_FromPlaylist()
+	}
+	else
+	{
+		level.scoreLimit[TEAM_IMC] <- GetScoreLimit_FromPlaylist()
+		level.scoreLimit[TEAM_MILITIA] <- GetScoreLimit_FromPlaylist()
+	}
+
+	#if HAS_GAMEMODES
+	Assert( gameMode == GameRules_GetGameMode() )
+	switch ( gameMode )
+	{
+		case CAPTURE_THE_FLAG:
+			vgui.s.friendlyFlag <- scoreGroup.CreateElement( "FriendlyFlag", panel )
+			vgui.s.enemyFlag <- scoreGroup.CreateElement( "EnemyFlag", panel )
+
+			vgui.s.friendlyFlagLabel <- scoreGroup.CreateElement( "FriendlyFlagLabel", panel )
+			vgui.s.enemyFlagLabel <- scoreGroup.CreateElement( "EnemyFlagLabel", panel )
+
+			thread CaptureTheFlagThink( vgui, player )
+			break
+
+		case MARKED_FOR_DEATH:
+		case MARKED_FOR_DEATH_PRO:
+			thread MarkedForDeathHudThink( vgui, player, scoreGroup )
+			break
+	}
+	#endif
+
+	thread TitanEliminationThink( vgui, player )
+
+	thread RoundScoreThink( vgui, scoreGroup, player )
+
+	vgui.s.scoreboardProgressGroup <- scoreGroup
+
+	hudScores.GameInfoBG.Show()
+
+	local scoreboardArrays = {}
+	vgui.s.scoreboardArrays <- scoreboardArrays
+
+	//if ( ShouldUsePlayerStatusCount() ) //Can't just do PilotEliminationBased check here because it isn't set when first connecting
+	//{
+	//	//ToDo: Eventually turn it on for normal Titan count too. Need to make sure "Titan ready but not called in yet" icon doesn't get hidden by this element
+	//	hudScores.Player_Status_BG <- scoreGroup.CreateElement( "Player_Status_BG", panel )
+	//	hudScores.Player_Status_BG.Show()
+	//
+	//	CreatePlayerStatusElementsFriendly( scoreboardArrays, scoreGroup, panel )
+	//	CreatePlayerStatusElementsEnemy( scoreboardArrays, scoreGroup, panel )
+	//
+	//	thread ScoreBarsPlayerStatusThink( vgui, player, scoreboardArrays.FriendlyPlayerStatusCount, scoreboardArrays.EnemyPlayerStatusCount )
+	//}
+	//else
+	//{
+	//	hudScores.Player_Status_BG <- scoreGroup.CreateElement( "Player_Status_BG", panel )
+	//	hudScores.Player_Status_BG.Show()
+	//	thread ScoreBarsTitanCountThink( vgui, player, hudScores.FriendlyTitanCount, hudScores.FriendlyTitanReadyCount, hudScores.EnemyTitanCount )
+	//}
+
+	if ( IsWatchingReplay() )
+		vgui.s.scoreboardProgressGroup.Hide()
+
+	UpdatePlayerStatusCounts()
+
+	if ( IsSuddenDeathGameMode() )
+		thread SuddenDeathHUDThink( vgui, player )
+}
+
+function CaptureTheFlagThink( vgui, entity player )
+{
+	vgui.EndSignal( "OnDestroy" )
+
+	if ( vgui instanceof C_VGuiScreen )
+		player.EndSignal( "OnDestroy" )
+
+	vgui.s.friendlyFlag.Show()
+	vgui.s.enemyFlag.Show()
+	vgui.s.friendlyFlagLabel.Show()
+	vgui.s.enemyFlagLabel.Show()
+
+	while ( GetGameState() < eGameState.Epilogue )
+	{
+		if ( "friendlyFlagState" in player.s )
+		{
+			switch ( player.s.friendlyFlagState )
+			{
+				case eFlagState.None:
+					vgui.s.friendlyFlagLabel.SetText( "" )
+					break
+				case eFlagState.Home:
+					vgui.s.friendlyFlagLabel.SetText( "#GAMEMODE_FLAG_HOME" )
+					break
+				case eFlagState.Held:
+					vgui.s.friendlyFlagLabel.SetText( player.s.friendlyFlagCarrierName )
+					break
+				case eFlagState.Away:
+					vgui.s.friendlyFlagLabel.SetText( "#GAMEMODE_FLAG_DROPPED" )
+					break
+			}
+
+			switch ( player.s.enemyFlagState )
+			{
+				case eFlagState.None:
+					vgui.s.enemyFlagLabel.SetText( "" )
+					break
+				case eFlagState.Home:
+					vgui.s.enemyFlagLabel.SetText( "#GAMEMODE_FLAG_HOME" )
+					break
+				case eFlagState.Held:
+					vgui.s.enemyFlagLabel.SetText( player.s.enemyFlagCarrierName )
+					break
+				case eFlagState.Away:
+					vgui.s.enemyFlagLabel.SetText( "#GAMEMODE_FLAG_DROPPED" )
+					break
+			}
+		}
+
+		clGlobal.levelEnt.WaitSignal( "FlagUpdate" )
+
+		WaitEndFrame()
+	}
+
+	vgui.s.friendlyFlag.Hide()
+	vgui.s.enemyFlag.Hide()
+	vgui.s.friendlyFlagLabel.Hide()
+	vgui.s.enemyFlagLabel.Hide()
+}
+
+
+
+function TitanEliminationThink( vgui, entity player )
+{
+	vgui.EndSignal( "OnDestroy" )
+	player.EndSignal( "OnDestroy" )
+
+	if ( player != GetLocalClientPlayer() )
+		return
+
+	OnThreadEnd(
+		function() : ( player )
+		{
+			if ( !IsValid( player ) )
+				return
+
+			if ( player.cv.hud.s.lastEventNotificationText == "#GAMEMODE_CALLINTITAN_COUNTDOWN" )
+				HideEventNotification()
+		}
+	)
+
+	while ( true )
+	{
+		if ( Riff_EliminationMode() == eEliminationMode.Titans )
+		{
+			if ( IsAlive( player ) && GamePlayingOrSuddenDeath() && level.nv.secondsTitanCheckTime > Time() && !player.IsTitan() && !IsValid( player.GetPetTitan() ) && player.GetNextTitanRespawnAvailable() >= 0 )
+			{
+				SetTimedEventNotificationHATT( level.nv.secondsTitanCheckTime - Time(), "#GAMEMODE_CALLINTITAN_COUNTDOWN", HATT_GAME_COUNTDOWN_SECONDS_MILLISECONDS, level.nv.secondsTitanCheckTime )
+			}
+			else if ( player.cv.hud.s.lastEventNotificationText == "#GAMEMODE_CALLINTITAN_COUNTDOWN" )
+			{
+				HideEventNotification()
+			}
+		}
+		else if ( Riff_EliminationMode() == eEliminationMode.Pilots )
+		{
+
+		}
+
+		WaitSignal( player, "UpdateLastTitanStanding", "PetTitanChanged", "OnDeath" )
+	}
+}
+
+function RoundScoreThink( var vgui, var scoreGroup, entity player )
+{
+	vgui.EndSignal( "OnDestroy" )
+	player.EndSignal( "OnDestroy" )
+
+	FlagWait( "EntitiesDidLoad" ) //Have to do this because the nv that determines if RoundBased or not might not get set yet
+
+	int friendlyTeam = player.GetTeam()
+	int enemyTeam = friendlyTeam == TEAM_IMC ? TEAM_MILITIA : TEAM_IMC
+
+	local isRoundBased = IsRoundBased()
+	bool showRoundScore = true
+	int roundScoreLimit = GetRoundScoreLimit_FromPlaylist()
+	int scoreLimit = GetScoreLimit_FromPlaylist()
+
+	if ( isRoundBased && showRoundScore )
+	{
+		level.scoreLimit[TEAM_IMC] <- roundScoreLimit
+		level.scoreLimit[TEAM_MILITIA] <- roundScoreLimit
+	}
+	else
+	{
+		level.scoreLimit[TEAM_IMC] <- scoreLimit
+		level.scoreLimit[TEAM_MILITIA] <- scoreLimit
+	}
+
+	local hudScores = vgui.s.scoreboardProgressBars
+
+	while ( true )
+	{
+		if ( isRoundBased && showRoundScore )
+		{
+			hudScores.Friendly_Number.SetAutoText( "", HATT_FRIENDLY_TEAM_ROUND_SCORE, 0 )
+			hudScores.Enemy_Number.SetAutoText( "", HATT_ENEMY_TEAM_ROUND_SCORE, 0 )
+		}
+
+		hudScores.ScoresFriendly.SetBarProgressRemap( 0, level.scoreLimit[friendlyTeam], 0.011, 0.96 )
+		hudScores.ScoresEnemy.SetBarProgressRemap( 0, level.scoreLimit[enemyTeam], 0.011, 0.96 )
+		wait 1.0
+	}
+}
+
+function CreatePlayerStatusElementsFriendly( scoreboardArrays, scoreGroup, panel )
+{
+	scoreboardArrays.FriendlyPlayerStatusCount <- arrayofsize( 8 )
+
+	for ( int i = 0; i < 8; ++i )
+	{
+		scoreboardArrays.FriendlyPlayerStatusCount[ i ] = scoreGroup.CreateElement( "Friendly_Player_Status_" + i, panel )
+	}
+}
+
+function CreatePlayerStatusElementsEnemy( scoreboardArrays, scoreGroup, panel )
+{
+	scoreboardArrays.EnemyPlayerStatusCount <- arrayofsize( 8 )
+
+	for ( int i = 0; i < 8; ++i )
+	{
+		scoreboardArrays.EnemyPlayerStatusCount[ i ] = scoreGroup.CreateElement( "Enemy_Player_Status_" + i, panel )
+	}
+}
+
+
+function ScoreBarsPlayerStatusThink( vgui, entity player, friendlyPlayerStatusElem, enemyPlayerStatusElem )
+{
+	int friendlyTeam = player.GetTeam()
+	int enemyTeam = friendlyTeam == TEAM_IMC ? TEAM_MILITIA : TEAM_IMC
+
+	vgui.EndSignal( "OnDestroy" )
+
+	while( true )
+	{
+		clGlobal.levelEnt.WaitSignal( "UpdatePlayerStatusCounts" )
+
+		if ( IsWatchingReplay() ) //Don't update visibility if the scoreboardgroup should be hidden
+			continue
+
+		UpdatePlayerStatusForTeam( friendlyTeam, friendlyPlayerStatusElem, $"ui/icon_status_titan_friendly", $"ui/icon_status_pilot_friendly", $"ui/icon_status_burncard_friendly", $"ui/icon_status_burncard_friendly" )
+		UpdatePlayerStatusForTeam( enemyTeam, enemyPlayerStatusElem, $"ui/icon_status_titan_enemy", $"ui/icon_status_pilot_enemy", $"ui/icon_status_burncard_enemy", $"ui/icon_status_burncard_enemy" )
+	}
+}
+
+function CountPlayerStatusTypes( array<entity> teamPlayers )
+{
+	table resultTable = {
+		titanWithBurnCard = 0,
+		titan = 0,
+		pilotWithBurnCard = 0
+		pilot = 0,
+	}
+
+	foreach ( player in teamPlayers )
+	{
+		entity playerPetTitan = player.GetPetTitan()
+
+		if ( !IsAlive( player ) )
+		{
+			if ( IsAlive( playerPetTitan ) )
+				resultTable.titan++
+		}
+		else
+		{
+			if ( player.IsTitan() )
+				resultTable.titan++
+			else if ( IsAlive( playerPetTitan ) )
+				resultTable.titan++
+			else
+				resultTable.pilot++
+		}
+
+	}
+
+	return resultTable
+}
+
+
+function UpdatePlayerStatusForTeam( int team, teamStatusElem, titanImage, pilotImage, pilotBurnCardImage, titanBurnCardImage )
+{
+	array<entity> teamPlayers = GetPlayerArrayOfTeam( team )
+	local teamResultTable = CountPlayerStatusTypes( teamPlayers )
+
+	int maxElems = 8
+
+	int index = 0
+	int currentElem = 0
+
+	for ( index = 0; index < teamResultTable.titanWithBurnCard && currentElem < maxElems; index++, currentElem++ )
+	{
+		teamStatusElem[ currentElem ].Show()
+		teamStatusElem[ currentElem ].SetImage( titanBurnCardImage )
+	}
+
+	for ( index = 0; index < teamResultTable.titan && index < maxElems; index++, currentElem++ )
+	{
+		teamStatusElem[ currentElem ].Show()
+		teamStatusElem[ currentElem ].SetImage( titanImage )
+	}
+
+	for ( index = 0; index < teamResultTable.pilotWithBurnCard && index < maxElems; index++, currentElem++ )
+	{
+		teamStatusElem[ currentElem ].Show()
+		teamStatusElem[ currentElem ].SetImage( pilotBurnCardImage )
+	}
+
+	for ( index = 0; index < teamResultTable.pilot && index < maxElems; index++, currentElem++ )
+	{
+		teamStatusElem[ currentElem ].Show()
+		teamStatusElem[ currentElem ].SetImage( pilotImage )
+	}
+
+	for( ; currentElem < maxElems; currentElem++ )
+	{
+		teamStatusElem[ currentElem ].Hide()
+	}
+}
+function SuddenDeathHUDThink( vgui, entity player )
+{
+	Signal( player, "SuddenDeathHUDThink" )
+	player.EndSignal( "SuddenDeathHUDThink" )
+	vgui.EndSignal( "OnDestroy" )
+
+	while ( GetGameState() != eGameState.SuddenDeath )
+		WaitSignal( player, "GameStateChanged" )
+
+	EndSignal( player, "GameStateChanged" )
+
+	local hudScores = vgui.s.scoreboardProgressBars
+
+	OnThreadEnd(
+		function() : ( hudScores, player )
+		{
+			if ( !IsValid( hudScores ) )
+				return
+
+			hudScores.GameInfo_Label.SetColor( 255, 255, 255, 255 )
+
+			string restoredGameModeLabelText = GAMETYPE_TEXT[ GameRules_GetGameMode() ]
+			hudScores.GameModeLabel.SetText( restoredGameModeLabelText )
+
+			if ( player == GetLocalClientPlayer() )
+			{
+				local scoreElemsClient = player.cv.clientHud.s.mainVGUI.s.scoreboardProgressGroup.elements
+				scoreElemsClient.GameModeLabel.SetText( restoredGameModeLabelText )
+			}
+		}
+	)
+
+	string gameModeLabelText = ""
+
+	switch ( GAMETYPE )
+	{
+		case CAPTURE_THE_FLAG:
+			gameModeLabelText = "#GAMEMODE_CAPTURE_THE_FLAG_SUDDEN_DEATH"
+			break
+
+		case TEAM_DEATHMATCH:
+		case HARDCORE_TDM:
+			gameModeLabelText = "#GAMEMODE_PILOT_HUNTER_SUDDEN_DEATH"
+			break
+
+		default:
+			gameModeLabelText = GAMETYPE_TEXT[ GameRules_GetGameMode() ]
+	}
+
+	hudScores.GameModeLabel.SetText( gameModeLabelText )
+
+	if ( player == GetLocalClientPlayer() )
+	{
+		local scoreElemsClient = player.cv.clientHud.s.mainVGUI.s.scoreboardProgressGroup.elements
+		scoreElemsClient.GameModeLabel.SetText( gameModeLabelText )
+	}
+
+	float startTime = Time()
+	float pulseFrac = 0.0
+
+	while ( true )
+	{
+		pulseFrac = Graph( GetPulseFrac( 1.0, startTime ), 0.0, 1.0, 0.05, 1.0 )
+		hudScores.GameInfo_Label.SetColor( 255, 255, 255, 255 * pulseFrac )
+
+		wait( 0.0 )
+	}
+}

--- a/Northstar.Client/mod/scripts/vscripts/weapons/sh_titancore_utility.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/weapons/sh_titancore_utility.gnut
@@ -1,0 +1,647 @@
+untyped
+
+global function MpTitanabilityFusionCore_Init
+
+global function OnAbilityCharge_TitanCore
+
+global function OnAbilityStart_TitanCore
+
+#if SERVER
+	global function OnAbilityEnd_TitanCore
+	global function OnAbilityChargeEnd_TitanCore
+
+	global function SoulTitanCore_SetNextAvailableTime
+	global function SoulTitanCore_SetExpireTime
+#endif
+
+global function SoulTitanCore_GetNextAvailableTime
+global function SoulTitanCore_GetExpireTime
+global function IsTitanCoreFiring
+
+global function CheckCoreAvailable
+global function IsCoreAvailable
+global function IsCoreChargeAvailable
+
+global function CoreChargeBegin
+
+#if SERVER
+	global function CoreChargeEnd
+
+	global function CoreActivate
+	global function CoreDeactivate
+
+	global function CoreBegin
+	global function CoreEnd
+#endif
+
+const EMP_BLAST_EFFECT = $"P_titan_core_atlas_blast"
+const EMP_BLAST_CHARGE_EFFECT = $"P_titan_core_atlas_charge"
+
+#if SERVER
+	global function SetUsedCoreCallback
+	global function CreateDefaultChargeEffect
+	global function SetCoreEffect
+	global function CreateCoreEffect
+	global function CleanupCoreEffect
+	global function HideTitanCoreFX
+
+	global function OnAbilityStart_DashCore
+	global function OnAbilityEnd_DashCore
+
+	global function LowerEnemyAccuracy
+#endif
+
+#if SERVER
+struct
+{
+	void functionref( entity, entity ) usedCoreCallback
+} file
+#endif
+
+// Northstar
+#if CLIENT
+global function AddCallback_OnUsedCore
+#endif
+
+#if CLIENT
+struct
+{
+	array< void functionref( entity, entity ) > onUsedCoreCallbacks
+} file
+#endif
+///////////
+
+function MpTitanabilityFusionCore_Init()
+{
+	PrecacheParticleSystem( EMP_BLAST_CHARGE_EFFECT )
+	PrecacheParticleSystem( EMP_BLAST_EFFECT )
+
+	LaserCannon_Init()
+	Shift_Core_Init()
+	FlightCore_Init()
+	SalvoCore_Init()
+	UpgradeCore_Init()
+
+	RegisterSignal( "CoreActivated" )
+	RegisterSignal( "CoreBegin" )
+	RegisterSignal( "CoreEnd" )
+
+	#if SERVER
+		AddCallback_OnPlayerKilled( TitanCore_PlayerKilledCleanup )
+		AddDamageCallback( "player", TitanCore_OnDamage )
+	#endif
+}
+
+#if SERVER
+void function SetUsedCoreCallback( void functionref( entity, entity ) func )
+{
+	file.usedCoreCallback = func
+}
+
+void function TitanCore_OnDamage( entity ent, var damageInfo )
+{
+	float damageReduction = StatusEffect_Get( ent, eStatusEffect.damage_reduction )
+	float damageScale = 1.0 - damageReduction
+	if ( damageScale != 1.0 )
+		DamageInfo_SetDamage( damageInfo, DamageInfo_GetDamage( damageInfo ) * damageScale )
+}
+#endif
+
+//Northstar
+#if CLIENT
+void function AddCallback_OnUsedCore( void functionref( entity, entity ) callbackFunc )
+{
+	Assert( !file.onUsedCoreCallbacks.contains( callbackFunc ), "Already added " + string( callbackFunc ) + " with AddCallback_OnUsedCore" )
+	file.onUsedCoreCallbacks.append( callbackFunc )
+}
+#endif
+//////////
+
+bool function IsTitanCoreFiring( entity titan )
+{
+	if ( !titan.IsTitan() )
+		return false
+
+	entity soul = titan.GetTitanSoul()
+	float time = Time()
+	return time >= soul.GetCoreChargeStartTime() && time <= soul.GetCoreChargeExpireTime()
+}
+
+bool function OnAbilityCharge_TitanCore( entity weapon )
+{
+	if ( !CheckCoreAvailable( weapon ) )
+		return false
+
+	entity player = weapon.GetWeaponOwner()
+
+	#if CLIENT
+	if ( IsFirstTimePredicted() )
+	{
+	#endif
+		// printt( "chargebegin" )
+	#if SERVER
+		CoreActivate( player )
+	#endif
+		CoreChargeBegin( player, player, weapon )
+	#if CLIENT
+	}
+	#endif
+
+	player.Signal( "CoreActivated" )
+
+	return true
+}
+
+bool function OnAbilityStart_TitanCore( entity weapon )
+{
+	entity titan = weapon.GetWeaponOwner()
+	// printt( "abilitybegin" )
+	titan.Signal( "CoreBegin" )
+
+	// Northstar
+	#if CLIENT
+	foreach( callback in file.onUsedCoreCallbacks ) {
+		callback( titan, weapon )
+	}
+	#endif
+	////////////
+
+	#if SERVER
+	CoreBegin( titan, titan, weapon )
+	#endif
+
+	if ( titan.IsPlayer() )
+	{
+		PlayerUsedOffhand( titan, weapon )
+		#if SERVER && MP
+			PIN_PlayerAbility( titan, "core", weapon.GetWeaponClassName(), {} )
+		#endif
+	}
+	return true
+}
+
+#if SERVER
+void function OnAbilityChargeEnd_TitanCore( entity weapon )
+{
+	// printt( "chargeend" )
+	entity titan = weapon.GetWeaponOwner()
+
+	if ( titan == null )
+		return
+
+	CoreChargeEnd( titan, weapon )
+}
+
+void function OnAbilityEnd_TitanCore( entity weapon )
+{
+	// printt( "abilityend" )
+	entity titan = weapon.GetWeaponOwner()
+
+	if ( titan == null )
+		return
+
+	CoreDeactivate( titan, weapon )
+	CoreEnd( titan, titan, weapon )
+}
+#endif
+
+bool function CheckCoreAvailable( entity weapon )
+{
+	// printt( "IsCoreAvailable?" )
+	entity titan = weapon.GetWeaponOwner()
+
+	if ( !titan.IsTitan() )
+		return false
+
+	if ( titan.ContextAction_IsActive() )
+		return false
+
+	if ( titan.IsPlayer() && IsInExecutionMeleeState( titan ) )
+		return false
+
+	if ( titan.GetParent() != null )
+		return false
+
+	entity soul = titan.GetTitanSoul()
+
+	if ( soul == null )
+		return false
+
+	if ( soul.IsEjecting() )
+		return false
+
+	if ( !IsCoreChargeAvailable( titan, soul ) )
+	{
+		return false
+	}
+
+	return true
+}
+
+#if SERVER
+void function CoreActivate( entity player )
+{
+	// printt( "activate" )
+	entity soul = player.GetTitanSoul()
+
+	if ( IsValid( soul ) && !player.ContextAction_IsMeleeExecution() )
+	{
+		if ( TitanDamageRewardsTitanCoreTime() )
+			SoulTitanCore_SetNextAvailableTime( soul, 0.0 )
+		else
+			SoulTitanCore_SetNextAvailableTime( soul, Time() + 1000 )
+	}
+}
+
+void function CoreDeactivate( entity player, entity weapon )
+{
+	// printt( "deactivate" )
+	Assert( player.IsTitan() )
+	entity soul = player.GetTitanSoul();
+
+	if ( IsValid( soul ) && !player.ContextAction_IsMeleeExecution() )
+	{
+		if ( TitanDamageRewardsTitanCoreTime() )
+		{
+			if ( SoulHasPassive( soul, ePassives.PAS_HYPER_CORE ) )
+			{
+				SoulTitanCore_SetNextAvailableTime( soul, 0.20 )
+				GiveOffhandElectricSmoke( player )
+			}
+		}
+		else if ( IsValid( player ) )
+		{
+			SoulTitanCore_SetNextAvailableTime( soul, Time() + GetTitanCoreBuildTimeFromWeapon( weapon ) )
+		}
+	}
+}
+
+bool function CoreBegin( entity player, entity titan, entity weapon )
+{
+	entity soul = titan.GetTitanSoul()
+
+	bool marathon = false
+
+	if ( !IsAlive( titan ) )
+		return false
+
+	if ( !titan.IsTitan() )
+		return false
+
+	if ( player.IsPlayer() )
+	{
+		marathon = PlayerHasPassive( player, ePassives.PAS_MARATHON_CORE )
+		BlastScreenShake( titan )
+
+		var passive = GetPassiveFromWeapon( weapon )
+
+		if ( passive != null )
+			GivePassive( soul, expect int( passive ) )
+
+		if ( IsSingleplayer() )
+		{
+			if ( titan.IsPlayer() && weapon.GetWeaponInfoFileKeyField( "damage_protection" ) != 0 )
+			{
+				float duration = weapon.GetCoreDuration()
+				StatusEffect_AddTimed( soul, eStatusEffect.damage_reduction, 0.75, duration, 0 )
+				thread LowerEnemyAccuracy( titan, duration )
+			}
+			else if ( weapon.IsSustainedDischargeWeapon() )
+			{
+				float duration = weapon.GetSustainedDischargeDuration()
+				thread LowerEnemyAccuracy( titan, duration )
+			}
+
+			ResetCoreKillCounter()
+		}
+
+		#if SERVER && MP
+			PIN_AddToPlayerCountStat( player, "titan_cores" )
+		#endif
+	}
+
+	if ( marathon )
+		EmitSoundOnEntity( titan, "Titan_CoreAbility_Sustain_Long" )
+	else
+		EmitSoundOnEntity( titan, "Titan_CoreAbility_Sustain" )
+
+	SetCoreEffect( titan, CreateCoreEffect, EMP_BLAST_EFFECT )
+
+	if ( file.usedCoreCallback != null )
+		file.usedCoreCallback( titan, weapon )
+
+	return true
+}
+
+void function LowerEnemyAccuracy( entity titan, float duration )
+{
+	Assert( titan.IsPlayer() )
+
+	titan.EndSignal( "OnDeath" )
+	titan.EndSignal( "TitanEjectionStarted" )
+	titan.EndSignal( "CoreEnd" )
+	titan.EndSignal( "DisembarkingTitan" )
+	titan.EndSignal( "OnSyncedMelee" )
+
+	OnThreadEnd(
+	function() : ( titan )
+		{
+			if ( IsValid( titan ) )
+			{
+				print( "Making player titan Shootable\n" )
+				titan.kv.EnemyAccuracyMultiplier = 1.0
+			}
+		}
+	)
+
+	titan.kv.EnemyAccuracyMultiplier = 0.3
+	wait duration
+}
+
+void function CoreEnd( entity player, entity titan, entity weapon )
+{
+	entity soul = titan.GetTitanSoul()
+
+	if ( soul != null )
+	{
+		var passive = GetPassiveFromWeapon( weapon )
+
+		if ( passive != null )
+			TakePassive( soul, expect int( passive ) )
+
+		CleanupCoreEffect( soul )
+
+		if ( IsValid( titan ) )
+		{
+			StopSoundOnEntity( titan, "Titan_CoreAbility_Sustain_Long" )
+			StopSoundOnEntity( titan, "Titan_CoreAbility_Sustain" )
+		}
+	}
+
+	if ( IsValid( player ) )
+		player.Signal( "CoreEnd" )
+}
+#endif // #if SERVER
+
+bool function CoreChargeBegin( entity player, entity titan, entity weapon )
+{
+	entity soul = titan.GetTitanSoul()
+
+#if CLIENT
+	thread CoreActivatedVO( player )
+#if HAS_BOSS_AI
+	if ( titan.IsPlayer() )
+	{
+		BossTitanPlayerUsedCoreAbility( titan, GetTitanCurrentRegenTab( titan ) )
+	}
+#endif
+#else // #if CLIENT
+	float coreWaitTime = GetTitanCoreDurationFromWeapon( weapon ) + GetTitanCoreChargeTimeFromWeapon( weapon )
+
+	SoulTitanCore_SetExpireTime( soul, Time() + coreWaitTime )
+	soul.SetCoreChargeStartTime( Time() )
+	soul.SetCoreUseDuration( coreWaitTime )
+
+#if HAS_BOSS_AI
+	if ( titan.IsNPC() && BossTitanVDUEnabled( titan ) )
+	{
+		entity p = titan.GetEnemy()
+		if ( p.IsPlayer() )
+			Remote_CallFunction_NonReplay( p, "ServerCallback_BossTitanUseCoreAbility", titan.GetEncodedEHandle(), GetTitanCurrentRegenTab( titan ) )
+	}
+#endif
+	if ( SoulHasPassive( soul, ePassives.PAS_SHIELDED_CORE ) )
+		thread ShieldedCore( soul, coreWaitTime )
+#endif // #else // #if CLIENT
+
+	return true
+}
+
+#if SERVER
+void function CoreChargeEnd( entity titan, entity weapon )
+{
+	if ( IsValid( titan ) )
+	{
+		entity soul = titan.GetTitanSoul()
+		if ( soul != null )
+			CleanupCoreEffect( soul )
+	}
+}
+#endif // #if SERVER
+
+bool function IsCoreChargeAvailable( entity player, entity soul )
+{
+	if ( soul == null )
+		return false
+
+	if ( TitanDamageRewardsTitanCoreTime() )
+		return SoulTitanCore_GetNextAvailableTime( soul ) >= 1.0
+
+	if ( Time() >= SoulTitanCore_GetNextAvailableTime( soul ) && IsCoreAvailable( player ) )
+		return true
+
+	return false
+}
+
+bool function IsCoreAvailable( entity player )
+{
+	entity coreWeapon = player.GetOffhandWeapon( OFFHAND_EQUIPMENT )
+
+	if ( coreWeapon == null )
+		return false
+
+	return ( GetDoomedState( player ) == false || CoreAvailableDuringDoomState() )
+}
+
+var function GetPassiveFromWeapon( entity weapon )
+{
+	var passiveName = weapon.GetWeaponInfoFileKeyField( "passive" )
+	if ( passiveName == null )
+		return null
+
+	switch ( passiveName )
+	{
+		case "PAS_FUSION_CORE":
+			return ePassives.PAS_FUSION_CORE
+		case "PAS_SHIELD_BOOST":
+			return ePassives.PAS_SHIELD_BOOST
+		case "PAS_BERSERKER":
+			return ePassives.PAS_BERSERKER
+		case "PAS_SHIFT_CORE":
+			return ePassives.PAS_SHIFT_CORE
+		case "PAS_SMART_CORE":
+			return ePassives.PAS_SMART_CORE
+	}
+
+	return null
+}
+
+#if SERVER
+void functionref( entity ) function PROTO_CoreStringToFunction( string funcName )
+{
+	return null
+}
+
+void functionref( entity ) function GetFuncFromWeaponEntry( weaponName, string field )
+{
+	var funcName = GetWeaponInfoFileKeyField_Global( weaponName, field )
+	if ( funcName == null )
+		return null
+
+	expect string( funcName )
+	return PROTO_CoreStringToFunction( funcName )
+}
+
+////////////////////////////////////////////////////////////////////////
+// Core-start effect functions
+////////////////////////////////////////////////////////////////////////
+
+void function CreateDefaultChargeEffect( entity titan )
+{
+	SetCoreEffect( titan, CreateCoreEffect, EMP_BLAST_CHARGE_EFFECT )
+}
+
+function BlastScreenShake( entity titan )
+{
+	// Screen shake
+	float amplitude = 16.0
+	float frequency = 5.0
+	float duration = 2.0
+	float radius = 1500.0
+	entity shake = CreateShake( titan.GetOrigin(), amplitude, frequency, duration, radius )
+	shake.SetParent( titan, "CHESTFOCUS" )
+	shake.Kill_Deprecated_UseDestroyInstead( 3.0 )
+}
+#endif // #if SERVER
+
+#if SERVER
+void function TitanCore_PlayerKilledCleanup( entity player, entity attacker, var damageInfo )
+{
+	ForceTitanSustainedDischargeEnd( player )
+}
+
+void function CleanupCoreEffect( entity soul )
+{
+	if ( "coreEffect" in soul.s && IsValid( soul.s.coreEffect.ent ) )
+	{
+		soul.s.coreEffect.ent.Destroy()
+	}
+
+	if ( "coreEffect" in soul.s )
+		delete soul.s.coreEffect
+}
+
+void function SetCoreEffect( entity titan, entity functionref(entity,asset) func, asset effectName )
+{
+	Assert( IsAlive( titan ) )
+	Assert( titan.IsTitan() )
+	entity soul = titan.GetTitanSoul()
+	local chargeEffect = func( titan, effectName )
+	if ( "coreEffect" in soul.s )
+	{
+		soul.s.coreEffect.ent.Kill_Deprecated_UseDestroyInstead()
+	}
+	else
+	{
+		soul.s.coreEffect <- null
+	}
+
+	soul.s.coreEffect = { parameter = effectName, ent = chargeEffect, func = func }
+}
+
+////////////////////////////////////////////////////////////////////////
+// core fx and color correction
+////////////////////////////////////////////////////////////////////////
+entity function CreateCoreEffect( entity player, asset effectName )
+{
+	Assert( player.IsTitan() )
+
+	int index = player.LookupAttachment( "hijack" )
+	entity chargeEffect = StartParticleEffectOnEntity_ReturnEntity( player, GetParticleSystemIndex( effectName ), FX_PATTACH_POINT_FOLLOW, index )
+
+	chargeEffect.kv.VisibilityFlags = (ENTITY_VISIBLE_TO_FRIENDLY | ENTITY_VISIBLE_TO_ENEMY) // everyone but owner
+	chargeEffect.SetOwner( player )
+	return chargeEffect
+
+}
+
+function HideTitanCoreFX( entity titan, float duration )
+{
+	titan.EndSignal( "OnDestroy" )
+
+	CleanupCoreEffect( titan.GetTitanSoul() )
+
+	wait duration
+
+	CreateDefaultChargeEffect( titan )
+}
+
+////////////////////////////////////////////////////////////////////////
+// R1 core functions
+////////////////////////////////////////////////////////////////////////
+
+void function OnAbilityEnd_DashCore( entity player )
+{
+	player.SetDodgePowerDelayScale( 1.0 )
+	player.SetPowerRegenRateScale( 1.0 )
+}
+
+void function OnAbilityStart_DashCore( entity player )
+{
+	// Dash recharges fast
+	player.SetDodgePowerDelayScale( 0.05 )
+	player.SetPowerRegenRateScale( 16.0 )
+}
+
+//PAS_SHIELDED_CORE
+void function ShieldedCore( entity soul, float coreDuration )
+{
+	soul.EndSignal( "OnDestroy" )
+	soul.EndSignal( "OnTitanDeath" )
+
+	int health = soul.GetShieldHealthMax()
+	soul.SetShieldHealth( health )
+
+	OnThreadEnd(
+	function() : ( soul )
+		{
+			if ( IsValid( soul ) )
+				soul.SetShieldHealth( 0 )
+		}
+	)
+
+	wait max( 3.0, coreDuration )
+}
+#endif
+
+#if SERVER
+void function SoulTitanCore_SetNextAvailableTime( entity soul, float time )
+{
+	soul.SetTitanSoulNetFloat( "coreAvailableFrac", min( time, 1.0 ) )
+	soul.SetNextCoreChargeAvailable( time )
+}
+
+void function SoulTitanCore_SetExpireTime( entity soul, float expireTime )
+{
+	if ( expireTime - Time() > 0 )
+	{
+		soul.SetTitanSoulNetFloat( "coreExpireFrac", 1.0 )
+		soul.SetTitanSoulNetFloatOverTime( "coreExpireFrac", 0.0, expireTime - Time() )
+	}
+	else
+	{
+		soul.SetTitanSoulNetFloat( "coreExpireFrac", 0.0 )
+	}
+	soul.SetCoreChargeExpireTime( expireTime )
+}
+#endif
+
+float function SoulTitanCore_GetNextAvailableTime( entity soul )
+{
+	return soul.GetNextCoreChargeAvailable()
+}
+
+float function SoulTitanCore_GetExpireTime( entity soul )
+{
+	return soul.GetCoreChargeExpireTime()
+}


### PR DESCRIPTION
<!-- 
WHEN OPENING A PULL REQUEST KEEP IN MIND:
-> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
-> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)

-> For fixes, description on how to reproduce the bug are appreciated and help your PR get merged faster
-> For features, description on how to use or a sample mod that makes use of the feature is appreciated and will help your PR get merged faster

-> Please use a sensible title for your pull request

-> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).

-> If you made multiple independent changes, please make a new PR for each one. This prevents your PR being blocked from merging by one of the changes you made.

Note that commit messages in PRs will generally be squashed to keep commit history clean.
-->

This change adds a few new global functions for registering client side callback functions as well as implementation for the callbacks. Specifically, the code from [S2.ClientKillCallback](https://github.com/S2ymi/R2NS-ClientKillCallback) is added to allow for easier installation of mods that depend on these features. Addtionally, callbacks that trigger when any entity is killed regardless of the type have been added. Similarly callback handlers are added to `cl_player.gnut` and `weapons/sh_titancore_utility.gnut` to allow callbacks when the player does damage or uses a titan core.

To register a new callback, the following functions can be used:
- `AddCallback_OnPlayerKilled` - passes an instance of the `ObituaryCallbackParams` struct to the callback
- `AddCallback_OnEntityKilled` - passes an instance of the `ObituaryCallbackParams` struct to the callback
- `AddCallback_OnUsedCore` - passes the titan and weapon entities being used to the callback in that order
- `AddCallback_OnLocalPlayerDidDamage` - passes an instance of `PlayerDidDamageParams` to the callback