### PR TITLE
Remove Clutter Client Logging from Glitch

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/mp/levels/cl_mp_glitch.nut
+++ b/Northstar.Client/mod/scripts/vscripts/mp/levels/cl_mp_glitch.nut
@@ -101,10 +101,6 @@ void function AddInWorldMinimapObject( entity ent ) //TODO: If we want radar jam
 
 void function AddInWorldMinimapObjectInternal( entity ent, var screen )
 {
-	printt( "AddInWorldMinimapObject" )
-	printt( screen )
-	printt( ent )
-
 	bool isNPCTitan = ent.IsNPC() && ent.IsTitan()
 	bool isPetTitan = ent == GetLocalViewPlayer().GetPetTitan()
 	bool isLocalPlayer = ent == GetLocalViewPlayer()


### PR DESCRIPTION
Whenever a pilot respawns or a Titan also spawns, the clientsided script of Glitch generates lots of clutter logs about those entities being added to the minimap panels in the walls of the map. We don't need that, it only bulks client logs without reason.