### PR TITLE
Fix UI error when leaving the lobby too quickly

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_loadouts.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_loadouts.nut
@@ -2812,6 +2812,9 @@ string function GetParentLoadoutProperty( string loadoutType, string propertyNam
 
 int function GetPersistentSpawnLoadoutIndex( entity player, string loadoutType )
 {
+	if (!IsValid ( player ) )
+		return -1
+
 	int loadoutIndex = player.GetPersistentVarAsInt( loadoutType + "SpawnLoadout.index" )
 	if ( loadoutType == "titan" && loadoutIndex >= NUM_PERSISTENT_TITAN_LOADOUTS )
 		loadoutIndex = 0


### PR DESCRIPTION
Fixes https://github.com/R2Northstar/NorthstarMods/issues/849, using the fix suggested by [Jan200101](https://github.com/Jan200101).

How to test:

1. Click "Launch Northstar"
2. When the lobby starts loading and you can see you character, immediately press "right arrow + space", to join a private match.
Without this pr, the game would kick you to the main menu. With this pr, no kick

Before:
https://github.com/user-attachments/assets/2447566b-68ae-4be5-8f22-35b45b7c094b

After:
https://github.com/user-attachments/assets/b59a50b7-ec12-4df5-82a5-78ed66769c70


