### PR TITLE
Fix: intro dropship crash

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_classic_mp_dropship_intro.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_classic_mp_dropship_intro.gnut
@@ -31,6 +31,8 @@ struct {
 	table< entity, array<entity> > imcDropships
 	
 	float introStartTime
+
+	bool doneLoadingEnts = false
 } file
 
 
@@ -38,6 +40,13 @@ void function ClassicMP_DefaultDropshipIntro_Setup()
 {
 	AddCallback_OnClientConnected( DropshipIntro_OnClientConnected )	
 	AddCallback_GameStateEnter( eGameState.Prematch, OnPrematchStart )
+
+	AddCallback_EntitiesDidLoad( OnEntitiesDidLoad )
+}
+
+void function OnEntitiesDidLoad()
+{
+	file.doneLoadingEnts = true
 }
 
 void function DropshipIntro_OnClientConnected( entity player )
@@ -53,6 +62,17 @@ void function DropshipIntro_OnClientConnected( entity player )
 
 void function OnPrematchStart()
 {
+	thread OnPrematchStart_Delayed()
+}
+
+void function OnPrematchStart_Delayed()
+{
+	// we have to wait for entities to load in, because GetEntArrayByClass_Expensive
+	// is used later in the func, and it can run before dropship entities are loaded,
+	// causing no dropship spawn points to be found
+	while ( !file.doneLoadingEnts )
+		WaitFrame()
+
 	ClassicMP_OnIntroStarted()
 
 	print( "starting dropship intro!" )
@@ -85,7 +105,7 @@ void function OnPrematchStart()
 		table< entity, array<entity> > teamDropships = createTeam == TEAM_MILITIA ? file.militiaDropships : file.imcDropships
 		
 		if ( teamDropships.len() >= 2 )
-			break
+			continue
 
 		entity dropship = CreateDropship( createTeam, dropshipSpawn.GetOrigin(), dropshipSpawn.GetAngles() )
 		AddAnimEvent( dropship, "dropship_warpout", WarpoutEffect )
@@ -103,6 +123,9 @@ void function OnPrematchStart()
 		teamDropships[ dropship ] <- [ null, null, null, null ]
 		
 		thread PlayAnim( dropship, "dropship_classic_mp_flyin" )
+
+		if ( file.imcDropships.len() >= 2 && file.militiaDropships.len() >= 2 )
+			break
 	}
 	
 	// Populate Dropships

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_classic_mp_dropship_intro.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_classic_mp_dropship_intro.gnut
@@ -31,8 +31,6 @@ struct {
 	table< entity, array<entity> > imcDropships
 	
 	float introStartTime
-
-	bool doneLoadingEnts = false
 } file
 
 
@@ -62,17 +60,12 @@ void function DropshipIntro_OnClientConnected( entity player )
 
 void function OnPrematchStart()
 {
-	thread OnPrematchStart_Delayed()
+	thread OnPrematchStart_Threaded()
 }
 
-void function OnPrematchStart_Delayed()
+void function OnPrematchStart_Threaded()
 {
-	// we have to wait for entities to load in, because GetEntArrayByClass_Expensive
-	// is used later in the func, and it can run before dropship entities are loaded,
-	// causing no dropship spawn points to be found
-	while ( !file.doneLoadingEnts )
-		WaitFrame()
-
+	FlagWait( "EntitiesDidLoad" )
 	ClassicMP_OnIntroStarted()
 
 	print( "starting dropship intro!" )

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_classic_mp_dropship_intro.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_classic_mp_dropship_intro.gnut
@@ -38,13 +38,6 @@ void function ClassicMP_DefaultDropshipIntro_Setup()
 {
 	AddCallback_OnClientConnected( DropshipIntro_OnClientConnected )	
 	AddCallback_GameStateEnter( eGameState.Prematch, OnPrematchStart )
-
-	AddCallback_EntitiesDidLoad( OnEntitiesDidLoad )
-}
-
-void function OnEntitiesDidLoad()
-{
-	file.doneLoadingEnts = true
 }
 
 void function DropshipIntro_OnClientConnected( entity player )


### PR DESCRIPTION
<!-- 
WHEN OPENING A PULL REQUEST KEEP IN MIND:
-> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
-> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)

-> For fixes, description on how to reproduce the bug are appreciated and help your PR get merged faster
-> For features, description on how to use or a sample mod that makes use of the feature is appreciated and will help your PR get merged faster

-> Please use a sensible title for your pull request

-> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).

-> If you made multiple independent changes, please make a new PR for each one. This prevents your PR being blocked from merging by one of the changes you made.

Note that commit messages in PRs will generally be squashed to keep commit history clean.
-->

This PR fixes an inconsistent crash during the intro dropships, which was introduced in #809. Oddly, this issue only seems to happen on dedicated servers.
```
[00:47:00] [SCRIPT SV] [info] SCRIPT ERROR: [SERVER] getrandom(): Array is empty
[00:47:00] [SCRIPT SV] [info]  -> playerDropship = introDropships.getrandom()
[00:47:00] [SCRIPT SV] [info]
CALLSTACK
*FUNCTION [PutPlayerInDropship()] mp/_classic_mp_dropship_intro.gnut line [168]
*FUNCTION [DropshipIntro_OnClientConnected()] mp/_classic_mp_dropship_intro.gnut line [50]
*FUNCTION [CodeCallback_OnClientConnectionCompleted()] mp/_base_gametype_mp.gnut line [173]
```

### Why this happens:

When the code runs `GetEntArrayByClass_Expensive( "info_spawnpoint_dropship_start" )` to get places to spawn the dropships, sometimes it will run before the server has finished loading all the ents, which can cause this to return an empty or incomplete list. There are no checks for this, so the code will continue running until it tries to put players in the dropship, which will cause it to crash due to the list being empty.

### The fix:

The prematch code will now wait until all entities have been loaded (`AddCallback_EntitiesDidLoad`). Additionally, the loop for spawning dropships has been updated to fix a rare case where too few or no dropships can spawn.

### Testing:

This fix (and several other attempts) has been extensively tested on the previous ikhadhonger servers. But to test this, simply start a dedicated server and switch maps several times. Without this PR it will eventually crash.