### PR TITLE
Disable MAD by default

### DIFF
--- a/Northstar.Client/mod.json
+++ b/Northstar.Client/mod.json
@@ -7,7 +7,7 @@
 	"ConVars": [
 		{
 			"Name": "allow_mod_auto_download",
-			"DefaultValue": "1"
+			"DefaultValue": "0"
 		},
 		{
 			"Name": "filter_hide_empty",


### PR DESCRIPTION
Disables MAD[^1] by default again by flipping the value of the corresponding convar by reverting #782 

[^1]: mod-auto-download

To be clear, MAD can still be enabled on client by just changing a single convar. The reason we are disabling it by default again, is so that we can implement some breaking changes like e.g. https://github.com/R2Northstar/VerifiedMods/pull/23 without having half the user-base cry out why MAD suddenly stopped working.

We will of course re-enable MAD again, once we deem it ready to ship and have a more mods in stock for it as well :D