### PR TITLE
Add custom OOB timer per level scope

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype.gnut
@@ -36,6 +36,7 @@ function BaseGametype_Init()
 		level.titanAlwaysAvailableForTeam <- [ 0, 0, 0, 0 ]
 
 		level.missingPlayersTimeout <- null
+		level.customOOBTimer <- 0.0
 
 		CreateTeamColorControlPoints()
 
@@ -1792,10 +1793,14 @@ void function EntityOutOfBounds( entity trigger, entity ent, entity caller, var 
 
 	//printt( "Valid Out OfBounds Entity, EntityOutOfBounds" )
 
+	float overridenOOBTimer = expect float( level.customOOBTimer )
 	if ( !(ent in file.outOfBoundsTable) ) //Note that we never remove the ent from the table after adding it
 	{
 		OutOfBoundsDataStruct initialDataStruct
 		initialDataStruct.timeBackInBound = max( 0, Time() - OUT_OF_BOUNDS_DECAY_TIME )
+		
+		if( overridenOOBTimer > 0.0 )
+			initialDataStruct.timeLeftBeforeDyingFromOutOfBounds = overridenOOBTimer
 
 		ManageAddEntToOutOfBoundsTable( ent,  initialDataStruct  )
 	}
@@ -1813,6 +1818,12 @@ void function EntityOutOfBounds( entity trigger, entity ent, entity caller, var 
 		float outOfBoundsTimeRegained = decayTime * ( OUT_OF_BOUNDS_TIME_LIMIT / OUT_OF_BOUNDS_DECAY_TIME )
 		float deadTime = clamp( dataStruct.timeLeftBeforeDyingFromOutOfBounds + outOfBoundsTimeRegained, 0.0, OUT_OF_BOUNDS_TIME_LIMIT )
 
+		if( overridenOOBTimer > 0.0 )
+		{
+			outOfBoundsTimeRegained = decayTime * ( overridenOOBTimer / OUT_OF_BOUNDS_DECAY_TIME )
+			deadTime = clamp( dataStruct.timeLeftBeforeDyingFromOutOfBounds + outOfBoundsTimeRegained, 0.0, overridenOOBTimer )
+		}
+		
 		//printt( "Decay Time: " + decayTime + ", outOfBoundsTimeRegained:" + outOfBoundsTimeRegained + ", timeLeftBeforeDyingFromOutOfBounds: " + dataStruct.timeLeftBeforeDyingFromOutOfBounds + ", deadTime: " + deadTime  )
 
 		dataStruct.timeLeftBeforeDyingFromOutOfBounds = deadTime


### PR DESCRIPTION
This PR on its own will not do anything, this is a feature support for mods or custom gamemodes that allows them to override the amount of time players can stay in the Out of Bounds areas.