### PR TITLE
Fix map rotation for Hide-and-Seek and remove duplicate entries

### DIFF
--- a/Northstar.Custom/keyvalues/playlists_v2.txt
+++ b/Northstar.Custom/keyvalues/playlists_v2.txt
@@ -395,7 +395,6 @@ playlists
 						mp_colony02 1
 						mp_glitch 1
 						mp_lf_stacks 1
-						mp_lf_stacks 1
 						mp_lf_deck 1
 						mp_lf_meadow 1
 						mp_lf_traffic 1
@@ -449,7 +448,6 @@ playlists
 						mp_colony02 1
 						mp_glitch 1
 						mp_lf_stacks 1
-						mp_lf_stacks 1
 						mp_lf_deck 1
 						mp_lf_meadow 1
 						mp_lf_traffic 1
@@ -497,7 +495,6 @@ playlists
 						mp_angel_city 1
 						mp_colony02 1
 						mp_glitch 1
-						mp_lf_stacks 1
 						mp_lf_stacks 1
 						mp_lf_deck 1
 						mp_lf_meadow 1
@@ -626,35 +623,27 @@ playlists
 				{
 					maps
 					{
-						mp_complex3 1
-						mp_drydock 1
-						mp_glitch 1
-						mp_homestead 2
-						mp_eden 1
 						mp_forwardbase_kodai 1
-						mp_black_water_canal 1
-						mp_glitch 1
-						mp_angel_city 1
-						mp_colony02 1
-						mp_relic02 1
 						mp_grave 1
 						mp_homestead 1
-						mp_drydock 1
-						mp_glitch 1
 						mp_thaw 1
-						mp_eden 2
 						mp_black_water_canal 1
-						mp_glitch 1
-						mp_relic02 1
-						mp_wargames 1
-						mp_rise 1
+						mp_eden 1
+						mp_drydock 1
 						mp_crashsite3 1
+						mp_complex3 1
+						mp_angel_city 1
+						mp_colony02 1
+						mp_glitch 1
 						mp_lf_stacks 1
 						mp_lf_deck 1
 						mp_lf_meadow 1
 						mp_lf_traffic 1
 						mp_lf_township 1
 						mp_lf_uma 1
+						mp_relic02 1
+						mp_wargames 1
+						mp_rise 1
 					}
 				}
 			}
@@ -681,35 +670,27 @@ playlists
 				{
 					maps 
 					{
-						mp_complex3 1
-						mp_drydock 1
-						mp_glitch 1
-						mp_homestead 2
-						mp_eden 1
 						mp_forwardbase_kodai 1
-						mp_black_water_canal 1
-						mp_glitch 1
-						mp_angel_city 1
-						mp_colony02 1
-						mp_relic02 1
 						mp_grave 1
 						mp_homestead 1
-						mp_drydock 1
-						mp_glitch 1
 						mp_thaw 1
-						mp_eden 2
 						mp_black_water_canal 1
-						mp_glitch 1
-						mp_relic02 1
-						mp_wargames 1
-						mp_rise 1
+						mp_eden 1
+						mp_drydock 1
 						mp_crashsite3 1
+						mp_complex3 1
+						mp_angel_city 1
+						mp_colony02 1
+						mp_glitch 1
 						mp_lf_stacks 1
 						mp_lf_deck 1
 						mp_lf_meadow 1
 						mp_lf_traffic 1
 						mp_lf_township 1
 						mp_lf_uma 1
+						mp_relic02 1
+						mp_wargames 1
+						mp_rise 1
 					}
 				}
 			}
@@ -746,7 +727,6 @@ playlists
 						mp_angel_city 1
 						mp_colony02 1
 						mp_glitch 1
-						mp_lf_stacks 1
 						mp_lf_stacks 1
 						mp_lf_deck 1
 						mp_lf_meadow 1
@@ -795,7 +775,6 @@ playlists
 						mp_colony02 1
 						mp_glitch 1
 						mp_lf_stacks 1
-						mp_lf_stacks 1
 						mp_lf_deck 1
 						mp_lf_meadow 1
 						mp_lf_traffic 1
@@ -829,18 +808,18 @@ playlists
 				{
 					maps
 					{
-							mp_forwardbase_kodai 1
-									mp_grave 1
-									mp_homestead 1
-									mp_thaw 1
-									mp_black_water_canal 1
-									mp_eden 1
-									mp_drydock 1
-									mp_crashsite3 1
-									mp_complex3 1
-									mp_angel_city 1
-									mp_colony02 1
-									mp_glitch 1
+						mp_forwardbase_kodai 1
+						mp_grave 1
+						mp_homestead 1
+						mp_thaw 1
+						mp_black_water_canal 1
+						mp_eden 1
+						mp_drydock 1
+						mp_crashsite3 1
+						mp_complex3 1
+						mp_angel_city 1
+						mp_colony02 1
+						mp_glitch 1
 						mp_relic02 1
 						mp_wargames 1
 						mp_rise 1


### PR DESCRIPTION
~~This PR only edits `playlists_v2.txt` and fixes two issues.~~

~~Several gamemode map rotations would have stacks listed twice right after one another, which caused a server to remain on stacks permanently.~~ --> #793

Additionally, some gamemodes had maps listed several times [^1], while this wouldn't put a server stuck on a map permanently, it would create loops which caused some maps to never appear despite being listed.

[^1]: The change for CTF was moved to #795