### PR TITLE
Remove Data Centers button from Main Menu

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
@@ -53,7 +53,7 @@ void function InitMainMenu()
 		AddMenuFooterOption( menu, BUTTON_A, "#A_BUTTON_SELECT", "" )
 	#endif // PC_PROG
 
-	AddMenuFooterOption( menu, BUTTON_X, "#X_BUTTON_INBOX_ACCEPT", "#INBOX_ACCEPT", OpenDataCenterDialog, IsDataCenterFooterValid, UpdateDataCenterFooter )
+	//AddMenuFooterOption( menu, BUTTON_X, "#X_BUTTON_INBOX_ACCEPT", "#INBOX_ACCEPT", OpenDataCenterDialog, IsDataCenterFooterValid, UpdateDataCenterFooter )
 
 #if DEV
 	if ( DevStartPoints() )

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_main.nut
@@ -53,7 +53,9 @@ void function InitMainMenu()
 		AddMenuFooterOption( menu, BUTTON_A, "#A_BUTTON_SELECT", "" )
 	#endif // PC_PROG
 
-	//AddMenuFooterOption( menu, BUTTON_X, "#X_BUTTON_INBOX_ACCEPT", "#INBOX_ACCEPT", OpenDataCenterDialog, IsDataCenterFooterValid, UpdateDataCenterFooter )
+	#if VANILLA
+	AddMenuFooterOption( menu, BUTTON_X, "#X_BUTTON_INBOX_ACCEPT", "#INBOX_ACCEPT", OpenDataCenterDialog, IsDataCenterFooterValid, UpdateDataCenterFooter )
+	#endif
 
 #if DEV
 	if ( DevStartPoints() )


### PR DESCRIPTION
We actually don't use them at all, there's no reason for the button to stay there, plenty of people do actually think they connect into Northstar servers through them only because the button is still there, when in fact it has zero impact on anything.