### PR TITLE
Fix Discord presence crashing on Campaign

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/presence/cl_presence.nut
+++ b/Northstar.Client/mod/scripts/vscripts/presence/cl_presence.nut
@@ -33,7 +33,8 @@ GameStateStruct function DiscordRPC_GenerateGameState( GameStateStruct gs )
     gs.currentPlayers = allKnownPlayersCount
     gs.maxPlayers = GetCurrentPlaylistVarInt( "max_players", 16 )
 
-    if ( IsValid( GetLocalClientPlayer() ) )gs.ownScore = GameRules_GetTeamScore( GetLocalClientPlayer().GetTeam() )
+    if ( IsValid( GetLocalClientPlayer() ) )
+		gs.ownScore = GameRules_GetTeamScore( GetLocalClientPlayer().GetTeam() )
 
     #if MP
     if ( GameRules_GetGameMode() == FD )

--- a/Northstar.Client/mod/scripts/vscripts/presence/cl_presence.nut
+++ b/Northstar.Client/mod/scripts/vscripts/presence/cl_presence.nut
@@ -22,13 +22,18 @@ GameStateStruct function DiscordRPC_GenerateGameState( GameStateStruct gs )
     gs.mapDisplayname = Localize(GetMapDisplayName(GetMapName()))
 
     gs.playlist = GetCurrentPlaylistName()
-    gs.playlistDisplayname = Localize(GetCurrentPlaylistVarString("name", GetCurrentPlaylistName()))
+    gs.playlistDisplayname = Localize( GetCurrentPlaylistVarString( "name", GetCurrentPlaylistName() ) ) 
 
-    gs.currentPlayers = GetPlayerArray().len()
-    gs.maxPlayers = GetCurrentPlaylistVarInt( "maxPlayers", -1 )
+    int reservedCount = GetTotalPendingPlayersReserved()
+    int connectingCount = GetTotalPendingPlayersConnecting()
+    int loadingCount = GetTotalPendingPlayersLoading()
+    int connectedCount = GetPlayerArray().len()
+    int allKnownPlayersCount = reservedCount + connectingCount + loadingCount + connectedCount
 
-    if ( IsValid( GetLocalClientPlayer() ) )
-		gs.ownScore = GameRules_GetTeamScore( GetLocalClientPlayer().GetTeam() )
+    gs.currentPlayers = allKnownPlayersCount
+    gs.maxPlayers = GetCurrentPlaylistVarInt( "max_players", 16 )
+
+    if ( IsValid( GetLocalClientPlayer() ) )gs.ownScore = GameRules_GetTeamScore( GetLocalClientPlayer().GetTeam() )
 
     #if MP
     if ( GameRules_GetGameMode() == FD )

--- a/Northstar.Client/mod/scripts/vscripts/presence/cl_presence.nut
+++ b/Northstar.Client/mod/scripts/vscripts/presence/cl_presence.nut
@@ -30,6 +30,7 @@ GameStateStruct function DiscordRPC_GenerateGameState( GameStateStruct gs )
     if ( IsValid( GetLocalClientPlayer() ) )
 		gs.ownScore = GameRules_GetTeamScore( GetLocalClientPlayer().GetTeam() )
 
+    #if MP
     if ( GameRules_GetGameMode() == FD )
     {
         gs.playlist = "fd" // So it returns only one thing to the plugin side instead of the 5 separate difficulties FD have
@@ -41,6 +42,9 @@ GameStateStruct function DiscordRPC_GenerateGameState( GameStateStruct gs )
         else
             gs.fd_waveNumber = -1 // Tells plugin it's on Wave Break
     }
+	#else
+	gs.fd_waveNumber = -1 // Unecessary for campaign so return -1
+	#endif
 
     gs.serverGameState = GetGameState() == -1 ? 0 : GetGameState()
     gs.otherHighestScore = gs.ownScore == highestScore ? secondHighest : highestScore


### PR DESCRIPTION
Small oversight by my part when i did the feature improvements to the Discord RPC plugin, this should fix the issue when playing Campaign or Coop.

EDIT: I took the liberty to also use the PR to fix some other minor issues in regards to report how many players are currently playing the server and the actual max playerslots the server have in total.