### PR TITLE
Remove `SetShouldCreateMinimapSpawnZones()` from `_gamemode_ps.nut`

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ps.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/gamemodes/_gamemode_ps.nut
@@ -20,12 +20,6 @@ void function GamemodePs_Init()
 	ScoreEvent_SetupEarnMeterValuesForMixedModes()
 	SetTimeoutWinnerDecisionFunc( CheckScoreForDraw )
 	SetupGenericFFAChallenge()
-
-	// spawnzone stuff
-	SetShouldCreateMinimapSpawnZones( true )
-	
-	//AddCallback_OnPlayerKilled( CheckSpawnzoneSuspiciousDeaths )
-	//AddSpawnCallbackEditorClass( "trigger_multiple", "trigger_mp_spawn_zone", SpawnzoneTriggerInit )
 	
 	file.militiaPreviousSpawnZones = [ null, null, null ]
 	file.imcPreviousSpawnZones = [ null, null, null ]


### PR DESCRIPTION
Function is not necessary anymore, the reworked spawning logic at #829 uses playlistvars to control spawnzones creation on minimap.