### PR TITLE
Prevent rare crash when player disconnects during War Games intro

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_wargames.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_wargames.nut
@@ -232,7 +232,6 @@ void function OnPrematchStart()
 void function PlayerWatchesWargamesIntro( entity player )
 {
 	player.EndSignal( "OnDestroy" )
-	player.EndSignal( "OnDeath" )
 	
 	if ( IsAlive( player ) )
 		player.Die()
@@ -256,7 +255,7 @@ void function PlayerWatchesWargamesIntro( entity player )
 	
 	// we need to wait a frame if we killed ourselves to spawn into this, so just easier to do it all the time to remove any weirdness
 	WaitFrame()
-	
+	player.EndSignal( "OnDeath" )
 
 	int factionTeam = ConvertPlayerFactionToIMCOrMilitiaTeam( player )
 	entity playerPod

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_wargames.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_wargames.nut
@@ -231,6 +231,9 @@ void function OnPrematchStart()
 
 void function PlayerWatchesWargamesIntro( entity player )
 {
+	player.EndSignal( "OnDestroy" )
+	player.EndSignal( "OnDeath" )
+	
 	if ( IsAlive( player ) )
 		player.Die()
 
@@ -254,9 +257,7 @@ void function PlayerWatchesWargamesIntro( entity player )
 	// we need to wait a frame if we killed ourselves to spawn into this, so just easier to do it all the time to remove any weirdness
 	WaitFrame()
 	
-	player.EndSignal( "OnDestroy" )
-	player.EndSignal( "OnDeath" )
-	
+
 	int factionTeam = ConvertPlayerFactionToIMCOrMilitiaTeam( player )
 	entity playerPod
 	if ( factionTeam == TEAM_IMC )

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_wargames.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/levels/mp_wargames.nut
@@ -256,7 +256,7 @@ void function PlayerWatchesWargamesIntro( entity player )
 	// we need to wait a frame if we killed ourselves to spawn into this, so just easier to do it all the time to remove any weirdness
 	WaitFrame()
 	player.EndSignal( "OnDeath" )
-
+	
 	int factionTeam = ConvertPlayerFactionToIMCOrMilitiaTeam( player )
 	entity playerPod
 	if ( factionTeam == TEAM_IMC )


### PR DESCRIPTION
```
[15:02:59] [NORTHSTAR] [info] Player Elyearend disconnected: "Disconnect by user."
[15:02:59] [NORTHSTAR] [info] Player Elyearend disconnected: "Disconnect by user."
[15:02:59] [NORTHSTAR] [warn] attempted to write pdata of size 0!
[15:02:59] [SCRIPT SV] [info] SCRIPT ERROR: [SERVER] Attempted to call GetPersistentVar on invalid entity
[15:02:59] [SCRIPT SV] [info] -> return expect string ( player.GetPersistentVar( "factionChoice" ) )
[15:02:59] [SCRIPT SV] [info]
CALLSTACK
*FUNCTION [GetFactionChoice()] conversation/sh_faction_dialogue.gnut line [136]
*FUNCTION [ConvertPlayerFactionToIMCOrMilitiaTeam()] conversation/sh_faction_dialogue.gnut line [188]
*FUNCTION [PlayerWatchesWargamesIntro()] mp/levels/mp_wargames.nut line [260]
[15:02:59] [SCRIPT SV] [info] LOCALS
[player] ENTITY (NULL)
[this] TABLE
[player] ENTITY (NULL)
[this] TABLE
[player] ENTITY (NULL)
[this] TABLE
DIAGPRINTS
0114:fixme:msvcrt:__clean_type_info_names_internal (00006FFFFDD58788) stub
nswrap: northstar exited with status 3
nswrap: killing xvfb
nswrap: waiting for children to exit
```

that really need a lot of luck
i fell like i lost a winning ticket
sorry for my bad english :(