### PR TITLE
Add missing `IsValidPlayer()` check for CTF capture assists

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
@@ -315,12 +315,15 @@ void function CaptureFlag( entity player, entity flag )
 	
 	foreach( entity assistPlayer in assistList )
 	{
-		if ( player != assistPlayer )
-			AddPlayerScore( assistPlayer, "FlagCaptureAssist", player )
-		if( !HasPlayerCompletedMeritScore( assistPlayer ) )
+		if ( IsValidPlayer( assistPlayer ) )
 		{
-			AddPlayerScore( assistPlayer, "ChallengeCTFCapAssist" )
-			SetPlayerChallengeMeritScore( assistPlayer )
+			if ( player != assistPlayer )
+				AddPlayerScore( assistPlayer, "FlagCaptureAssist", player )
+			if( !HasPlayerCompletedMeritScore( assistPlayer ) )
+			{
+				AddPlayerScore( assistPlayer, "ChallengeCTFCapAssist" )
+				SetPlayerChallengeMeritScore( assistPlayer )
+			}
 		}
 	}
 		


### PR DESCRIPTION
Taken from #830 

Just adds an `IsValidPlayer()` check so testing can be skipped here to speed up the process.