### PR TITLE
allow gamemode mods to use banners as mode images and patches as icons

### DIFF
--- a/Northstar.Client/mod/resource/ui/menus/mode_select.menu
+++ b/Northstar.Client/mod/resource/ui/menus/mode_select.menu
@@ -1,0 +1,357 @@
+resource/ui/menus/mode_select.menu
+{
+	menu
+	{
+		ControlName				Frame
+		xpos					0
+		ypos					0
+		zpos					3
+		wide					f0
+		tall					f0
+		autoResize				0
+		pinCorner				0
+		visible					1
+		enabled					1
+		PaintBackgroundType		0
+		infocus_bgcolor_override	"0 0 0 0"
+		outoffocus_bgcolor_override	"0 0 0 0"
+
+		MenuCommon
+		{
+			ControlName				CNestedPanel
+			xpos					0
+			ypos					0
+			wide					f0
+			tall					f0
+			visible					1
+			controlSettingsFile		"resource/ui/menus/panels/menu_common.res"
+		}
+
+		MatchmakingStatus
+		{
+			ControlName				CNestedPanel
+			xpos					0
+			ypos					0
+			wide					f0
+			tall					f0
+			visible					1
+			controlSettingsFile		"resource/ui/menus/panels/matchmaking_status.res"
+		}
+
+        NextModeImageFrame
+        {
+            ControlName				RuiPanel
+			xpos 					800
+			ypos					160
+			wide					860
+			tall					418
+            labelText				""
+            visible				    1
+            bgcolor_override        "0 0 0 0"
+            paintbackground         1
+            rui                     "ui/basic_border_box.rpak"
+        }
+
+		NextModeImage
+		{
+			ControlName				RuiPanel
+			pin_to_sibling			NextModeImageFrame
+			pin_corner_to_sibling	BOTTOM
+			pin_to_sibling_corner	BOTTOM
+//			xpos                    -12
+			ypos                    -12
+			wide					480
+			tall					240
+			visible					1
+			scaleImage				1
+            rui                     "ui/basic_menu_image.rpak"
+			zpos					2
+		}
+		NextModeImageCallsign //For calling card icons
+		{
+			ControlName 			RuiPanel
+//			xpos                    -12
+			ypos                    -12
+			wide					480
+			tall					240
+			visible 				1
+			scaleImage 				1
+			zpos 					2
+			pin_to_sibling			NextModeImageFrame
+			pin_corner_to_sibling	BOTTOM
+			pin_to_sibling_corner	BOTTOM
+			rui "ui/callsign_icon_button.rpak" //For callsign mode images
+		}
+		ModeIconImage
+		{
+			ControlName				RuiPanel
+			pin_to_sibling			NextModeImage
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	TOP_LEFT
+			xpos                    0
+			ypos                    -16
+			wide					72
+			tall					72
+			visible					1
+			scaleImage				1
+            rui                     "ui/basic_image_add.rpak"
+			zpos					3
+		}
+
+		NextModeName
+		{
+			ControlName				Label
+			pin_to_sibling			NextModeImageFrame
+			pin_corner_to_sibling	TOP
+			pin_to_sibling_corner	TOP
+			ypos					-20
+			wide                    840
+			auto_tall_tocontents	1
+			visible					1
+			labelText				"Foo"
+			textAlignment           center
+			centerWrap              1
+			font					Default_43_DropShadow
+			allcaps					1
+			fgcolor_override		"255 255 255 255"
+		}
+
+		NextModeDesc
+		{
+			ControlName				Label
+			pin_to_sibling			NextModeName
+			pin_corner_to_sibling	TOP
+			pin_to_sibling_corner	BOTTOM
+			xpos					0
+			ypos					0
+			wide					840
+			wrap					1
+			auto_tall_tocontents	1
+			visible					1
+			labelText				"Bar"
+			textAlignment           center
+			centerWrap              1
+			font					Default_27
+			allcaps					0
+			fgcolor_override		"255 255 255 255"
+		}
+
+		MenuTitle
+		{
+			ControlName				Label
+			InheritProperties		MenuTitle
+			labelText				"#SELECT_GAME_MODE"
+		}
+
+		ButtonRowAnchor
+		{
+			ControlName				Label
+			labelText				""
+
+			xpos                    96
+            ypos                    160
+		}
+
+		BtnMode1
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				0
+			navUp					BtnMode15
+			navDown					BtnMode2
+
+			pin_to_sibling				ButtonRowAnchor
+			pin_corner_to_sibling		TOP_LEFT
+			pin_to_sibling_corner		TOP_LEFT
+		}
+		BtnMode2
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				1
+			pin_to_sibling			BtnMode1
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode1
+			navDown					BtnMode3
+		}
+		BtnMode3
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				2
+			pin_to_sibling			BtnMode2
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode2
+			navDown					BtnMode4
+		}
+		BtnMode4
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				3
+			pin_to_sibling			BtnMode3
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			//ypos					11
+			navUp					BtnMode3
+			navDown					BtnMode5
+		}
+		BtnMode5
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				4
+			pin_to_sibling			BtnMode4
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode4
+			navDown					BtnMode6
+		}
+		BtnMode6
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				5
+			pin_to_sibling			BtnMode5
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode5
+			navDown					BtnMode7
+		}
+		BtnMode7
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				6
+			pin_to_sibling			BtnMode6
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode6
+			navDown					BtnMode8
+		}
+		BtnMode8
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				7
+			pin_to_sibling			BtnMode7
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode7
+			navDown					BtnMode9
+		}
+		BtnMode9
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				8
+			pin_to_sibling			BtnMode8
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode8
+			navDown					BtnMode10
+		}
+		BtnMode10
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				9
+			pin_to_sibling			BtnMode9
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode9
+			navDown					BtnMode11
+		}
+		BtnMode11
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				10
+			pin_to_sibling			BtnMode10
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode10
+			navDown					BtnMode12
+		}
+		BtnMode12
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				11
+			pin_to_sibling			BtnMode11
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode11
+			navDown					BtnMode13
+		}
+		BtnMode13
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				12
+			pin_to_sibling			BtnMode12
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode12
+			navDown					BtnMode14
+		}
+		BtnMode14
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				13
+			pin_to_sibling			BtnMode13
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode13
+			navDown					BtnMode15
+		}
+		BtnMode15
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiSmallButton
+			classname 				ModeButton
+			scriptID				14
+			pin_to_sibling			BtnMode14
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+			navUp					BtnMode14
+			navDown					BtnMode1
+		}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+		ButtonTooltip
+		{
+			ControlName				CNestedPanel
+			InheritProperties		ButtonTooltip
+		}
+
+		FooterButtons
+		{
+			ControlName				CNestedPanel
+			xpos					0
+			ypos					r119
+			wide					f0
+			tall					36
+			visible					1
+			controlSettingsFile		"resource/ui/menus/panels/footer_buttons.res"
+		}
+	}
+}

--- a/Northstar.Client/mod/resource/ui/menus/mode_select.menu
+++ b/Northstar.Client/mod/resource/ui/menus/mode_select.menu
@@ -19,22 +19,16 @@ resource/ui/menus/mode_select.menu
 		MenuCommon
 		{
 			ControlName				CNestedPanel
-			xpos					0
-			ypos					0
 			wide					f0
 			tall					f0
-			visible					1
 			controlSettingsFile		"resource/ui/menus/panels/menu_common.res"
 		}
 
 		MatchmakingStatus
 		{
 			ControlName				CNestedPanel
-			xpos					0
-			ypos					0
 			wide					f0
 			tall					f0
-			visible					1
 			controlSettingsFile		"resource/ui/menus/panels/matchmaking_status.res"
 		}
 

--- a/Northstar.Client/mod/resource/ui/menus/mode_select.menu
+++ b/Northstar.Client/mod/resource/ui/menus/mode_select.menu
@@ -91,6 +91,21 @@ resource/ui/menus/mode_select.menu
             rui                     "ui/basic_image_add.rpak"
 			zpos					3
 		}
+		ModeIconImagePatch //For patch icons
+		{
+			ControlName 			RuiPanel
+			xpos                    0
+			ypos                    -16
+			wide					72
+			tall					72
+			visible 				1
+			scaleImage 				1
+			zpos					3
+			pin_to_sibling			NextModeImage
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	TOP_LEFT
+			rui "ui/callsign_icon_button.rpak"
+		}
 
 		NextModeName
 		{

--- a/Northstar.Client/mod/resource/ui/menus/private_lobby.menu
+++ b/Northstar.Client/mod/resource/ui/menus/private_lobby.menu
@@ -1,0 +1,292 @@
+#base "combo_buttons.res"
+resource/ui/menus/private_lobby.menu
+{
+	menu
+	{
+		ControlName				Frame
+		xpos					0
+		ypos					0
+		zpos					3
+		wide					f0
+		tall					f0
+		autoResize				0
+		pinCorner				0
+		visible					1
+		enabled					1
+		PaintBackgroundType		0
+		infocus_bgcolor_override	"0 0 0 0"
+		outoffocus_bgcolor_override	"0 0 0 0"
+
+        Vignette
+        {
+            ControlName             ImagePanel
+            InheritProperties       MenuVignette
+        }
+
+		MenuTitle
+		{
+			ControlName				Label
+			InheritProperties		MenuTitle
+			labelText				"#PRIVATE_LOBBY"
+		}
+
+		ImgTopBar
+		{
+			ControlName				ImagePanel
+			InheritProperties		MenuTopBar
+		}
+
+		MatchmakingStatus
+		{
+			ControlName				CNestedPanel
+			wide					f0
+			tall					f0
+			visible					1
+			controlSettingsFile		"resource/ui/menus/panels/matchmaking_status.res"
+		}
+
+	    CreditsAvailable
+	    {
+	        ControlName             RuiPanel
+	        InheritProperties       CreditsAvailableProperties
+	    }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        Screen
+        {
+            ControlName		ImagePanel
+			wide					f0
+			tall					f0
+            visible			1
+            scaleImage		1
+            fillColor		"0 0 0 0"
+            drawColor		"0 0 0 0"
+        }
+
+		CallsignCard
+		{
+			ControlName				RuiPanel
+			rui                     "ui/callsign_basic.rpak"
+			pin_to_sibling          Screen
+            pin_corner_to_sibling	TOP_RIGHT
+            pin_to_sibling_corner	TOP_RIGHT
+            xpos					-96
+            ypos					-166
+			wide                    320
+			tall                    172
+			visible					1
+			scaleImage				1
+			image					vgui/white
+            fillColor               "255 255 255 255"
+			zpos -1
+		}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+		ButtonRowAnchor
+		{
+			ControlName				Label
+			labelText				""
+
+			xpos                    96
+			ypos                    215
+		}
+
+		StartMatchButton
+		{
+			ControlName				RuiButton
+			InheritProperties		RuiStartMatchButton
+			visible					1
+			tabposition             1
+			ypos                    10
+
+			navRight                ListFriendlies
+
+			pin_to_sibling			ButtonRowAnchor
+			pin_corner_to_sibling	BOTTOM_LEFT
+			pin_to_sibling_corner	TOP_LEFT
+		}
+
+		NextMapImage
+		{
+			ControlName				RuiPanel
+			wide					500
+			tall					288
+			visible					0
+			scaleImage				1
+			image					""
+			zpos -1
+
+			rui                     "ui/basic_menu_image.rpak"
+
+			pin_to_sibling			MatchEnemiesPanel
+			pin_corner_to_sibling	BOTTOM_LEFT
+			pin_to_sibling_corner	TOP_LEFT
+
+			ypos					16
+		}
+		NextMapName
+		{
+			ControlName				Label
+			pin_to_sibling			NextMapImage
+			pin_corner_to_sibling	BOTTOM_RIGHT
+			pin_to_sibling_corner	BOTTOM_RIGHT
+
+			xpos                    -12
+			ypos                    0
+
+			auto_wide_tocontents 	1
+			auto_tall_tocontents	1
+			labelText				""
+			font					Default_43_DropShadow
+			allcaps					1
+			fgcolor_override		"255 255 255 255"
+		}
+		NextGameModeName
+		{
+			ControlName				Label
+			pin_to_sibling			NextMapName
+			pin_corner_to_sibling	BOTTOM_RIGHT
+			pin_to_sibling_corner	TOP_RIGHT
+
+			ypos					-8
+
+			auto_wide_tocontents 	1
+			auto_tall_tocontents	1
+			labelText				""
+			use_proportional_insets	1
+			textinsetx 				2
+			font					Default_28_DropShadow
+			allcaps					1
+			fgcolor_override		"255 255 255 255"
+		}
+		NextModeIcon
+		{
+			ControlName				RuiPanel
+			wide					72
+			tall					72
+			visible					0
+			scaleImage				1
+			image					""
+
+			rui                     "ui/basic_image_add.rpak"
+
+			pin_to_sibling			NextGameModeName
+			pin_corner_to_sibling	BOTTOM_RIGHT
+			pin_to_sibling_corner	TOP_RIGHT
+		}
+		NextModeIconPatch
+		{
+			ControlName				RuiPanel
+			wide					72
+			tall					72
+			visible					0
+			scaleImage				1
+			image					""
+
+			rui                     "ui/basic_image_add.rpak"
+
+			pin_to_sibling			NextGameModeName
+			pin_corner_to_sibling	BOTTOM_RIGHT
+			pin_to_sibling_corner	TOP_RIGHT
+		}
+
+		MatchSettings
+		{
+			ControlName				RuiPanel
+			InheritProperties		MenuTooltipLarge
+
+			rui                     "ui/private_settings_description.rpak"
+
+			pin_to_sibling			NextMapImage
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	TOP_RIGHT
+			xpos 16
+			ypos 0
+			
+			wide 500
+			tall 288
+
+			visible 0
+		}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+		SpectatorLabel
+		{
+			ControlName				Label
+			pin_to_sibling			MatchFriendliesPanel
+			pin_corner_to_sibling	BOTTOM_LEFT
+			pin_to_sibling_corner	TOP_LEFT
+
+			xpos                    0
+			ypos                    0
+
+			textAlignment           center
+
+            wide                    500
+            tall                    40
+			labelText				"#LOBBY_SPECTATOR"
+			font					Default_26
+			allcaps					1
+			fgcolor_override		"255 255 255 255"
+		}
+		MatchFriendliesPanel
+		{
+			ControlName				CNestedPanel
+
+			pin_to_sibling			ButtonRowAnchor
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+
+            ypos                    435
+
+			InheritProperties		LobbyPlayerListBackground
+			controlSettingsFile		"resource/ui/menus/panels/match_friendlies.res"
+		}
+
+		MatchEnemiesPanel
+		{
+			ControlName				CNestedPanel
+
+			pin_to_sibling			MatchFriendliesPanel
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	TOP_RIGHT
+
+			xpos                    16
+
+			InheritProperties		LobbyPlayerListBackground
+			controlSettingsFile		"resource/ui/menus/panels/match_enemies.res"
+		}
+
+		LobbyChatBox [$WINDOWS]
+		{
+			ControlName				CBaseHudChat
+			InheritProperties		ChatBox
+
+			destination				"match"
+			messageModeAlwaysOn		1
+
+			pin_to_sibling			MatchEnemiesPanel
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	TOP_RIGHT
+
+			xpos					16
+		}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+		ButtonTooltip
+		{
+			ControlName				CNestedPanel
+			InheritProperties		ButtonTooltip
+		}
+
+		FooterButtons
+		{
+			ControlName				CNestedPanel
+			InheritProperties       FooterButtons
+		}
+	}
+}

--- a/Northstar.Client/mod/resource/ui/menus/server_browser.menu
+++ b/Northstar.Client/mod/resource/ui/menus/server_browser.menu
@@ -2491,6 +2491,22 @@ resource/ui/menus/mods_browse.menu
 			pin_corner_to_sibling BOTTOM_RIGHT
 			pin_to_sibling_corner TOP_RIGHT
 		}
+		NextModeIconPatch
+		{
+			ControlName RuiPanel
+			wide 72
+			tall 72
+			visible 0
+			scaleImage 1
+			image ""
+			zpos 1
+
+			rui                     "ui/callsign_icon_button.rpak"
+
+			pin_to_sibling NextGameModeName
+			pin_corner_to_sibling BOTTOM_RIGHT
+			pin_to_sibling_corner TOP_RIGHT
+		}
 
 		ServerName
 		{

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_mode_select.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_mode_select.nut
@@ -102,14 +102,14 @@ void function ModeButton_GetFocus( var button )
 		asset playlistImage = GetPlaylistImage( modeName )
 		RuiSetImage( Hud_GetRui( nextModeImage ), "basicImage", playlistImage )
 		Hud_SetVisible(nextModeImage, true)
-        Hud_SetVisible(nextModeImageAlt, false)
+        	Hud_SetVisible(nextModeImageAlt, false)
 	}
 	else
 	{
 		asset playlistImage = GetPlaylistBannerImage(imagename)
 		RuiSetImage( Hud_GetRui( nextModeImageAlt ), "iconImage", playlistImage )
 		Hud_SetVisible(nextModeImageAlt, true)
-        Hud_SetVisible(nextModeImage, false)
+        	Hud_SetVisible(nextModeImage, false)
 	}
 	RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( modeName ) )
 	Hud_SetText( nextModeName, GetGameModeDisplayName( modeName ) )

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_mode_select.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_mode_select.nut
@@ -1,7 +1,10 @@
 global function InitModesMenu
 
+global function RegisterPlaylistBannerImage
+global function GetPlaylistBannerImage
 struct {
 	int currentModePage
+	table<string, asset> bannerPlaylistImages
 } file
 
 const int MODES_PER_PAGE = 15
@@ -20,6 +23,20 @@ void function InitModesMenu()
 	
 	AddMenuFooterOption( menu, BUTTON_SHOULDER_LEFT, "#PRIVATE_MATCH_PAGE_PREV", "#PRIVATE_MATCH_PAGE_PREV", CycleModesBack )
 	AddMenuFooterOption( menu, BUTTON_SHOULDER_RIGHT, "#PRIVATE_MATCH_PAGE_NEXT", "#PRIVATE_MATCH_PAGE_NEXT", CycleModesForward )
+}
+
+bool function RegisterPlaylistBannerImage(string name, asset image)
+{
+	if( name in file.bannerPlaylistImages )
+		return false
+	file.bannerPlaylistImages[name] <- image
+	return true
+}
+asset function GetPlaylistBannerImage(string name)
+{
+	if(!( name in file.bannerPlaylistImages ))
+		return $""
+	return file.bannerPlaylistImages[name]
 }
 
 void function OnOpenModesMenu()
@@ -66,6 +83,7 @@ void function ModeButton_GetFocus( var button )
 
 	var menu = GetMenu( "ModesMenu" )
 	var nextModeImage = Hud_GetChild( menu, "NextModeImage" )
+	var nextModeImageAlt = Hud_GetChild( menu, "NextModeImageCallsign" )
 	var nextModeIcon = Hud_GetChild( menu, "ModeIconImage" )
 	var nextModeName = Hud_GetChild( menu, "NextModeName" )
 	var nextModeDesc = Hud_GetChild( menu, "NextModeDesc" )
@@ -77,8 +95,22 @@ void function ModeButton_GetFocus( var button )
 
 	string modeName = modesArray[modeId]
 
-	asset playlistImage = GetPlaylistImage( modeName )
-	RuiSetImage( Hud_GetRui( nextModeImage ), "basicImage", playlistImage )
+
+	string imagename = GetPlaylistVarOrUseValue( modeName, "image", "default" )
+	if(GetPlaylistBannerImage(imagename) == $"")
+	{
+		asset playlistImage = GetPlaylistImage( modeName )
+		RuiSetImage( Hud_GetRui( nextModeImage ), "basicImage", playlistImage )
+		Hud_SetVisible(nextModeImage, true)
+        Hud_SetVisible(nextModeImageAlt, false)
+	}
+	else
+	{
+		asset playlistImage = GetPlaylistBannerImage(imagename)
+		RuiSetImage( Hud_GetRui( nextModeImageAlt ), "iconImage", playlistImage )
+		Hud_SetVisible(nextModeImageAlt, true)
+        Hud_SetVisible(nextModeImage, false)
+	}
 	RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( modeName ) )
 	Hud_SetText( nextModeName, GetGameModeDisplayName( modeName ) )
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_mode_select.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_mode_select.nut
@@ -1,10 +1,8 @@
 global function InitModesMenu
 
-global function RegisterPlaylistBannerImage
-global function GetPlaylistBannerImage
+
 struct {
 	int currentModePage
-	table<string, asset> bannerPlaylistImages
 } file
 
 const int MODES_PER_PAGE = 15
@@ -25,19 +23,6 @@ void function InitModesMenu()
 	AddMenuFooterOption( menu, BUTTON_SHOULDER_RIGHT, "#PRIVATE_MATCH_PAGE_NEXT", "#PRIVATE_MATCH_PAGE_NEXT", CycleModesForward )
 }
 
-bool function RegisterPlaylistBannerImage(string name, asset image)
-{
-	if( name in file.bannerPlaylistImages )
-		return false
-	file.bannerPlaylistImages[name] <- image
-	return true
-}
-asset function GetPlaylistBannerImage(string name)
-{
-	if(!( name in file.bannerPlaylistImages ))
-		return $""
-	return file.bannerPlaylistImages[name]
-}
 
 void function OnOpenModesMenu()
 {
@@ -85,6 +70,7 @@ void function ModeButton_GetFocus( var button )
 	var nextModeImage = Hud_GetChild( menu, "NextModeImage" )
 	var nextModeImageAlt = Hud_GetChild( menu, "NextModeImageCallsign" )
 	var nextModeIcon = Hud_GetChild( menu, "ModeIconImage" )
+	var nextModeIconAlt = Hud_GetChild( menu, "ModeIconImagePatch" )
 	var nextModeName = Hud_GetChild( menu, "NextModeName" )
 	var nextModeDesc = Hud_GetChild( menu, "NextModeDesc" )
 
@@ -96,22 +82,38 @@ void function ModeButton_GetFocus( var button )
 	string modeName = modesArray[modeId]
 
 
-	string imagename = GetPlaylistVarOrUseValue( modeName, "image", "default" )
-	if(GetPlaylistBannerImage(imagename) == $"")
+	string imageName = GetPlaylistVarOrUseValue( modeName, "imageOverride", "default" )
+	if(imageName == "default")
 	{
 		asset playlistImage = GetPlaylistImage( modeName )
 		RuiSetImage( Hud_GetRui( nextModeImage ), "basicImage", playlistImage )
+		
 		Hud_SetVisible(nextModeImage, true)
-        	Hud_SetVisible(nextModeImageAlt, false)
+		Hud_SetVisible(nextModeImageAlt, false)
 	}
 	else
 	{
-		asset playlistImage = GetPlaylistBannerImage(imagename)
+		asset playlistImage = StringToAsset(imageName)
 		RuiSetImage( Hud_GetRui( nextModeImageAlt ), "iconImage", playlistImage )
+		
 		Hud_SetVisible(nextModeImageAlt, true)
-        	Hud_SetVisible(nextModeImage, false)
+		Hud_SetVisible(nextModeImage, false)
 	}
-	RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( modeName ) )
+	string iconName = GetPlaylistVarOrUseValue( modeName, "IconOverride", "default" )
+	if(iconName == "default")
+	{
+		RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( modeName ) )
+		Hud_SetVisible(nextModeIcon, true)
+		Hud_SetVisible(nextModeIconAlt, false)
+	}
+	else
+	{
+		var rui = Hud_GetRui( nextModeIconAlt )
+		RuiSetImage( rui, "iconImage", StringToAsset(iconName) )
+		Hud_SetVisible(nextModeIcon, false)
+		Hud_SetVisible(nextModeIconAlt, true)
+	}
+
 	Hud_SetText( nextModeName, GetGameModeDisplayName( modeName ) )
 
 	string mapName = PrivateMatch_GetSelectedMap()

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_mode_select.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_mode_select.nut
@@ -103,7 +103,7 @@ void function ModeButton_GetFocus( var button )
 	if( iconName == "default" )
 	{
 		RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( modeName ) )
-		Hud_Showe( nextModeIcon )
+		Hud_Show( nextModeIcon )
 		Hud_Hide( nextModeIconAlt )
 	}
 	else

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_mode_select.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_mode_select.nut
@@ -83,35 +83,35 @@ void function ModeButton_GetFocus( var button )
 
 
 	string imageName = GetPlaylistVarOrUseValue( modeName, "imageOverride", "default" )
-	if(imageName == "default")
+	if( imageName == "default" )
 	{
 		asset playlistImage = GetPlaylistImage( modeName )
 		RuiSetImage( Hud_GetRui( nextModeImage ), "basicImage", playlistImage )
 		
-		Hud_SetVisible(nextModeImage, true)
-		Hud_SetVisible(nextModeImageAlt, false)
+		Hud_Show( nextModeImage )
+		Hud_Hide( nextModeImageAlt )
 	}
 	else
 	{
-		asset playlistImage = StringToAsset(imageName)
+		asset playlistImage = StringToAsset( imageName )
 		RuiSetImage( Hud_GetRui( nextModeImageAlt ), "iconImage", playlistImage )
 		
-		Hud_SetVisible(nextModeImageAlt, true)
-		Hud_SetVisible(nextModeImage, false)
+	    Hud_Show( nextModeImageAlt )
+		Hud_Hide( nextModeImage )
 	}
 	string iconName = GetPlaylistVarOrUseValue( modeName, "IconOverride", "default" )
-	if(iconName == "default")
+	if( iconName == "default" )
 	{
 		RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( modeName ) )
-		Hud_SetVisible(nextModeIcon, true)
-		Hud_SetVisible(nextModeIconAlt, false)
+		Hud_Showe( nextModeIcon )
+		Hud_Hide( nextModeIconAlt )
 	}
 	else
 	{
 		var rui = Hud_GetRui( nextModeIconAlt )
-		RuiSetImage( rui, "iconImage", StringToAsset(iconName) )
-		Hud_SetVisible(nextModeIcon, false)
-		Hud_SetVisible(nextModeIconAlt, true)
+		RuiSetImage( rui, "iconImage", StringToAsset( iconName ) )
+		Hud_Show( nextModeIcon )
+		Hud_Hide( nextModeIconAlt )
 	}
 
 	Hud_SetText( nextModeName, GetGameModeDisplayName( modeName ) )

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -763,7 +763,6 @@ void function FilterServerList()
 		tempServer.serverPlayers = NSGetServerPlayerCount( i )
 		tempServer.serverPlayersMax = NSGetServerMaxPlayerCount( i )
 		tempServer.serverMap = NSGetServerMap( i )
-		//tempServer.serverGamemode = GetGameModeDisplayName( NSGetServerPlaylist ( i ) )
 		tempServer.serverGamemode =  NSGetServerPlaylist ( i ) 
 
 		totalPlayers += tempServer.serverPlayers
@@ -937,9 +936,7 @@ void function DisplayFocusedServerInfo( int scriptID )
 	// mode name/image
 	string mode = GetGameModeDisplayName( file.serversArrayFiltered[ serverIndex ].serverGamemode )
 	string playlist = file.serversArrayFiltered[ serverIndex ].serverGamemode
-	print("mode "+mode)
 	Hud_SetVisible( Hud_GetChild( menu, "NextModeIcon" ), true )
-	//RuiSetImage( Hud_GetRui( Hud_GetChild( menu, "NextModeIcon" ) ), "basicImage", GetPlaylistThumbnailImage( mode ) )
 	
 	var nextModeIconAlt = Hud_GetChild( menu, "NextModeIconPatch" )
 	var nextModeIcon = Hud_GetChild( menu, "NextModeIcon" )
@@ -949,15 +946,15 @@ void function DisplayFocusedServerInfo( int scriptID )
 	{
 		RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( playlist ) )
 		
-		Hud_SetVisible(nextModeIcon, true)
-		Hud_SetVisible(nextModeIconAlt, false)
+		Hud_Show( nextModeIcon )
+		Hud_Hide( nextModeIconAlt )
 	}	
 	else
 	{
 		RuiSetImage( Hud_GetRui( nextModeIconAlt ), "iconImage", StringToAsset(iconName) )
 		
-		Hud_SetVisible(nextModeIcon, false)
-		Hud_SetVisible(nextModeIconAlt, true)
+		Hud_Hide( nextModeIcon )
+		Hud_Show( nextModeIconAlt )
 	}
 
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -756,16 +756,7 @@ void function FilterServerList()
 
 	foreach ( ServerInfo server in servers )
 	{
-		serverStruct tempServer
-		tempServer.serverIndex = i
-		tempServer.serverProtected = NSServerRequiresPassword( i )
-		tempServer.serverName = NSGetServerName( i )
-		tempServer.serverPlayers = NSGetServerPlayerCount( i )
-		tempServer.serverPlayersMax = NSGetServerMaxPlayerCount( i )
-		tempServer.serverMap = NSGetServerMap( i )
-		tempServer.serverGamemode =  NSGetServerPlaylist ( i ) 
-
-		totalPlayers += tempServer.serverPlayers
+		totalPlayers += server.playerCount
 
 
 		// Filters
@@ -788,12 +779,13 @@ void function FilterServerList()
 		if ( filterArguments.useSearch )
 		{	
 			array<string> sName
-			sName.append( tempServer.serverName.tolower() )
-			sName.append( Localize( GetMapDisplayName( tempServer.serverMap ) ).tolower() )
-			sName.append( tempServer.serverMap.tolower() )
-			sName.append( GetGameModeDisplayName( tempServer.serverGamemode ).tolower() )
-			sName.append( Localize( GetGameModeDisplayName( tempServer.serverGamemode ) ).tolower() )
-			sName.append( NSGetServerDescription( i ).tolower() )
+			sName.append( server.name.tolower() )
+			sName.append( Localize( GetMapDisplayName( server.map ) ).tolower() )
+			sName.append( server.map.tolower() )
+			sName.append( server.playlist.tolower() )
+			sName.append( Localize( server.playlist ).tolower() )
+			sName.append( server.description.tolower() )
+			sName.append( server.region.tolower() )
 
 			string sTerm = filterArguments.searchTerm.tolower()
 			
@@ -841,11 +833,12 @@ void function UpdateShownPage()
 		Hud_SetEnabled( file.serverButtons[ i ], true )
 		Hud_SetVisible( file.serverButtons[ i ], true )
 
-		Hud_SetVisible( file.serversProtected[ i ], file.serversArrayFiltered[ buttonIndex ].serverProtected )
-		Hud_SetText( file.serversName[ i ], file.serversArrayFiltered[ buttonIndex ].serverName )
-		Hud_SetText( file.playerCountLabels[ i ], format( "%i/%i", file.serversArrayFiltered[ buttonIndex ].serverPlayers, file.serversArrayFiltered[ buttonIndex ].serverPlayersMax ) )
-		Hud_SetText( file.serversMap[ i ], GetMapDisplayName( file.serversArrayFiltered[ buttonIndex ].serverMap ) )
-		Hud_SetText( file.serversGamemode[ i ], GetGameModeDisplayName( file.serversArrayFiltered[ buttonIndex ].serverGamemode ) )
+		Hud_SetVisible( file.serversProtected[ i ], server.requiresPassword )
+		Hud_SetText( file.serversName[ i ], server.name )
+		Hud_SetText( file.playerCountLabels[ i ], format( "%i/%i", server.playerCount, server.maxPlayerCount ) )
+		Hud_SetText( file.serversMap[ i ], GetMapDisplayName( server.map ) )
+		Hud_SetText( file.serversGamemode[ i ], GetGameModeDisplayName( server.playlist ) )
+		Hud_SetText( file.serversRegion[ i ], server.region )
 	}
 
 
@@ -934,17 +927,16 @@ void function DisplayFocusedServerInfo( int scriptID )
 	Hud_SetText( Hud_GetChild( menu, "ServerName" ), server.name )
 
 	// mode name/image
-	string mode = GetGameModeDisplayName( file.serversArrayFiltered[ serverIndex ].serverGamemode )
-	string playlist = file.serversArrayFiltered[ serverIndex ].serverGamemode
+	string mode = server.playlist
 	Hud_SetVisible( Hud_GetChild( menu, "NextModeIcon" ), true )
 	
 	var nextModeIconAlt = Hud_GetChild( menu, "NextModeIconPatch" )
 	var nextModeIcon = Hud_GetChild( menu, "NextModeIcon" )
-	string iconName = GetPlaylistVarOrUseValue( playlist, "iconOverride", "default" )
+	string iconName = GetPlaylistVarOrUseValue( mode, "iconOverride", "default" )
 	
 	if(iconName == "default")
 	{
-		RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( playlist ) )
+		RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( mode ) )
 		
 		Hud_Show( nextModeIcon )
 		Hud_Hide( nextModeIconAlt )
@@ -1269,8 +1261,8 @@ int function ServerSortLogic ( ServerInfo a, ServerInfo b )
 			direction = filterDirection.serverMap
 			break;
 		case sortingBy.GAMEMODE:
-			aTemp = Localize( GetGameModeDisplayName( a.serverGamemode ) ).tolower()
-			bTemp = Localize( GetGameModeDisplayName( b.serverGamemode ) ).tolower()
+			aTemp = Localize( a.playlist ).tolower()
+			bTemp = Localize( b.playlist ).tolower()
 			direction = filterDirection.serverGamemode
 			break;
 		case sortingBy.REGION:

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_private_match.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_private_match.nut
@@ -523,7 +523,7 @@ void function SetModeInfo( string modeName )
 	}	
 	else
 	{
-		RuiSetImage( Hud_GetRui( nextModeIconAlt ), "iconImage", StringToAsset(iconName) )
+		RuiSetImage( Hud_GetRui( nextModeIconAlt ), "iconImage", StringToAsset( iconName ) )
 		
 		Hud_Hide( nextModeIcon )
 		Hud_Show( nextModeIconAlt )

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_private_match.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_private_match.nut
@@ -514,21 +514,20 @@ void function SetModeInfo( string modeName )
 	var nextModeIcon = Hud_GetChild( file.menu, "NextModeIcon" )
 	string iconName = GetPlaylistVarOrUseValue( modeName, "iconOverride", "default" )
 	
-	if(iconName == "default")
+	if( iconName == "default" )
 	{
 		RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( modeName ) )
 		
-		Hud_SetVisible(nextModeIcon, true)
-		Hud_SetVisible(nextModeIconAlt, false)
+		Hud_Show( nextModeIcon )
+		Hud_Hide( nextModeIconAlt )
 	}	
 	else
 	{
 		RuiSetImage( Hud_GetRui( nextModeIconAlt ), "iconImage", StringToAsset(iconName) )
 		
-		Hud_SetVisible(nextModeIcon, false)
-		Hud_SetVisible(nextModeIconAlt, true)
+		Hud_Hide( nextModeIcon )
+		Hud_Show( nextModeIconAlt )
 	}
-	//Hud_Show( nextModeIcon )
 
 	Hud_SetText( file.nextGameModeLabel, GetGameModeDisplayName( modeName ) )
 }

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_private_match.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_private_match.nut
@@ -510,9 +510,25 @@ void function SetMapInfo( string mapName )
 
 void function SetModeInfo( string modeName )
 {
+	var nextModeIconAlt = Hud_GetChild( file.menu, "NextModeIconPatch" )
 	var nextModeIcon = Hud_GetChild( file.menu, "NextModeIcon" )
-	RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( modeName ) )
-	Hud_Show( nextModeIcon )
+	string iconName = GetPlaylistVarOrUseValue( modeName, "iconOverride", "default" )
+	
+	if(iconName == "default")
+	{
+		RuiSetImage( Hud_GetRui( nextModeIcon ), "basicImage", GetPlaylistThumbnailImage( modeName ) )
+		
+		Hud_SetVisible(nextModeIcon, true)
+		Hud_SetVisible(nextModeIconAlt, false)
+	}	
+	else
+	{
+		RuiSetImage( Hud_GetRui( nextModeIconAlt ), "iconImage", StringToAsset(iconName) )
+		
+		Hud_SetVisible(nextModeIcon, false)
+		Hud_SetVisible(nextModeIconAlt, true)
+	}
+	//Hud_Show( nextModeIcon )
 
 	Hud_SetText( file.nextGameModeLabel, GetGameModeDisplayName( modeName ) )
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41163714/179397672-7ba36db3-17e3-4c99-a035-d2cb3084499c.png)

Modifies menu_mode_select to add GetPlaylistBannerImage and RegisterPlaylistBannerImage, also modifies ModeButton_GetFocus to show/hide correct rui since basic_menu_image.rpak cannot show banner images, also adds mode_select.menu, only difference here is `NextModeImageCallsign` which is just an identical panel using the `"ui/callsign_icon_button.rpak"` rui instead of basic menu image

[ImageTest.zip](https://github.com/R2Northstar/NorthstarMods/files/9331976/ImageTest.zip)
test mod