### PR TITLE
Fix Spectre first person executions script error

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/client/cl_codecallbacks.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_codecallbacks.gnut
@@ -62,17 +62,9 @@ void function ClientCodeCallback_BodyGroupChanged( entity ent, int bodyGroupInde
 {
 //	PrintFunc( "entity " + ent + " index " + bodyGroupIndex + "newstate " + newState )
 
-	if ( IsSpectre( ent ) )
+	if ( IsSpectre( ent ) || IsStalker( ent ) )
 	{
 		if ( bodyGroupIndex == ent.FindBodyGroup( "head" ) || bodyGroupIndex == ent.FindBodyGroup( "removableHead" ) )
-		{
-			ModelFX_DisableGroup( ent, "foe_lights" )
-			ModelFX_DisableGroup( ent, "friend_lights" )
-		}
-	}
-	else if ( IsStalker( ent ) )
-	{
-		if ( bodyGroupIndex == ent.FindBodyGroup( "removableHead" ) )
 		{
 			ModelFX_DisableGroup( ent, "foe_lights" )
 			ModelFX_DisableGroup( ent, "friend_lights" )

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_codecallbacks.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_codecallbacks.gnut
@@ -62,7 +62,15 @@ void function ClientCodeCallback_BodyGroupChanged( entity ent, int bodyGroupInde
 {
 //	PrintFunc( "entity " + ent + " index " + bodyGroupIndex + "newstate " + newState )
 
-	if ( IsSpectre( ent ) || IsStalker( ent ) )
+	if ( IsSpectre( ent ) )
+	{
+		if ( bodyGroupIndex == ent.FindBodyGroup( "head" ) || bodyGroupIndex == ent.FindBodyGroup( "removableHead" ) )
+		{
+			ModelFX_DisableGroup( ent, "foe_lights" )
+			ModelFX_DisableGroup( ent, "friend_lights" )
+		}
+	}
+	else if ( IsStalker( ent ) )
 	{
 		if ( bodyGroupIndex == ent.FindBodyGroup( "removableHead" ) )
 		{

--- a/Northstar.Client/mod/scripts/vscripts/client/objects/cl_spectre.nut
+++ b/Northstar.Client/mod/scripts/vscripts/client/objects/cl_spectre.nut
@@ -1,0 +1,44 @@
+global function ClSpectre_Init
+
+struct
+{
+	table <asset,bool> initialized
+} file
+
+void function ClSpectre_Init()
+{
+	AddCreateCallback( "npc_spectre", CreateCallback_Spectre )
+
+	RegisterSignal( "SpectreGlowEYEGLOW" )
+
+	PrecacheParticleSystem( $"P_spectre_eye_foe" )
+	PrecacheParticleSystem( $"P_spectre_eye_friend" )
+}
+
+void function CreateCallback_Spectre( entity spectre )
+{
+	AddAnimEvent( spectre, "create_dataknife", CreateThirdPersonDataKnife )
+	spectre.DoBodyGroupChangeScriptCallback( true, spectre.FindBodyGroup( "removableHead" ) )
+
+	asset model = spectre.GetModelName()
+	if ( model in file.initialized )
+		return
+	file.initialized[ model ] <- true
+
+	//----------------------
+	// model Lights - Friend
+	//----------------------
+	ModelFX_BeginData( "friend_lights", model, "friend", true )
+		ModelFX_HideFromLocalPlayer()
+		ModelFX_AddTagSpawnFX( "EYEGLOW",		$"P_spectre_eye_friend" )
+	ModelFX_EndData()
+
+	//----------------------
+	// model Lights - Foe
+	//----------------------
+	ModelFX_BeginData( "foe_lights", model, "foe", true )
+		ModelFX_HideFromLocalPlayer()
+		ModelFX_AddTagSpawnFX( "EYEGLOW",		$"P_spectre_eye_foe" )
+	ModelFX_EndData()
+}
+

--- a/Northstar.Client/mod/scripts/vscripts/client/objects/cl_spectre.nut
+++ b/Northstar.Client/mod/scripts/vscripts/client/objects/cl_spectre.nut
@@ -18,7 +18,12 @@ void function ClSpectre_Init()
 void function CreateCallback_Spectre( entity spectre )
 {
 	AddAnimEvent( spectre, "create_dataknife", CreateThirdPersonDataKnife )
-	spectre.DoBodyGroupChangeScriptCallback( true, spectre.FindBodyGroup( "removableHead" ) )
+
+	int bodyGroupIndex = spectre.FindBodyGroup( "head" )
+	if ( bodyGroupIndex == -1 )
+		bodyGroupIndex = spectre.FindBodyGroup( "removableHead" )
+
+	spectre.DoBodyGroupChangeScriptCallback( true, bodyGroupIndex )
 
 	asset model = spectre.GetModelName()
 	if ( model in file.initialized )

--- a/Northstar.Custom/mod/scripts/vscripts/ai/_ai_spectre.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/ai/_ai_spectre.gnut
@@ -1,0 +1,131 @@
+global function AiSpectre_Init
+global function NPCCarriesBattery
+
+void function AiSpectre_Init()
+{
+	//AddDamageCallback( "npc_spectre", SpectreOnDamaged )
+	AddDeathCallback( "npc_spectre", SpectreOnDeath )
+	//AddSpawnCallback( "npc_spectre", SpectreOnSpawned )
+
+	#if !SPECTRE_CHATTER_MP_ENABLED
+		AddCallback_OnPlayerKilled( SpectreChatter_OnPlayerKilled )
+		AddCallback_OnNPCKilled( SpectreChatter_OnNPCKilled )
+	#endif
+}
+
+void function SpectreOnSpawned( entity npc )
+{
+
+}
+
+void function SpectreOnDeath( entity npc, var damageInfo )
+{
+	if ( !IsValidHeadShot( damageInfo, npc ) )
+		return
+
+	// Set these so cl_player knows to kill the eye glow and play the right SFX
+	DamageInfo_AddCustomDamageType( damageInfo, DF_HEADSHOT )
+	DamageInfo_AddCustomDamageType( damageInfo, DF_KILLSHOT )
+//	EmitSoundOnEntityExceptToPlayer( npc, attacker, "SuicideSpectre.BulletImpact_HeadShot_3P_vs_3P" )
+
+	int bodyGroupIndex = npc.FindBodyGroup( "removableHead" )
+	int stateIndex = 1  // 0 = show, 1 = hide
+	npc.SetBodygroup( bodyGroupIndex, stateIndex )
+
+	DamageInfo_SetDamage( damageInfo, npc.GetMaxHealth() )
+
+}
+
+// All damage to spectres comes here for modification and then either branches out to other npc types (Suicide, etc) for custom stuff or it just continues like normal.
+void function SpectreOnDamaged( entity npc, var damageInfo )
+{
+
+}
+
+void function SpectreChatter_OnPlayerKilled( entity playerKilled, entity attacker, var damageInfo )
+{
+	if ( !IsSpectre( attacker ) )
+		return
+
+	if ( playerKilled.IsTitan() )
+		thread PlaySpectreChatterAfterDelay( attacker, "spectre_gs_gruntkillstitan_02_1" )
+	else
+		thread PlaySpectreChatterAfterDelay( attacker, "spectre_gs_killenemypilot_01_1" )
+
+}
+
+void function SpectreChatter_OnNPCKilled( entity npcKilled, entity attacker, var damageInfo )
+{
+	if ( IsSpectre( npcKilled ) )
+	{
+		string deadGuySquadName = expect string( npcKilled.kv.squadname )
+		if ( deadGuySquadName == "" )
+			return
+
+		array<entity> squad = GetNPCArrayBySquad( deadGuySquadName )
+
+		entity speakingSquadMate = null
+
+		foreach( squadMate in squad )
+		{
+			if ( IsSpectre( squadMate ) )
+			{
+				speakingSquadMate = squadMate
+				break
+			}
+		}
+		if ( speakingSquadMate == null )
+			return
+
+		if ( squad.len() == 1 )
+			thread PlaySpectreChatterAfterDelay( speakingSquadMate, "spectre_gs_squaddeplete_01_1" )
+		else if ( squad.len() > 0  )
+			thread PlaySpectreChatterAfterDelay( speakingSquadMate, "spectre_gs_allygrundown_05_1" )
+	}
+	else
+	{
+		if ( !IsSpectre( attacker ) )
+			return
+
+		if ( npcKilled.IsTitan() )
+			thread PlaySpectreChatterAfterDelay( attacker, "spectre_gs_gruntkillstitan_02_1" )
+	}
+}
+
+void function PlaySpectreChatterAfterDelay( entity spectre, string chatterLine, float delay = 0.3 )
+{
+	wait delay
+
+	if ( !IsAlive( spectre ) ) //Really this is just an optimization thing, if the spectre is dead no point in running the same check for every player nearby in ShouldPlaySpectreChatterMPLine
+		return
+
+	PlaySpectreChatterToAll( chatterLine, spectre )
+}
+
+void function NPCCarriesBattery( entity npc )
+{
+	entity battery = Rodeo_CreateBatteryPack()
+	battery.SetParent( npc, "BATTERY_ATTACH" )
+	battery.MarkAsNonMovingAttachment()
+	thread SpectreBatteryThink( npc, battery )
+}
+
+void function SpectreBatteryThink( entity npc, entity battery )
+{
+	battery.EndSignal( "OnDestroy" )
+	npc.EndSignal( "OnDestroy" )
+
+	OnThreadEnd(
+	function() : ( battery )
+		{
+			if ( IsValid( battery ) )
+			{
+				battery.ClearParent()
+				battery.SetAngles( < 0,0,0 > )
+				battery.SetVelocity( < 0,0,200 > )
+			}
+		}
+	)
+
+	npc.WaitSignal( "OnDeath" )
+}

--- a/Northstar.Custom/mod/scripts/vscripts/ai/_ai_spectre.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/ai/_ai_spectre.gnut
@@ -28,7 +28,10 @@ void function SpectreOnDeath( entity npc, var damageInfo )
 	DamageInfo_AddCustomDamageType( damageInfo, DF_KILLSHOT )
 //	EmitSoundOnEntityExceptToPlayer( npc, attacker, "SuicideSpectre.BulletImpact_HeadShot_3P_vs_3P" )
 
-	int bodyGroupIndex = npc.FindBodyGroup( "removableHead" )
+	int bodyGroupIndex = npc.FindBodyGroup( "head" )
+	if ( bodyGroupIndex == -1 )
+		bodyGroupIndex = npc.FindBodyGroup( "removableHead" )
+
 	int stateIndex = 1  // 0 = show, 1 = hide
 	npc.SetBodygroup( bodyGroupIndex, stateIndex )
 


### PR DESCRIPTION
Fixes https://github.com/R2Northstar/Northstar/issues/418 and the Spectre part of https://github.com/R2Northstar/NorthstarMods/issues/885.

The reason this happens is because the fp executions code tries to find the ``"head"`` bodygroup, but Spectres have ``"removableHead"`` instead, so i fixed it by:

1. Decompiling the Spectre model
2. Renaming the ``"removableHead"`` bodygroup to ``"head"``
3. Replacing every instance in code of ``"removableHead"`` when referencing Spectres. The new code checks for ``"head"`` first, and then falls back to ``"removableHead"`` if it doesn't find it, so it shouldn't cause any issues if someone disables ``Northstar.Custom`` or uses a Spectre model that doesn't have this change


https://github.com/user-attachments/assets/9f1446cf-a161-408b-8f69-5e29ac968496

-``cl_spectre.nut`` was taken from ``englishclient_mp_common.vpk``
-``_ai_spectre.gnut`` was taken from ``englishclient_sp_timeshift_spoke02.vpk`` ( but it should be in any sp vpk )


I'd also like to note that Stalkers technically should have this issue as well, but we can't execute them so it doesn't really matter