### PR TITLE
Support multiple spaces in custom damage source ID display names

### DIFF
--- a/Northstar.Custom/mod/scripts/vscripts/sh_damage_types.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/sh_damage_types.nut
@@ -727,7 +727,7 @@ bool function RegisterWeaponDamageSourceInternal( int id, string newVal, string 
 	damageSourceID[ newVal ] <- id
 	file.damageSourceIDToString[ id ] <- newVal
 	file.damageSourceIDToName[ id ] <- stringVal
-	file.customDamageSourceIDList.extend( [ id.tostring(), newVal, StringReplace( stringVal, " ", MESSAGE_SPACE_PADDING ) ] )
+	file.customDamageSourceIDList.extend( [ id.tostring(), newVal, StringReplace( stringVal, " ", MESSAGE_SPACE_PADDING, true ) ] )
 	return true
 }
 
@@ -773,6 +773,6 @@ void function ReceiveNewDamageSourceIDs( array<string> args )
 {
 	// IDs are inserted to the custom list in triplets, so we can trust these indices exist and the loop will end properly
 	for ( int i = 0; i < args.len(); i += 3 )
-		RegisterWeaponDamageSourceInternal( args[ i ].tointeger(), args[ i + 1 ], StringReplace( args[ i + 2 ], MESSAGE_SPACE_PADDING, " " ) )
+		RegisterWeaponDamageSourceInternal( args[ i ].tointeger(), args[ i + 1 ], StringReplace( args[ i + 2 ], MESSAGE_SPACE_PADDING, " ", true ) )
 }
 #endif


### PR DESCRIPTION
Simple change that allows the custom damage source IDs to support multiple spaces rather than only one. The logic relies on string commands to sync them, so having spaces in the names causes issues. Currently it only replaces one space.

For instance, `RegisterWeaponDamageSource( "mp_titanweapon_brute4_quad_rocket", "Brute4 Quad Rocket" )` results in a client crash:

![damage_type_crash_example](https://github.com/user-attachments/assets/6b269f98-ee00-4ff6-826c-ecb75d5428d3)

With the PR, it works:

![damage_type_example](https://github.com/user-attachments/assets/8fdbcc96-e81b-418d-8b90-91c63aaeb7b3)