### PR TITLE
Fix script error related to dropship and player server leave

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_anim.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_anim.gnut
@@ -1031,7 +1031,6 @@ void function FirstPersonSequence( FirstPersonSequenceStruct sequence, entity pl
 	player.EndSignal( "NewFirstPersonSequence" )
 	player.EndSignal( "ScriptAnimStop" )
 
-
 	player.SetVelocity( <0,0,0> ) // fix this
 	if ( player.IsPlayer() && sequence.snapPlayerFeetToEyes )
 	{

--- a/Northstar.CustomServers/mod/scripts/vscripts/_anim.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_anim.gnut
@@ -1031,8 +1031,6 @@ void function FirstPersonSequence( FirstPersonSequenceStruct sequence, entity pl
 	player.EndSignal( "NewFirstPersonSequence" )
 	player.EndSignal( "ScriptAnimStop" )
 
-	if ( !IsValid( player ) )
-		return
 
 	player.SetVelocity( <0,0,0> ) // fix this
 	if ( player.IsPlayer() && sequence.snapPlayerFeetToEyes )

--- a/Northstar.CustomServers/mod/scripts/vscripts/_anim.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_anim.gnut
@@ -1031,6 +1031,9 @@ void function FirstPersonSequence( FirstPersonSequenceStruct sequence, entity pl
 	player.EndSignal( "NewFirstPersonSequence" )
 	player.EndSignal( "ScriptAnimStop" )
 
+	if ( !IsValid( player ) )
+		return
+
 	player.SetVelocity( <0,0,0> ) // fix this
 	if ( player.IsPlayer() && sequence.snapPlayerFeetToEyes )
 	{

--- a/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
@@ -490,6 +490,7 @@ void function AddPlayerToEvacDropship( entity dropship, entity player )
 
     // need to cancel if the dropship dies
     dropship.EndSignal( "OnDeath", "OnDestroy" )
+	player.EndSignal( "OnDestroy" )
 
 	player.SetInvulnerable()
 	player.UnforceCrouch()
@@ -514,9 +515,6 @@ void function AddPlayerToEvacDropship( entity dropship, entity player )
 	idleFp.teleport = true
 	idleFp.hideProxy = true
 	idleFp.viewConeFunction = ViewConeWide  
-		
-	player.EndSignal( "OnDestroy" )
-	
 	thread FirstPersonSequence( idleFp, player, dropship )
 	ViewConeWide( player ) // gotta do this after for some reason, adding it to idleFp does not work for some reason
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
@@ -515,6 +515,8 @@ void function AddPlayerToEvacDropship( entity dropship, entity player )
 	idleFp.hideProxy = true
 	idleFp.viewConeFunction = ViewConeWide  
 		
+	player.EndSignal( "OnDestroy" )
+	
 	thread FirstPersonSequence( idleFp, player, dropship )
 	ViewConeWide( player ) // gotta do this after for some reason, adding it to idleFp does not work for some reason
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
@@ -515,7 +515,7 @@ void function AddPlayerToEvacDropship( entity dropship, entity player )
 	idleFp.teleport = true
 	idleFp.hideProxy = true
 	idleFp.viewConeFunction = ViewConeWide  
-	
+		
 	thread FirstPersonSequence( idleFp, player, dropship )
 	ViewConeWide( player ) // gotta do this after for some reason, adding it to idleFp does not work for some reason
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/evac/_evac.gnut
@@ -515,6 +515,7 @@ void function AddPlayerToEvacDropship( entity dropship, entity player )
 	idleFp.teleport = true
 	idleFp.hideProxy = true
 	idleFp.viewConeFunction = ViewConeWide  
+	
 	thread FirstPersonSequence( idleFp, player, dropship )
 	ViewConeWide( player ) // gotta do this after for some reason, adding it to idleFp does not work for some reason
 }


### PR DESCRIPTION
<!-- 
WHEN OPENING A PULL REQUEST KEEP IN MIND:
-> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
-> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)

-> For fixes, description on how to reproduce the bug are appreciated and help your PR get merged faster
-> For features, description on how to use or a sample mod that makes use of the feature is appreciated and will help your PR get merged faster

-> Please use a sensible title for your pull request

-> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).

-> If you made multiple independent changes, please make a new PR for each one. This prevents your PR being blocked from merging by one of the changes you made.

Note that commit messages in PRs will generally be squashed to keep commit history clean.
-->

If a player leaves the same frame they enter the dropship, the server will crash. This is due to the SetVelocity line.

### Code review:

It's a one line change

### Testing:

Testing isn't needed, it's literally just an OnDestroy.
