### PR TITLE
Add PlayerAssist callback logic

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype.gnut
@@ -795,13 +795,16 @@ bool function PlayerOrNPCKilled( entity ent, var damageInfo )
 			
 			foreach( DamageHistoryStruct attackerInfo in victim.e.recentDamageHistory )
 			{
-				if ( !IsValidPlayer( attackerInfo.attacker ) || attackerInfo.attacker == victim )
+				if ( !IsValid( attackerInfo.attacker ) || !attackerInfo.attacker.IsPlayer() || attackerInfo.attacker == victim )
 					continue
 				
 				bool exists = attackerInfo.attacker.GetEncodedEHandle() in alreadyAssisted ? true : false
 				if( attackerInfo.attacker != attacker && !exists )
 				{
 					alreadyAssisted[attackerInfo.attacker.GetEncodedEHandle()] <- true
+					foreach ( player in GetPlayerArray() )
+						Remote_CallFunction_Replay( player, "ServerCallback_SetAssistInformation", attackerInfo.damageSourceId, attacker.GetEncodedEHandle(), ent.GetEncodedEHandle(), attackerInfo.time )
+
 					foreach ( callback in svGlobal.onPlayerAssistCallbacks )
 						callback( attackerInfo.attacker, victim )
 				}

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype.gnut
@@ -786,6 +786,26 @@ bool function PlayerOrNPCKilled( entity ent, var damageInfo )
 			ScoreEvent_TitanKilled( ent, attacker, damageInfo )
 		else
 			ScoreEvent_NPCKilled( ent, attacker, damageInfo )
+		
+		entity victim = ent.IsTitan() ? ent.GetTitanSoul() : ent
+		if ( IsValid( victim ) )
+		{
+			table<int, bool> alreadyAssisted
+			
+			foreach( DamageHistoryStruct attackerInfo in victim.e.recentDamageHistory )
+			{
+				if ( !IsValidPlayer( attackerInfo.attacker ) || attackerInfo.attacker == victim )
+					continue
+				
+				bool exists = attackerInfo.attacker.GetEncodedEHandle() in alreadyAssisted ? true : false
+				if( attackerInfo.attacker != attacker && !exists )
+				{
+					alreadyAssisted[attackerInfo.attacker.GetEncodedEHandle()] <- true
+					foreach ( callback in svGlobal.onPlayerAssistCallbacks )
+						callback( attackerInfo.attacker, victim )
+				}
+			}
+		}
 	}
 	PostScoreEventUpdateStats( attacker, ent )
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype_mp.gnut
@@ -45,6 +45,7 @@ void function BaseGametype_Init_MPSP()
 	
 	AddCallback_OnNPCKilled( CheckForAutoTitanDeath )
 	AddCallback_OnPlayerKilled( CheckForAutoTitanDeath )
+	AddCallback_OnPlayerAssist( PlayerAssistedKill )
 	RegisterSignal( "PlayerRespawnStarted" )
 	RegisterSignal( "KillCamOver" )
 
@@ -250,6 +251,18 @@ void function CodeCallback_OnPlayerRespawned( entity player )
 	ClearLastAttacker( player ) // so dying to anything doesn't credit the same attacker after respawning
 }
 
+void function PlayerAssistedKill( entity attacker, entity victim )
+{
+	if( victim.IsPlayer() )
+	{
+		AddPlayerScore( attacker, "PilotAssist" )
+		attacker.AddToPlayerGameStat( PGS_ASSISTS, 1 )
+
+		if ( attacker.IsPlayer() )	
+			Highlight_SetDeathRecapHighlight( attacker, "killer_outline" )
+	}
+}
+
 void function CodeCallback_OnPlayerKilled( entity player, var damageInfo )
 {
 	PlayerOrNPCKilled( player, damageInfo )
@@ -306,28 +319,6 @@ void function PostDeathThread_MP( entity player, var damageInfo ) // based on ga
 	if ( inflictor && ShouldTryUseProjectileReplay( player, attacker, damageInfo, false ) )
 		eHandle = inflictor.GetEncodedEHandle()
 	int methodOfDeath = DamageInfo_GetDamageSourceIdentifier( damageInfo )
-
-	table<int, bool> alreadyAssisted
-	if ( IsValid( attacker ) )
-	{
-		foreach( DamageHistoryStruct attackerInfo in player.e.recentDamageHistory )
-		{
-			if ( !IsValid( attackerInfo.attacker ) || !attackerInfo.attacker.IsPlayer() || attackerInfo.attacker == player )
-				continue
-
-			bool exists = attackerInfo.attacker.GetEncodedEHandle() in alreadyAssisted ? true : false
-			if( attackerInfo.attacker != attacker && !exists )
-			{
-				alreadyAssisted[attackerInfo.attacker.GetEncodedEHandle()] <- true
-				Remote_CallFunction_NonReplay( attackerInfo.attacker, "ServerCallback_SetAssistInformation", attackerInfo.damageSourceId, attacker.GetEncodedEHandle(), player.GetEncodedEHandle(), attackerInfo.time ) 
-				AddPlayerScore( attackerInfo.attacker, "PilotAssist" )
-				attackerInfo.attacker.AddToPlayerGameStat( PGS_ASSISTS, 1 )
-			}
-		}
-
-		if( attacker.IsPlayer() )	
-			Highlight_SetDeathRecapHighlight( attacker, "killer_outline" )
-	}
 
 	player.p.rematchOrigin = player.p.deathOrigin
 	if ( IsValid( attacker ) && methodOfDeath == eDamageSourceId.titan_execution )

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_score.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_score.nut
@@ -22,6 +22,7 @@ void function Score_Init()
 {
 	SvXP_Init()
 	AddCallback_OnClientConnected( InitPlayerForScoreEvents )
+	AddCallback_OnPlayerAssist( TitanAssistedKill )
 }
 
 void function InitPlayerForScoreEvents( entity player )
@@ -216,28 +217,17 @@ void function ScoreEvent_TitanKilled( entity victim, entity attacker, var damage
 			AddPlayerScore( attacker, "KillTitan" )
 	}
 
-	entity soul = victim.GetTitanSoul()
-	if ( IsValid( soul ) )
-	{
-		table<int, bool> alreadyAssisted
-		
-		foreach( DamageHistoryStruct attackerInfo in soul.e.recentDamageHistory )
-		{
-			if ( !IsValid( attackerInfo.attacker ) || !attackerInfo.attacker.IsPlayer() || attackerInfo.attacker == soul )
-				continue
-			
-			bool exists = attackerInfo.attacker.GetEncodedEHandle() in alreadyAssisted ? true : false
-			if( attackerInfo.attacker != attacker && !exists )
-			{
-				alreadyAssisted[attackerInfo.attacker.GetEncodedEHandle()] <- true
-				AddPlayerScore(attackerInfo.attacker, "TitanAssist" )
-				Remote_CallFunction_NonReplay( attackerInfo.attacker, "ServerCallback_SetAssistInformation", attackerInfo.damageSourceId, attacker.GetEncodedEHandle(), soul.GetEncodedEHandle(), attackerInfo.time ) 
-			}
-		}
-	}
-
 	if( !victim.IsNPC() ) // don't let killing a npc titan plays dialogue
 		KilledPlayerTitanDialogue( attacker, victim )
+}
+
+void function TitanAssistedKill( entity attacker, entity victim )
+{
+	if ( IsSoul( victim ) )
+	{
+		AddPlayerScore( attacker, "TitanAssist" )
+		attacker.AddToPlayerGameStat( PGS_ASSISTS, 1 )
+	}
 }
 
 void function ScoreEvent_NPCKilled( entity victim, entity attacker, var damageInfo )


### PR DESCRIPTION
#729 is stale since NoCatt left, this is my approach to restoring the assist callback.

This should make the callbacks actually trigger on both players and NPCs for better modding support and centralized logic since we have this block of code repeated several times across several scripts because this callback wasn't working before.

I'll do further PRs addressing those repeated cases into just this callback usage.