### PR TITLE
Add missing trailing commas

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_modmenu.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_modmenu.nut
@@ -13,7 +13,7 @@ struct panelContent {
 enum filterShow {
 	ALL = 0,
 	ONLY_ENABLED = 1,
-	ONLY_DISABLED = 2
+	ONLY_DISABLED = 2,
 	ONLY_NOT_REQUIRED = 3,
 	ONLY_REQUIRED = 4
 }

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_modmenu.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_modmenu.nut
@@ -712,3 +712,4 @@ void function ReloadMods()
 	// note: the logic for this seems really odd, unsure why it doesn't seem to update, since the same code seems to get run irregardless of whether we've read weapon data before
 	ClientCommand( "uiscript_reset" )
 }
+

--- a/Northstar.Custom/mod/scripts/vscripts/sh_northstar_http_requests.gnut
+++ b/Northstar.Custom/mod/scripts/vscripts/sh_northstar_http_requests.gnut
@@ -3,7 +3,7 @@ globalize_all_functions
 global enum HttpRequestMethod
 {
 	GET = 0,
-	POST = 1
+	POST = 1,
 	HEAD = 2,
 	PUT = 3,
 	DELETE = 4,


### PR DESCRIPTION
Some enums are just randomly missing commas between elements
it doesnt actually do anything but its kinda gross and now that I know i cant unsee it