### PR TITLE
Fix Thunderbolt crashing clients when owner is invalid

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/client/cl_damage_indicator.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_damage_indicator.gnut
@@ -366,7 +366,7 @@ void function DamageIndicators( DamageHistoryStruct damageHistory, bool playerIs
 				cockpit.AddToTitanHudDamageHistory( COCKPIT_PANEL_LEFT, damageHistory.damage )
 		}
 
-		if ( damageHistory.attacker && damageHistory.attacker.GetParent() == localViewPlayer )
+		if ( damageHistory.damageSourceId != eDamageSourceId.mp_weapon_arc_launcher && damageHistory.attacker && damageHistory.attacker.GetParent() == localViewPlayer )
 		{
 			damageHistory.rodeoDamage = true
 			return


### PR DESCRIPTION
I tried several approaches in several test sessions with @Alystrasz to see how i could finally fix this issue, unfortunately this is the only one that prevented this screen from happening:
![image](https://github.com/user-attachments/assets/11056b4e-1777-494b-92d6-9aad06eb1c9d)

This also fixes NPCs doing this exact same crash if they fire a Thunderbolt and are killed right after.

The problem in here is not a validity check in the attacker, that check is actually passing when i tested, what is causing the crash is the `GetParent()` function and i cannot simply remove that because it's the check responsible to tell when an attack was done from rodeo (i.e battery pulls, classic rodeo riff).