### PR TITLE
Add `IsValidPlayer()` before flag return cleanup

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ctf.nut
@@ -453,9 +453,11 @@ void function TryReturnFlag( entity player, entity flag )
 	
 	OnThreadEnd( function() : ( player )
 	{
-		// cleanup
-		Remote_CallFunction_NonReplay( player, "ServerCallback_CTF_StopReturnFlagProgressBar" )
-		StopSoundOnEntity( player, "UI_CTF_1P_FlagReturnMeter" )
+		if ( IsValidPlayer( player ) )
+		{
+			Remote_CallFunction_NonReplay( player, "ServerCallback_CTF_StopReturnFlagProgressBar" )
+			StopSoundOnEntity( player, "UI_CTF_1P_FlagReturnMeter" )
+		}
 	})
 	
 	player.EndSignal( "FlagReturnEnded" )


### PR DESCRIPTION
Add validity check to player validity cuz Thread of that function might end on via OnDestroy signal by disconnection, and by that point, the player is no longer valid.