### PR TITLE
Enable MAD by default

### DIFF
--- a/Northstar.Client/mod.json
+++ b/Northstar.Client/mod.json
@@ -7,7 +7,7 @@
 	"ConVars": [
 		{
 			"Name": "allow_mod_auto_download",
-			"DefaultValue": "0"
+			"DefaultValue": "1"
 		},
 		{
 			"Name": "filter_hide_empty",


### PR DESCRIPTION
Sets `allow_mod_auto_download` to `1` by default.

IMO this should only be temporary for the Parkour event and the reverted once we get more mods verified so that we can make a big release once we got a bunch of mods out.

Specific details can of course still be figured out later