### PR TITLE
Add option to manually run merge conflict label action

### DIFF
--- a/.github/workflows/merge-conflict-auto-label.yml
+++ b/.github/workflows/merge-conflict-auto-label.yml
@@ -1,5 +1,6 @@
 name: Merge Conflict Auto Label
 on:
+  workflow_dispatch: # Manual run
   push:
     branches:
       - main


### PR DESCRIPTION
Add option to manually run merge conflict label action so that labels can easily be updated if need be.