### PR TITLE
Fix oversight in "Total MVP" not registering in regards to progression

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -861,6 +861,7 @@ void function SetWinner( int team, string winningReason = "", string losingReaso
 					{
 						case 1:
 							UpdatePlayerStat( players[i], "game_stats", "mvp" )
+							UpdatePlayerStat( players[i], "game_stats", "mvp_total" )
 							UpdatePlayerStat( players[i], "game_stats", "top3OnTeam" )
 							break
 						case 2:

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_stats.nut
@@ -334,6 +334,10 @@ void function OnPlayerOrNPCKilled( entity victim, entity attacker, var damageInf
 		thread SetLastPosForDistanceStatValid_Threaded( victim, false )
 
 	HandleDeathStats( victim, attacker, damageInfo )
+	
+	if( victim == attacker ) //Suicides are registering stats, afaik vanilla ignores them
+		return
+	
 	HandleKillStats( victim, attacker, damageInfo )
 	HandleWeaponKillStats( victim, attacker, damageInfo )
 	HandleTitanStats( victim, attacker, damageInfo )


### PR DESCRIPTION
The game have an extra stat especifically to count the total amount of times a player has been MVP in all matches, while the other mvp stat which i previously thought to be absolutely is only registered per map, not globally.