### PR TITLE
Add mod version argument to `NSSetModEnabled` function

### DIFF
--- a/.github/nativefuncs.json
+++ b/.github/nativefuncs.json
@@ -16,7 +16,7 @@
 			"name":"NSSetModEnabled",
 			"helpText":"",
 			"returnTypeString":"void",
-			"argTypes":"string modName, bool enabled"
+			"argTypes":"string modName, string modVersion, bool enabled"
 		},
 		{
 			"name":"DecodeJSON",
@@ -222,7 +222,7 @@
 			"name":"NSSetModEnabled",
 			"helpText":"",
 			"returnTypeString":"void",
-			"argTypes":"string modName, bool enabled"
+			"argTypes":"string modName, string modVersion, bool enabled"
 		},
 		{
 			"name":"DecodeJSON",
@@ -392,7 +392,7 @@
 			"name":"NSSetModEnabled",
 			"helpText":"",
 			"returnTypeString":"void",
-			"argTypes":"string modName, bool enabled"
+			"argTypes":"string modName, string modVersion, bool enabled"
 		},
 		{
 			"name": "NSFetchVerifiedModsManifesto",

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_modmenu.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_modmenu.nut
@@ -210,7 +210,7 @@ void function OnModButtonPressed( var button )
 		CoreModToggleDialog( modName )
 	else
 	{
-		NSSetModEnabled( modName, !mod.enabled )
+		NSSetModEnabled( modName, mod.version, !mod.enabled )
 
 		// retrieve state of the mod that just got toggled
 		array<ModInfo> infos = NSGetModInformation( mod.name )
@@ -304,7 +304,7 @@ void function DisableMod()
 {
 	ModInfo mod = file.mods[ int ( Hud_GetScriptID( Hud_GetParent( file.currentButton ) ) ) + file.scrollOffset - 1 ].mod
 	string modName = mod.name
-	NSSetModEnabled( modName, false )
+	NSSetModEnabled( modName, mod.version, false )
 
 	// retrieve state of the mod that just got toggled
 	array<ModInfo> infos = NSGetModInformation( mod.name )

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -1132,7 +1132,7 @@ void function ThreadedAuthAndConnectToServer( string password = "", bool modsCha
 				if (!found)
 				{
 					modsChanged = true
-					NSSetModEnabled( modName, false )
+					NSSetModEnabled( modName, mod.version, false )
 					print(format("Disabled \"%s\" (v%s) since it's not required on server.", modName, modVersion))
 				}
 			}
@@ -1151,7 +1151,7 @@ void function ThreadedAuthAndConnectToServer( string password = "", bool modsCha
 				if ( !localModInfos[0].enabled )
 				{
 					modsChanged = true
-					NSSetModEnabled( modName, true )
+					NSSetModEnabled( modName, localModInfos[0].version, true )
 					print(format("Enabled \"%s\" (v%s) to join server.", modName, localModInfos[0].version))
 				}
 			}
@@ -1163,7 +1163,7 @@ void function ThreadedAuthAndConnectToServer( string password = "", bool modsCha
 					if ( localMod.version == mod.version )
 					{
 						modsChanged = true
-						NSSetModEnabled( mod.name, true )
+						NSSetModEnabled( mod.name, mod.version, true )
 						print(format("Enabled \"%s\" (v%s) to join server.", modName, modVersion))
 						break
 					}


### PR DESCRIPTION
With this PR, the `NSSetModEnabled` function enables a given version of the input mod only, and not all of its versions (which would crash due to files conflicts).

You can find the launcher PR counterpart there: https://github.com/R2Northstar/NorthstarLauncher/pull/851

---

#### Testing

1. Install both mods and launcher PRs;
2. Install 2 versions of the [`Extraction` gamemode](https://thunderstore.io/c/northstar/p/Zanieon/Extraction_Gamemode/versions/) (I tried `v1.2.1` and `v1.3.0`);
3. Put the `"Extraction": false` entry in your `enabledmods.json` file (otherwise your client will crash due to file conflict);
4. Open the server browser and find a server requiring the Extraction mode;
5. Enable the correct version of the mod through your console: `sv_cheats 1` / `script NSSetModEnabled("Extraction", "1.3.0", true)`;
6. You should then be able to join the server;