### PR TITLE
Unfuck the Spawns

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
@@ -75,27 +75,20 @@ void function RateSpawnpoints_CTF( int checkClass, array<entity> spawnpoints, in
 bool function VerifyCTFSpawnpoint( entity spawnpoint, int team )
 {
 	// ensure spawnpoints aren't too close to enemy base
+	vector allyFlagSpot
+	vector enemyFlagSpot
+	foreach ( entity spawn in GetEntArrayByClass_Expensive( "info_spawnpoint_flag" ) )
+	{
+		if( spawn.GetTeam() == team )
+			allyFlagSpot = spawn.GetOrigin()
+		else
+			enemyFlagSpot = spawn.GetOrigin()
+	}
 	
-	if ( HasSwitchedSides() )
-		team = GetOtherTeam( team )
+	if( Distance2D( spawnpoint.GetOrigin(), allyFlagSpot ) > Distance2D( spawnpoint.GetOrigin(), enemyFlagSpot ) )
+		return false
 	
-	array<entity> startSpawns = SpawnPoints_GetPilotStart( team )
-	array<entity> enemyStartSpawns = SpawnPoints_GetPilotStart( GetOtherTeam( team ) )
-	
-	vector averageFriendlySpawns
-	vector averageEnemySpawns
-	
-	foreach ( entity spawn in startSpawns )
-		averageFriendlySpawns += spawn.GetOrigin()
-	
-	averageFriendlySpawns /= startSpawns.len()
-	
-	foreach ( entity spawn in enemyStartSpawns )
-		averageEnemySpawns += spawn.GetOrigin()
-	
-	averageEnemySpawns /= startSpawns.len()
-	
-	return Distance2D( spawnpoint.GetOrigin(), averageEnemySpawns ) / Distance2D( averageFriendlySpawns, averageEnemySpawns ) > 0.35
+	return true
 }
 
 void function CTFInitPlayer( entity player )

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/spawn.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/spawn.nut
@@ -41,6 +41,27 @@ struct {
 	table<string, NoSpawnArea> noSpawnAreas
 } file
 
+
+
+
+
+
+
+
+
+
+
+/*
+
+██████╗  █████╗ ███████╗███████╗    ███████╗██╗   ██╗███╗   ██╗ ██████╗████████╗██╗ ██████╗ ███╗   ██╗███████╗
+██╔══██╗██╔══██╗██╔════╝██╔════╝    ██╔════╝██║   ██║████╗  ██║██╔════╝╚══██╔══╝██║██╔═══██╗████╗  ██║██╔════╝
+██████╔╝███████║███████╗█████╗      █████╗  ██║   ██║██╔██╗ ██║██║        ██║   ██║██║   ██║██╔██╗ ██║███████╗
+██╔══██╗██╔══██║╚════██║██╔══╝      ██╔══╝  ██║   ██║██║╚██╗██║██║        ██║   ██║██║   ██║██║╚██╗██║╚════██║
+██████╔╝██║  ██║███████║███████╗    ██║     ╚██████╔╝██║ ╚████║╚██████╗   ██║   ██║╚██████╔╝██║ ╚████║███████║
+╚═════╝ ╚═╝  ╚═╝╚══════╝╚══════╝    ╚═╝      ╚═════╝ ╚═╝  ╚═══╝ ╚═════╝   ╚═╝   ╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚══════╝
+
+*/
+
 void function Spawn_Init()
 {	
 	AddSpawnCallback( "info_spawnpoint_human", InitSpawnpoint )
@@ -126,11 +147,31 @@ void function InitRatings( entity player, int team )
 		SpawnPoints_InitRatings( player, team ) // no idea what the second arg supposed to be lol
 }
 
+
+
+
+
+
+
+
+
+
+/*
+
+███████╗██████╗  █████╗ ██╗    ██╗███╗   ██╗    ██████╗  ██████╗ ██╗███╗   ██╗████████╗███████╗
+██╔════╝██╔══██╗██╔══██╗██║    ██║████╗  ██║    ██╔══██╗██╔═══██╗██║████╗  ██║╚══██╔══╝██╔════╝
+███████╗██████╔╝███████║██║ █╗ ██║██╔██╗ ██║    ██████╔╝██║   ██║██║██╔██╗ ██║   ██║   ███████╗
+╚════██║██╔═══╝ ██╔══██║██║███╗██║██║╚██╗██║    ██╔═══╝ ██║   ██║██║██║╚██╗██║   ██║   ╚════██║
+███████║██║     ██║  ██║╚███╔███╔╝██║ ╚████║    ██║     ╚██████╔╝██║██║ ╚████║   ██║   ███████║
+╚══════╝╚═╝     ╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═══╝    ╚═╝      ╚═════╝ ╚═╝╚═╝  ╚═══╝   ╚═╝   ╚══════╝
+
+*/
+
 entity function FindSpawnPoint( entity player, bool isTitan, bool useStartSpawnpoint )
 {
 	int team = player.GetTeam()
 	if ( HasSwitchedSides() )
-		team = GetOtherTeam( team )
+		team = ( team == TEAM_MILITIA ) ? TEAM_IMC : TEAM_MILITIA
 
 	array<entity> spawnpoints
 	if ( useStartSpawnpoint )
@@ -181,29 +222,19 @@ entity function GetBestSpawnpoint( entity player, array<entity> spawnpoints )
 	foreach ( entity spawnpoint in spawnpoints )
 	{
 		if ( IsSpawnpointValid( spawnpoint, player.GetTeam() ) )
-		{
 			validSpawns.append( spawnpoint )
-			
-			if ( validSpawns.len() == 3 ) // arbitrary small sample size
-				break
-		}
 	}
 	
-	if ( validSpawns.len() == 0 )
+	if ( !validSpawns.len() )
 	{
 		// no valid spawns, very bad, so dont care about spawns being valid anymore
 		print( "found no valid spawns! spawns may be subpar!" )
 		foreach ( entity spawnpoint in spawnpoints )
-		{
 			validSpawns.append( spawnpoint )
-			
-			if ( validSpawns.len() == 3 ) // arbitrary small sample size
-				break
-		}
 	}
 	
 	// last resort
-	if ( validSpawns.len() == 0 )
+	if ( !validSpawns.len() )
 	{
 		print( "map has literally 0 spawnpoints, as such everything is fucked probably, attempting to use info_player_start if present" )
 		entity start = GetEnt( "info_player_start" )
@@ -215,7 +246,7 @@ entity function GetBestSpawnpoint( entity player, array<entity> spawnpoints )
 		}
 	}
 	
-	return validSpawns[ RandomInt( validSpawns.len() ) ] // slightly randomize it
+	return validSpawns.getrandom() // slightly randomize it
 }
 
 bool function IsSpawnpointValid( entity spawnpoint, int team )
@@ -232,15 +263,18 @@ bool function IsSpawnpointValid( entity spawnpoint, int team )
 			return false
 	}
 	
+	if( IsFFAGame() && !spawnpoint.IsVisibleToEnemies( team ) )
+		return true
+	
 	int compareTeam = spawnpoint.GetTeam()
-	if ( HasSwitchedSides() && ( compareTeam == TEAM_MILITIA || compareTeam == TEAM_IMC ) )
-		compareTeam = GetOtherTeam( compareTeam )
-		
+	if ( HasSwitchedSides() )
+		compareTeam = ( compareTeam == TEAM_MILITIA ) ? TEAM_IMC : TEAM_MILITIA
+	
 	foreach ( bool functionref( entity, int ) customValidationRule in file.customSpawnpointValidationRules )
 		if ( !customValidationRule( spawnpoint, team ) )
 			return false
 		
-	if ( spawnpoint.GetTeam() > 0 && compareTeam != team && !IsFFAGame() )
+	if ( spawnpoint.GetTeam() > 0 && compareTeam != team )
 		return false
 	
 	if ( spawnpoint.IsOccupied() )
@@ -261,28 +295,43 @@ bool function IsSpawnpointValid( entity spawnpoint, int team )
 			return false
 	}
 
-    const minEnemyDist = 1000.0 // about 20 meters?
-    // in rsquirrel extend returns null unlike in vanilla squirrel
-    array< entity > spawnBlockers = GetPlayerArrayEx( "any", TEAM_ANY, TEAM_ANY, spawnpoint.GetOrigin(), minEnemyDist )
-    spawnBlockers.extend( GetProjectileArrayEx( "any", TEAM_ANY, TEAM_ANY, spawnpoint.GetOrigin(), minEnemyDist ) )
-	foreach ( entity blocker in spawnBlockers )
-		if ( blocker.GetTeam() != team )
-			return false
+    const minEnemyDist = 1200.0
+    array< entity > spawnBlockers = GetPlayerArrayEx( "any", TEAM_ANY, spawnpoint.GetTeam(), spawnpoint.GetOrigin(), minEnemyDist )
+    spawnBlockers.extend( GetProjectileArrayEx( "any", TEAM_ANY, spawnpoint.GetTeam(), spawnpoint.GetOrigin(), minEnemyDist ) )
+    spawnBlockers.extend( GetNPCArrayEx( "any", TEAM_ANY, spawnpoint.GetTeam(), spawnpoint.GetOrigin(), minEnemyDist ) )
+	if ( spawnBlockers.len() )
+		return false
 	
 	// los check
 	return !spawnpoint.IsVisibleToEnemies( team )
 }
 
 
-// SPAWNPOINT RATING FUNCS BELOW
 
-// generic
+
+
+
+
+
+
+
+/*
+
+██████╗  ██████╗ ██╗███╗   ██╗████████╗    ██████╗  █████╗ ████████╗██╗███╗   ██╗ ██████╗ 
+██╔══██╗██╔═══██╗██║████╗  ██║╚══██╔══╝    ██╔══██╗██╔══██╗╚══██╔══╝██║████╗  ██║██╔════╝ 
+██████╔╝██║   ██║██║██╔██╗ ██║   ██║       ██████╔╝███████║   ██║   ██║██╔██╗ ██║██║  ███╗
+██╔═══╝ ██║   ██║██║██║╚██╗██║   ██║       ██╔══██╗██╔══██║   ██║   ██║██║╚██╗██║██║   ██║
+██║     ╚██████╔╝██║██║ ╚████║   ██║       ██║  ██║██║  ██║   ██║   ██║██║ ╚████║╚██████╔╝
+╚═╝      ╚═════╝ ╚═╝╚═╝  ╚═══╝   ╚═╝       ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ╚═╝╚═╝  ╚═══╝ ╚═════╝ 
+
+*/
+
 struct {
 	array<vector> preferSpawnNodes
 } spawnStateGeneric
 
 void function RateSpawnpoints_Generic( int checkClass, array<entity> spawnpoints, int team, entity player )
-{	
+{
 	if ( !IsFFAGame() )
 	{
 		// use frontline spawns in 2-team modes
@@ -399,14 +448,31 @@ void function InitPreferSpawnNodes()
 // frontline
 void function RateSpawnpoints_Frontline( int checkClass, array<entity> spawnpoints, int team, entity player )
 {
+	float rating = RandomFloatRange( 0.0, 100.0 )
 	foreach ( entity spawnpoint in spawnpoints )
-	{
-		float rating = spawnpoint.CalculateFrontlineRating()
-		spawnpoint.CalculateRating( checkClass, player.GetTeam(), rating, rating > 0 ? rating * 0.25 : rating )
-	}
+		spawnpoint.CalculateRating( checkClass, player.GetTeam(), rating, rating )
 }
 
-// spawnzones
+
+
+
+
+
+
+
+
+
+/*
+
+███████╗██████╗  █████╗ ██╗    ██╗███╗   ██╗███████╗ ██████╗ ███╗   ██╗███████╗███████╗
+██╔════╝██╔══██╗██╔══██╗██║    ██║████╗  ██║╚══███╔╝██╔═══██╗████╗  ██║██╔════╝██╔════╝
+███████╗██████╔╝███████║██║ █╗ ██║██╔██╗ ██║  ███╔╝ ██║   ██║██╔██╗ ██║█████╗  ███████╗
+╚════██║██╔═══╝ ██╔══██║██║███╗██║██║╚██╗██║ ███╔╝  ██║   ██║██║╚██╗██║██╔══╝  ╚════██║
+███████║██║     ██║  ██║╚███╔███╔╝██║ ╚████║███████╗╚██████╔╝██║ ╚████║███████╗███████║
+╚══════╝╚═╝     ╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═══╝╚══════╝ ╚═════╝ ╚═╝  ╚═══╝╚══════╝╚══════╝
+
+*/
+
 struct {
 	array<entity> mapSpawnzoneTriggers
 	entity functionref( array<entity>, int ) spawnzoneRatingFunc

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/spawn.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/spawn.nut
@@ -41,27 +41,6 @@ struct {
 	table<string, NoSpawnArea> noSpawnAreas
 } file
 
-
-
-
-
-
-
-
-
-
-
-/*
-
-██████╗  █████╗ ███████╗███████╗    ███████╗██╗   ██╗███╗   ██╗ ██████╗████████╗██╗ ██████╗ ███╗   ██╗███████╗
-██╔══██╗██╔══██╗██╔════╝██╔════╝    ██╔════╝██║   ██║████╗  ██║██╔════╝╚══██╔══╝██║██╔═══██╗████╗  ██║██╔════╝
-██████╔╝███████║███████╗█████╗      █████╗  ██║   ██║██╔██╗ ██║██║        ██║   ██║██║   ██║██╔██╗ ██║███████╗
-██╔══██╗██╔══██║╚════██║██╔══╝      ██╔══╝  ██║   ██║██║╚██╗██║██║        ██║   ██║██║   ██║██║╚██╗██║╚════██║
-██████╔╝██║  ██║███████║███████╗    ██║     ╚██████╔╝██║ ╚████║╚██████╗   ██║   ██║╚██████╔╝██║ ╚████║███████║
-╚═════╝ ╚═╝  ╚═╝╚══════╝╚══════╝    ╚═╝      ╚═════╝ ╚═╝  ╚═══╝ ╚═════╝   ╚═╝   ╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚══════╝
-
-*/
-
 void function Spawn_Init()
 {	
 	AddSpawnCallback( "info_spawnpoint_human", InitSpawnpoint )
@@ -147,31 +126,11 @@ void function InitRatings( entity player, int team )
 		SpawnPoints_InitRatings( player, team ) // no idea what the second arg supposed to be lol
 }
 
-
-
-
-
-
-
-
-
-
-/*
-
-███████╗██████╗  █████╗ ██╗    ██╗███╗   ██╗    ██████╗  ██████╗ ██╗███╗   ██╗████████╗███████╗
-██╔════╝██╔══██╗██╔══██╗██║    ██║████╗  ██║    ██╔══██╗██╔═══██╗██║████╗  ██║╚══██╔══╝██╔════╝
-███████╗██████╔╝███████║██║ █╗ ██║██╔██╗ ██║    ██████╔╝██║   ██║██║██╔██╗ ██║   ██║   ███████╗
-╚════██║██╔═══╝ ██╔══██║██║███╗██║██║╚██╗██║    ██╔═══╝ ██║   ██║██║██║╚██╗██║   ██║   ╚════██║
-███████║██║     ██║  ██║╚███╔███╔╝██║ ╚████║    ██║     ╚██████╔╝██║██║ ╚████║   ██║   ███████║
-╚══════╝╚═╝     ╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═══╝    ╚═╝      ╚═════╝ ╚═╝╚═╝  ╚═══╝   ╚═╝   ╚══════╝
-
-*/
-
 entity function FindSpawnPoint( entity player, bool isTitan, bool useStartSpawnpoint )
 {
 	int team = player.GetTeam()
 	if ( HasSwitchedSides() )
-		team = ( team == TEAM_MILITIA ) ? TEAM_IMC : TEAM_MILITIA
+		team = GetOtherTeam( team )
 
 	array<entity> spawnpoints
 	if ( useStartSpawnpoint )
@@ -307,31 +266,15 @@ bool function IsSpawnpointValid( entity spawnpoint, int team )
 }
 
 
+// SPAWNPOINT RATING FUNCS BELOW
 
-
-
-
-
-
-
-
-/*
-
-██████╗  ██████╗ ██╗███╗   ██╗████████╗    ██████╗  █████╗ ████████╗██╗███╗   ██╗ ██████╗ 
-██╔══██╗██╔═══██╗██║████╗  ██║╚══██╔══╝    ██╔══██╗██╔══██╗╚══██╔══╝██║████╗  ██║██╔════╝ 
-██████╔╝██║   ██║██║██╔██╗ ██║   ██║       ██████╔╝███████║   ██║   ██║██╔██╗ ██║██║  ███╗
-██╔═══╝ ██║   ██║██║██║╚██╗██║   ██║       ██╔══██╗██╔══██║   ██║   ██║██║╚██╗██║██║   ██║
-██║     ╚██████╔╝██║██║ ╚████║   ██║       ██║  ██║██║  ██║   ██║   ██║██║ ╚████║╚██████╔╝
-╚═╝      ╚═════╝ ╚═╝╚═╝  ╚═══╝   ╚═╝       ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ╚═╝╚═╝  ╚═══╝ ╚═════╝ 
-
-*/
-
+// generic
 struct {
 	array<vector> preferSpawnNodes
 } spawnStateGeneric
 
 void function RateSpawnpoints_Generic( int checkClass, array<entity> spawnpoints, int team, entity player )
-{
+{	
 	if ( !IsFFAGame() )
 	{
 		// use frontline spawns in 2-team modes
@@ -453,26 +396,7 @@ void function RateSpawnpoints_Frontline( int checkClass, array<entity> spawnpoin
 		spawnpoint.CalculateRating( checkClass, player.GetTeam(), rating, rating )
 }
 
-
-
-
-
-
-
-
-
-
-/*
-
-███████╗██████╗  █████╗ ██╗    ██╗███╗   ██╗███████╗ ██████╗ ███╗   ██╗███████╗███████╗
-██╔════╝██╔══██╗██╔══██╗██║    ██║████╗  ██║╚══███╔╝██╔═══██╗████╗  ██║██╔════╝██╔════╝
-███████╗██████╔╝███████║██║ █╗ ██║██╔██╗ ██║  ███╔╝ ██║   ██║██╔██╗ ██║█████╗  ███████╗
-╚════██║██╔═══╝ ██╔══██║██║███╗██║██║╚██╗██║ ███╔╝  ██║   ██║██║╚██╗██║██╔══╝  ╚════██║
-███████║██║     ██║  ██║╚███╔███╔╝██║ ╚████║███████╗╚██████╔╝██║ ╚████║███████╗███████║
-╚══════╝╚═╝     ╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝  ╚═══╝╚══════╝ ╚═════╝ ╚═╝  ╚═══╝╚══════╝╚══════╝
-
-*/
-
+// spawnzones
 struct {
 	array<entity> mapSpawnzoneTriggers
 	entity functionref( array<entity>, int ) spawnzoneRatingFunc

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/spawn.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/spawn.nut
@@ -130,7 +130,7 @@ entity function FindSpawnPoint( entity player, bool isTitan, bool useStartSpawnp
 {
 	int team = player.GetTeam()
 	if ( HasSwitchedSides() )
-		team = GetOtherTeam( team )
+		team = ( team == TEAM_MILITIA ) ? TEAM_IMC : TEAM_MILITIA
 
 	array<entity> spawnpoints
 	if ( useStartSpawnpoint )


### PR DESCRIPTION
Here's my babble to finally get rid of the shitty spawns for basically all gamemodes and especially make CTF playable.

What this PR tries to do:

1. Get rid of the odd logic of limiting the algorithm to 3 spawn points only, resulting in a very predictable and frustrating behavior.
2. Changes the specific CTF algorithm to calculate the spawn points from the Flag bases themselves rather than the initial spawn points which was causing severe inconsistencies.
3.  Remove some checks in regards to Map Side Swapping when matches reaches Half-Times, because apparently native code does flip the owning team of the spawn points together when that happens.
4. Mitigate usage of GetOtherTeam for certain checks since that function might return Unreachable when it's a gamemode with more than 2 Teams and intentionally script crash the server.