### PR TITLE
feat: Improve bleedout feature

### DIFF
--- a/Northstar.Client/mod/resource/northstar_client_localisation_english.txt
+++ b/Northstar.Client/mod/resource/northstar_client_localisation_english.txt
@@ -237,6 +237,7 @@ Press Yes if you agree to this. This choice can be changed in the mods menu at a
 		"player_bleedout_firstAidTimeSelf" "Self-res time"
 		"player_bleedout_firstAidHealPercent" "First aid health percentage"
 		"player_bleedout_aiBleedingPlayerMissChance" "Downed AI miss chance"
+		"BLEEDOUT_CALL_HELP" "You're bleeding out!"
 
 		// coop stuff
 		"PL_sp_coop" "(UNFINISHED) Singleplayer Coop"

--- a/Northstar.Client/mod/resource/northstar_client_localisation_french.txt
+++ b/Northstar.Client/mod/resource/northstar_client_localisation_french.txt
@@ -236,6 +236,7 @@ Choisissez Oui si vous êtes d'accord. Ce choix peut être modifié à tout inst
 		"player_bleedout_firstAidTimeSelf" "Temps d'auto-réanimation"
 		"player_bleedout_firstAidHealPercent" "Soins (%) des prem. secours"
 		"player_bleedout_aiBleedingPlayerMissChance" "Ratage (%) des IA à terre"
+		"BLEEDOUT_CALL_HELP" "Vous êtes à terre !"
 
 		// coop stuff
 		"PL_sp_coop" "(ALPHA) Campagne (coop)"

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
@@ -1,0 +1,152 @@
+
+global function BleedoutClient_Init
+
+//SERVER CALLBACKS
+global function ServerCallback_BLEEDOUT_StartFirstAidProgressBar
+global function ServerCallback_BLEEDOUT_StopFirstAidProgressBar
+global function ServerCallback_BLEEDOUT_ShowWoundedMarker
+global function ServerCallback_BLEEDOUT_HideWoundedMarker
+
+struct
+{
+	int currentResAttemptID = -1
+}
+file
+
+void function BleedoutClient_Init()
+{
+	RegisterSignal( "Bleedout_StopFirstAid" )
+	RegisterSignal( "Bleedout_OnRevive" )
+
+	StatusEffect_RegisterEnabledCallback( eStatusEffect.bleedoutDOF, Bleedout_StartDyingDOF )
+	StatusEffect_RegisterDisabledCallback( eStatusEffect.bleedoutDOF, Bleedout_PlayerRevivedDOF )
+}
+
+void function ServerCallback_BLEEDOUT_StartFirstAidProgressBar( float endTime, int playerEHandle, int healerEHandle, int resAttemptID )
+{
+	entity playerToRes = GetEntityFromEncodedEHandle( playerEHandle )
+	entity playerHealer = GetEntityFromEncodedEHandle( healerEHandle )
+
+	if ( !IsValid( playerToRes ) || !IsValid( playerHealer ) )
+		return
+
+	entity player = GetLocalClientPlayer()
+
+	//If the local player is already reciving healing, do not change their hud state
+	if ( player == playerToRes && file.currentResAttemptID != -1 )
+		return
+
+	player.Signal( "Bleedout_StopFirstAid" )
+
+	float progressTime = playerToRes == playerHealer ? Bleedout_GetFirstAidTimeSelf() : Bleedout_GetFirstAidTime()
+
+	if ( playerToRes == player && playerHealer != player )
+	{
+		thread Bleedout_DisplayFirstAidProgressBar( endTime, progressTime, playerHealer, "#BLEEDOUT_RECIEVING_FIRST_AID" )
+	}
+	else
+	{
+		thread Bleedout_DisplayFirstAidProgressBar( endTime, progressTime, playerToRes, "#BLEEDOUT_APPLYING_FIRST_AID" )
+	}
+
+	file.currentResAttemptID = resAttemptID
+}
+
+void function ServerCallback_BLEEDOUT_StopFirstAidProgressBar( int resAttemptID )
+{
+	//Ensure that the res instance that started the First Aid Progress Bar is the one to end it.
+	if ( resAttemptID != file.currentResAttemptID )
+		return
+
+	//Allow for new res attempts
+	file.currentResAttemptID = -1
+
+	entity player = GetLocalClientPlayer()
+	player.Signal( "Bleedout_StopFirstAid" )
+}
+
+void function Bleedout_DisplayFirstAidProgressBar( float endTime, float progressTime, entity playerToRes, string text )
+{
+	entity player = GetLocalClientPlayer()
+	player.EndSignal( "OnDeath" )
+	player.EndSignal( "Bleedout_StopFirstAid" )
+	playerToRes.EndSignal( "OnDeath" )
+	var rui = CreateCockpitRui( $"ui/bleedout_timer.rpak" )
+	RuiSetString( rui, "text", text )
+	RuiSetGameTime( rui, "endTime", endTime )
+	RuiSetFloat( rui, "progressTime", progressTime )
+
+	OnThreadEnd(
+		function() : ( rui )
+		{
+			RuiDestroy( rui )
+		}
+	)
+
+	while( Time() <= endTime )
+	{
+		WaitFrame()
+	}
+}
+
+void function Bleedout_StartDyingDOF( entity ent, int statusEffect, bool actuallyChanged )
+{
+	if ( !actuallyChanged )
+		return
+
+	if ( ent != GetLocalClientPlayer() )
+		return
+
+	DoF_LerpFarDepth( 1, 20, Bleedout_GetBleedoutTime() * 10 )
+}
+
+void function Bleedout_PlayerRevivedDOF( entity ent, int statusEffect, bool actuallyChanged )
+{
+	if ( !actuallyChanged )
+		return
+
+	if ( ent != GetLocalClientPlayer() )
+		return
+
+	DoF_SetFarDepthToDefault()
+}
+
+void function ServerCallback_BLEEDOUT_ShowWoundedMarker( int woundedPlayerEhandle, float startTime, float endTime )
+{
+	entity woundedPlayer = GetEntityFromEncodedEHandle( woundedPlayerEhandle )
+	if ( !IsValid( woundedPlayer ) )
+		return
+	thread ShowWoundedMarker_Internal( woundedPlayer, startTime, endTime )
+}
+
+void function ShowWoundedMarker_Internal( entity woundedPlayer, float startTime, float endTime )
+{
+	woundedPlayer.EndSignal( "OnDeath" )
+	woundedPlayer.EndSignal( "Bleedout_OnRevive" )
+	var rui = CreateCockpitRui( $"ui/bleedout_wounded_marker.rpak", 500 )
+	RuiTrackFloat3( rui, "pos", woundedPlayer, RUI_TRACK_POINT_FOLLOW, woundedPlayer.LookupAttachment( "HEADSHOT" ) )
+	RuiSetGameTime( rui, "startTime", startTime )
+	RuiSetGameTime( rui, "endTime", endTime )
+
+	if ( Bleedout_GetBleedoutTime() <= 0 )
+	{
+		RuiSetBool( rui, "showTimer", false )
+	}
+
+	OnThreadEnd(
+	function() : ( rui )
+		{
+			RuiDestroy( rui )
+		}
+	)
+
+	WaitForever()
+}
+
+void function ServerCallback_BLEEDOUT_HideWoundedMarker( int woundedPlayerEhandle )
+{
+	entity woundedPlayer = GetEntityFromEncodedEHandle( woundedPlayerEhandle )
+	if ( !IsValid( woundedPlayer ) )
+		return
+	woundedPlayer.Signal( "Bleedout_OnRevive" )
+}

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
@@ -1,4 +1,5 @@
 
+untyped
 global function BleedoutClient_Init
 
 //SERVER CALLBACKS
@@ -97,6 +98,9 @@ void function Bleedout_StartDyingDOF( entity ent, int statusEffect, bool actuall
 	if ( ent != GetLocalClientPlayer() )
 		return
 
+	ent.hudElems.damageOverlayRedBloom.SetColor( 255, 0, 0, 100 )
+	ent.hudElems.damageOverlayRedBloom.Show()
+	ent.hudElems.damageOverlayRedBloom.ColorOverTime( 255, 0, 0, 255, Bleedout_GetBleedoutTime())
 	DoF_LerpFarDepth( 1, 20, Bleedout_GetBleedoutTime() * 10 )
 }
 
@@ -108,6 +112,7 @@ void function Bleedout_PlayerRevivedDOF( entity ent, int statusEffect, bool actu
 	if ( ent != GetLocalClientPlayer() )
 		return
 
+	ent.hudElems.damageOverlayRedBloom.Hide()
 	DoF_SetFarDepthToDefault()
 }
 

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
@@ -121,11 +121,22 @@ void function Bleedout_StartDyingDOF( entity ent, int statusEffect, bool actuall
 		return
 
 	thread Bleedout_StartBleedoutProgressBar()
+	thread Bleedout_StartScreenEffects( ent )
 
-	ent.hudElems.damageOverlayRedBloom.SetColor( 255, 0, 0, 100 )
-	ent.hudElems.damageOverlayRedBloom.Show()
-	ent.hudElems.damageOverlayRedBloom.ColorOverTime( 255, 0, 0, 255, Bleedout_GetBleedoutTime())
 	DoF_LerpFarDepth( 1, 20, Bleedout_GetBleedoutTime() * 10 )
+}
+
+void function Bleedout_StartScreenEffects( entity ent )
+{
+	ent.hudElems.damageOverlayRedBloom.SetColor( 255, 0, 0, 100 )
+	ent.hudElems.damageOverlayRedBloom.ColorOverTime( 255, 0, 0, 255, Bleedout_GetBleedoutTime())
+
+	float flashDuration = 0.5
+	ent.hudElems.damageOverlayRedBloom.Show()
+	ScreenFade( ent, 255, 0, 0, 150, 0.5, 0.0, FFADE_IN | FFADE_PURGE) // red flash
+	wait flashDuration
+
+	ScreenFade( ent, 0, 0, 0, 240, Bleedout_GetBleedoutTime() - flashDuration, 0.0, FFADE_OUT | FFADE_PURGE )
 }
 
 void function Bleedout_PlayerRevivedDOF( entity ent, int statusEffect, bool actuallyChanged )
@@ -137,6 +148,7 @@ void function Bleedout_PlayerRevivedDOF( entity ent, int statusEffect, bool actu
 		return
 
 	ent.hudElems.damageOverlayRedBloom.Hide()
+	ScreenFade( ent, 0, 0, 0, 200, 0.5, 0.0, FFADE_IN | FFADE_PURGE)
 	DoF_SetFarDepthToDefault()
 }
 

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
@@ -41,6 +41,8 @@ void function Bleedout_StartBleedoutProgressBar()
 		function() : ( rui )
 		{
 			RuiDestroy( rui )
+			entity ent = GetLocalClientPlayer()
+			StopSoundOnEntity( ent, ent.IsMechanical() ? "Pilot_Critical_Breath_Loop_1P" : "GruntCooper_Wounded_Loop_1P" )
 		}
 	)
 
@@ -128,6 +130,7 @@ void function Bleedout_StartDyingDOF( entity ent, int statusEffect, bool actuall
 	file.isSelfBleeding = true
 	thread Bleedout_StartBleedoutProgressBar()
 	thread Bleedout_StartScreenEffects( ent )
+	EmitSoundOnEntity( ent, ent.IsMechanical() ? "Pilot_Critical_Breath_Loop_1P" : "GruntCooper_Wounded_Loop_1P" )
 
 	if ( !file.displayedTutorialMessage && Bleedout_GetFirstAidTimeSelf() < 0 )
 	{

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
@@ -12,6 +12,7 @@ struct
 {
 	int currentResAttemptID = -1
 	bool isSelfBleeding = false
+	bool displayedTutorialMessage = false
 }
 file
 
@@ -129,6 +130,12 @@ void function Bleedout_StartDyingDOF( entity ent, int statusEffect, bool actuall
 	thread Bleedout_StartBleedoutProgressBar()
 	thread Bleedout_StartScreenEffects( ent )
 
+	if ( !file.displayedTutorialMessage && Bleedout_GetFirstAidTimeSelf() < 0 )
+	{
+		AddPlayerHint( Bleedout_GetBleedoutTime() - 0.25, 0.5, $"","#BLEEDOUT_CALL_HELP" )
+		file.displayedTutorialMessage = true
+	}
+
 	DoF_LerpFarDepth( 1, 20, Bleedout_GetBleedoutTime() * 10 )
 }
 
@@ -156,6 +163,7 @@ void function Bleedout_PlayerRevivedDOF( entity ent, int statusEffect, bool actu
 	file.isSelfBleeding = false
 	ent.hudElems.damageOverlayRedBloom.Hide()
 	ScreenFade( ent, 0, 0, 0, 200, 0.5, 0.0, FFADE_IN | FFADE_PURGE)
+	HidePlayerHint( "#BLEEDOUT_CALL_HELP" )
 	DoF_SetFarDepthToDefault()
 }
 

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
@@ -146,7 +146,7 @@ void function Bleedout_StartScreenEffects( entity ent )
 
 	float flashDuration = 0.5
 	ent.hudElems.damageOverlayRedBloom.Show()
-	ScreenFade( ent, 255, 0, 0, 150, 0.5, 0.0, FFADE_IN | FFADE_PURGE) // red flash
+	ScreenFade( ent, 255, 0, 0, 175, 0.55, 0.0, FFADE_IN | FFADE_PURGE) // red flash
 	wait flashDuration
 
 	ScreenFade( ent, 0, 0, 0, 240, Bleedout_GetBleedoutTime() - flashDuration, 0.0, FFADE_OUT | FFADE_PURGE )

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
@@ -136,6 +136,7 @@ void function Bleedout_StartDyingDOF( entity ent, int statusEffect, bool actuall
 	}
 
 	DoF_LerpFarDepth( 1, 20, Bleedout_GetBleedoutTime() * 10 )
+	ent.DisableHealthChangedCallback()
 }
 
 void function Bleedout_StartScreenEffects( entity ent )
@@ -160,10 +161,10 @@ void function Bleedout_PlayerRevivedDOF( entity ent, int statusEffect, bool actu
 		return
 
 	file.isSelfBleeding = false
-	ent.hudElems.damageOverlayRedBloom.Hide()
-	ScreenFade( ent, 0, 0, 0, 200, 0.5, 0.0, FFADE_IN | FFADE_PURGE)
 	HidePlayerHint( "#BLEEDOUT_CALL_HELP" )
 	DoF_SetFarDepthToDefault()
+	HealthHUD_AddPlayer( ent )
+	ScreenFade( ent, 0, 0, 0, 200, 0.5, 0.0, FFADE_IN | FFADE_PURGE)
 }
 
 void function ServerCallback_BLEEDOUT_ShowWoundedMarker( int woundedPlayerEhandle, float startTime, float endTime )

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
@@ -30,8 +30,7 @@ void function Bleedout_StartBleedoutProgressBar()
 	entity player = GetLocalClientPlayer()
 	player.EndSignal( "OnDeath" )
 
-	// var rui = RuiCreate( $"ui/bleedout_wounded_marker.rpak", clGlobal.topoCockpitHud, RUI_DRAW_HUD, 0 )
-	var rui = CreatePermanentCockpitRui( $"ui/bleedout_wounded_marker.rpak" )
+	var rui = CreateFullscreenRui( $"ui/bleedout_wounded_marker.rpak", 10000 )
 	RuiTrackFloat3( rui, "pos", player, RUI_TRACK_ABSORIGIN_FOLLOW ) // RUI_TRACK_OVERHEAD_FOLLOW
 	RuiSetGameTime( rui, "startTime", Time() )
 	RuiSetGameTime( rui, "endTime", Time() + Bleedout_GetBleedoutTime() )

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
@@ -23,6 +23,28 @@ void function BleedoutClient_Init()
 	StatusEffect_RegisterDisabledCallback( eStatusEffect.bleedoutDOF, Bleedout_PlayerRevivedDOF )
 }
 
+void function Bleedout_StartBleedoutProgressBar()
+{
+	entity player = GetLocalClientPlayer()
+	player.EndSignal( "OnDeath" )
+
+	// var rui = RuiCreate( $"ui/bleedout_wounded_marker.rpak", clGlobal.topoCockpitHud, RUI_DRAW_HUD, 0 )
+	var rui = CreatePermanentCockpitRui( $"ui/bleedout_wounded_marker.rpak" )
+	RuiTrackFloat3( rui, "pos", player, RUI_TRACK_ABSORIGIN_FOLLOW ) // RUI_TRACK_OVERHEAD_FOLLOW
+	RuiSetGameTime( rui, "startTime", Time() )
+	RuiSetGameTime( rui, "endTime", Time() + Bleedout_GetBleedoutTime() )
+	//RuiSetString( rui, "title", "hello there" )
+	//RuiSetBool( rui, "showTimer", true )
+
+	OnThreadEnd(
+		function() : ( rui )
+		{
+			RuiDestroy( rui )
+		}
+	)
+	WaitForever()
+}
+
 void function ServerCallback_BLEEDOUT_StartFirstAidProgressBar( float endTime, int playerEHandle, int healerEHandle, int resAttemptID )
 {
 	entity playerToRes = GetEntityFromEncodedEHandle( playerEHandle )
@@ -97,6 +119,8 @@ void function Bleedout_StartDyingDOF( entity ent, int statusEffect, bool actuall
 
 	if ( ent != GetLocalClientPlayer() )
 		return
+
+	thread Bleedout_StartBleedoutProgressBar()
 
 	ent.hudElems.damageOverlayRedBloom.SetColor( 255, 0, 0, 100 )
 	ent.hudElems.damageOverlayRedBloom.Show()

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_bleedout.gnut
@@ -11,6 +11,7 @@ global function ServerCallback_BLEEDOUT_HideWoundedMarker
 struct
 {
 	int currentResAttemptID = -1
+	bool isSelfBleeding = false
 }
 file
 
@@ -42,7 +43,11 @@ void function Bleedout_StartBleedoutProgressBar()
 			RuiDestroy( rui )
 		}
 	)
-	WaitForever()
+
+	while ( file.isSelfBleeding )
+	{
+		WaitFrame()
+	}
 }
 
 void function ServerCallback_BLEEDOUT_StartFirstAidProgressBar( float endTime, int playerEHandle, int healerEHandle, int resAttemptID )
@@ -120,6 +125,7 @@ void function Bleedout_StartDyingDOF( entity ent, int statusEffect, bool actuall
 	if ( ent != GetLocalClientPlayer() )
 		return
 
+	file.isSelfBleeding = true
 	thread Bleedout_StartBleedoutProgressBar()
 	thread Bleedout_StartScreenEffects( ent )
 
@@ -147,6 +153,7 @@ void function Bleedout_PlayerRevivedDOF( entity ent, int statusEffect, bool actu
 	if ( ent != GetLocalClientPlayer() )
 		return
 
+	file.isSelfBleeding = false
 	ent.hudElems.damageOverlayRedBloom.Hide()
 	ScreenFade( ent, 0, 0, 0, 200, 0.5, 0.0, FFADE_IN | FFADE_PURGE)
 	DoF_SetFarDepthToDefault()

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_bleedout.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_bleedout.gnut
@@ -117,7 +117,7 @@ void function PlayerDying( entity player )
 				file.isBleeding[ player ] = false
 				file.lastAttacker[ player ] = svGlobal.worldspawn
 
-				player.UnforceCrouch()
+				thread MakePlayerStand( player )
 				player.SetOneHandedWeaponUsageOff()
 				//Remote_CallFunction_NonReplay( player, "ServerCallback_BLEEDOUT_PlayerRevivedDOF" )
 
@@ -158,6 +158,15 @@ void function PlayerDying( entity player )
 		WaitForever()
 
 	PlayerDiesFromBleedout( player, file.lastAttacker[ player ] )
+}
+
+void function MakePlayerStand( entity player )
+{
+	Assert( IsNewThread(), "Must be threaded off." )
+	player.UnforceCrouch()
+	player.ForceStand()
+	WaitFrame() // waiting for player to stand before allowing them to crouch again
+	player.UnforceStand()
 }
 
 void function EnablePlayerRes( entity player )


### PR DESCRIPTION
Currently, the bleedout feature does not have enough feedback, leading to players not aware their character is bleeding out.
Except for the focus change, you cannot really tell what's happening:

[old.webm](https://github.com/user-attachments/assets/ffcb499b-d91f-4666-8193-49717d13945f)

This PR attempts to fix that with small UI changes.

In short:
* a red flash helps the player acknowledge they are down;
* a marker is now displayed on HUD, along with a red screen border effect;
* a text message is displayed on first match bleedout;
* border red intensity increases as time passes by (screen also slowly fades to black).

[new.webm](https://github.com/user-attachments/assets/65481a5d-991b-4ec5-bc46-80dbc51e5e24)
