### PR TITLE
Avoid duplication of challenge award

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
@@ -334,10 +334,7 @@ void function CaptureFlag( entity player, entity flag )
 	EmitSoundOnEntityOnlyToPlayer( player, player, "UI_CTF_1P_PlayerScore" )
 	
 	if( !HasPlayerCompletedMeritScore( player ) )
-	{
-		AddPlayerScore( player, "ChallengeCTFRetAssist" )
 		SetPlayerChallengeMeritScore( player )
-	}
 	
 	MessageToTeam( team, eEventNotifications.PlayerCapturedEnemyFlag, player, player )
 	EmitSoundOnEntityToTeamExceptPlayer( flag, "UI_CTF_3P_TeamScore", player.GetTeam(), player )


### PR DESCRIPTION
Oversight on my part that players who capture the flag are also included in the assistList, so it's not needed to give them another Score Medal.