### PR TITLE
Fix `PlayerInventory_TakeAllInventoryItems` not being threaded

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/item_inventory/sv_item_inventory.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/item_inventory/sv_item_inventory.gnut
@@ -32,7 +32,7 @@ void function PrematchClearInventory() // vanilla behavior
 {
 	foreach( entity player in GetPlayerArray() )
 	{
-		PlayerInventory_TakeAllInventoryItems( player )
+		thread PlayerInventory_TakeAllInventoryItems( player )
 	}
 }
 


### PR DESCRIPTION
The reason this needs to be threaded is because on [L157](https://github.com/x3Karma/NorthstarMods/blob/7472d42bcdd2afc5c04268fdddeebd35169815e3/Northstar.CustomServers/mod/scripts/vscripts/item_inventory/sv_item_inventory.gnut#L157), it performs a `waitthread` on a function, which will cause an error.

![image](https://github.com/user-attachments/assets/de358be7-e1e3-4d38-846f-1449b85fed00)
