### PR TITLE
Change `IsValid()` check to `EndSignal()`

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_challenges.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_challenges.gnut
@@ -65,10 +65,9 @@ void function SetupPlayerMenuChallenges( entity player )
 
 void function SetupChallenges_Threaded( entity player )
 {
+	player.EndSignal( "OnDestroy" )
+	
 	WaitFrame()
-
-        if ( !IsValid( player ) )
-            return
 	
 	Remote_CallFunction_UI( player, "SCB_SetCompleteMeritState", 0 )
 	Remote_CallFunction_UI( player, "SCB_SetEvacMeritState", 4 ) //4 tells RUI to hide it


### PR DESCRIPTION
`_challenges.gnut` is quite a recently written script by me, @BobTheBob9 suggested to change the `IsValid` to `EndSignal` in discord and so i'm doing this mostly to keep the newly written code consistent in the formatting, and End Signals is truly a better use for this case.