### PR TITLE
Check player validity in `SetupChallenges_Threaded`

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_challenges.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_challenges.gnut
@@ -66,6 +66,9 @@ void function SetupPlayerMenuChallenges( entity player )
 void function SetupChallenges_Threaded( entity player )
 {
 	WaitFrame()
+
+        if ( !IsValid( player ) )
+            return
 	
 	Remote_CallFunction_UI( player, "SCB_SetCompleteMeritState", 0 )
 	Remote_CallFunction_UI( player, "SCB_SetEvacMeritState", 4 ) //4 tells RUI to hide it


### PR DESCRIPTION
So someone tried to join and immediately disconnect afterwards, and managed to crash the server after a few tries.
I speculate that if the player leaves during `WaitFrame()` in `SetupChallenges_Threaded`, then that is the cause.
I can't reproduce this so do what you will.

Server log (my auto-kicker kicked the player a few times because he was manually kicked before)

```
[18:11:25] [SCRIPT SV] [info] Player connect started: entity (2: player NSFWonGeneral [2])---UID:1008890740708
[18:11:25] [SCRIPT SV] [info] ############################
[18:11:25] [SCRIPT SV] [info] CommandString: VModEnable was not added via AddClientCommandCallback but is being called in CodeCallback_ClientCommand
[18:11:25] [SCRIPT SV] [info] ############################
[18:11:25] [SCRIPT SV] [info] ############################
[18:11:25] [SCRIPT SV] [info] CommandString: vban was not added via AddClientCommandCallback but is being called in CodeCallback_ClientCommand
[18:11:25] [SCRIPT SV] [info] ############################

...

[18:11:25] [SCRIPT SV] [info] AttackerShouldTriggerReplay(): Doing a replay because the attacker is a player.
[18:11:25] [SCRIPT SV] [info] [NUTONEAPI] Kill data sent!
[18:11:25] [SCRIPT SV] [info] Player client script initialization complete: entity (2: player NSFWonGeneral [2])
[18:11:25] [SCRIPT SV] [info] [fvnkhead.NetLib] client connected: 'NSFWonGeneral'/1008890740708/[redacted]
[18:11:25] [SCRIPT SV] [info] [ParseableLog]{"subject":{"type":"player","name":"NSFWonGeneral","playerIndex":1,"teamId":2,"uid":"1008890740708","ping":20972099,"kills":0,"deaths":0,"alive":false},"verb":"connected"}
[18:11:25] [SCRIPT SV] [info] [fvnkhead.mod] [Kick_Callback] kicking player 'NSFWonGeneral'/1008890740708/[redacted] due to network match: [redacted]
[18:11:26] [SCRIPT SV] [info] pilot primary skin/camo 0 0
[18:11:26] [SCRIPT SV] [info] pilot secondary skin/camo 1 46
[18:11:26] [SCRIPT SV] [info] pilot weapon3 skin/camo 1 20
[18:11:26] [SCRIPT SV] [info] [ParseableLog]{"subject":{"type":"player","name":"NSFWonGeneral","playerIndex":1,"teamId":2,"uid":"1008890740708","ping":20972099,"kills":0,"deaths":0,"alive":true,"titan":false,"location":{"type":"vector","x":6555.19,"y":-1393.77,"z":2247.03}},"verb":"respawned"}
[18:11:26] [SCRIPT SV] [info] [fvnkhead.mod] [Kick_Callback] kicking player 'NSFWonGeneral'/1008890740708/[redacted] due to network match: [redacted]
[18:11:26] [SCRIPT SV] [info] ############################
[18:11:26] [SCRIPT SV] [info] CommandString: ClientStatus was not added via AddClientCommandCallback but is being called in CodeCallback_ClientCommand
[18:11:26] [SCRIPT SV] [info] ############################
[18:11:26] [SCRIPT SV] [info] ############################
[18:11:26] [SCRIPT SV] [info] CommandString: AllDialogueFinished was not added via AddClientCommandCallback but is being called in CodeCallback_ClientCommand
[18:11:26] [SCRIPT SV] [info] ############################
[18:11:26] [NORTHSTAR] [info] hostname: fvnkhead's 8v8
[18:11:26] [NORTHSTAR] [info] version : 2.0.0.1/2001 6968 insecure
[18:11:26] [NORTHSTAR] [info] udp/ip  :  ::ffff:172.17.0.2:40000 os(Windows) type(dedicated)
[18:11:26] [NORTHSTAR] [info] players : 16 humans, 0 bots (16 max) (not hibernating)

[18:11:26] [NORTHSTAR] [info] # userid name uniqueid connected ping loss state rate

...

[18:11:26] [NORTHSTAR] [info] # 2 "NSFWonGeneral" 00:02 260 52 active 128000

...

[18:11:26] [NORTHSTAR] [info] #end
[18:11:26] [NORTHSTAR] [info] Player NSFWonGeneral disconnected: "Console"
[18:11:26] [SCRIPT SV] [info] [ParseableLog]{"subject":{"type":"player","name":"NSFWonGeneral","playerIndex":1,"teamId":2,"uid":"1008890740708","ping":20972099,"kills":0,"deaths":0,"alive":true,"titan":false,"location":{"type":"vector","x":6555.19,"y":-1393.77,"z":2246.03}},"verb":"disconnected"}
[18:11:26] [NORTHSTAR] [info] Player NSFWonGeneral disconnected: "Console"
[18:11:26] [NORTHSTAR] [warn] attempted to write pdata of size 0!
[18:11:26] [SCRIPT SV] [info] SCRIPT ERROR: [SERVER] Parameter is not an entity.
[18:11:26] [SCRIPT SV] [info]  -> Remote_CallFunction_UI( player, "SCB_SetCompleteMeritState", 0 )
[18:11:26] [SCRIPT SV] [info]
CALLSTACK
*FUNCTION [SetupChallenges_Threaded()] mp/_challenges.gnut line [70]

[18:11:26] [SCRIPT SV] [info] LOCALS
[player] ENTITY (NULL)
[this] TABLE

DIAGPRINTS

[18:11:26] [NORTHSTAR] [errr] -------------------------------------------
[18:11:26] [NORTHSTAR] [errr] Northstar has crashed!
[18:11:26] [NORTHSTAR] [errr]   Version: 1.26.1.0
[18:11:26] [NORTHSTAR] [errr]   EXCEPTION_ACCESS_VIOLATION
[18:11:26] [NORTHSTAR] [errr]   Attempted to read from: 0xffffffffffffffff
[18:11:26] [NORTHSTAR] [errr]   At: Northstar.dll + 0x325f35
```