### PR TITLE
Fix map rotation for CTF and remove duplicate entries

### DIFF
--- a/Northstar.Custom/keyvalues/playlists_v2.txt
+++ b/Northstar.Custom/keyvalues/playlists_v2.txt
@@ -623,35 +623,27 @@ playlists
 				{
 					maps
 					{
-						mp_complex3 1
-						mp_drydock 1
-						mp_glitch 1
-						mp_homestead 2
-						mp_eden 1
 						mp_forwardbase_kodai 1
-						mp_black_water_canal 1
-						mp_glitch 1
-						mp_angel_city 1
-						mp_colony02 1
-						mp_relic02 1
 						mp_grave 1
 						mp_homestead 1
-						mp_drydock 1
-						mp_glitch 1
 						mp_thaw 1
-						mp_eden 2
 						mp_black_water_canal 1
-						mp_glitch 1
-						mp_relic02 1
-						mp_wargames 1
-						mp_rise 1
+						mp_eden 1
+						mp_drydock 1
 						mp_crashsite3 1
+						mp_complex3 1
+						mp_angel_city 1
+						mp_colony02 1
+						mp_glitch 1
 						mp_lf_stacks 1
 						mp_lf_deck 1
 						mp_lf_meadow 1
 						mp_lf_traffic 1
 						mp_lf_township 1
 						mp_lf_uma 1
+						mp_relic02 1
+						mp_wargames 1
+						mp_rise 1
 					}
 				}
 			}


### PR DESCRIPTION
Changes the map order to match other gamemodes and removes duplicate map entries.

Spliced from #792 
