### PR TITLE
Improve voice chat hud element when using alltalk

### DIFF
--- a/Northstar.Client/mod/resource/ui/hudvoice.res
+++ b/Northstar.Client/mod/resource/ui/hudvoice.res
@@ -1,0 +1,167 @@
+"Resource/UI/HudVoice.res"
+{
+	VoiceSafeArea // Normal SafeArea couldn't be found
+	{
+		ControlName		ImagePanel
+		wide			%90
+		tall			%90
+		visible			1
+		scaleImage		1
+		fillColor		"0 0 0 0"
+		drawColor		"0 0 0 0"
+
+		pin_to_sibling				Screen
+		pin_corner_to_sibling		CENTER
+		pin_to_sibling_corner		CENTER
+	}
+
+	voiceMic0
+	{
+		ControlName			ImagePanel
+		wide				36
+		tall				36
+		visible				0
+		image				"ui/icon_mic_active"
+		scaleImage			1
+		zpos				900
+
+		pin_to_sibling				VoiceSafeArea
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		TOP_RIGHT
+	}
+	voiceName0
+	{
+		ControlName			Label
+		wide				450
+		tall				36
+		visible				0
+		font				Default_21_ShadowGlow
+		textAlignment		east
+		textinsetx			13
+		zpos				900
+
+		pin_to_sibling				voiceMic0
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		TOP_LEFT
+	}
+
+	voiceMic1
+	{
+		ControlName			ImagePanel
+		wide				36
+		tall				36
+		visible				0
+		image				"ui/icon_mic_active"
+		scaleImage			1
+		zpos				900
+
+		pin_to_sibling				voiceMic0
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		BOTTOM_RIGHT
+	}
+	voiceName1
+	{
+		ControlName			Label
+		wide				450
+		tall				36
+		visible				0
+		font				Default_21_ShadowGlow
+		textAlignment		east
+		textinsetx			13
+		zpos				900
+
+		pin_to_sibling				voiceMic1
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		TOP_LEFT
+	}
+
+	voiceMic2
+	{
+		ControlName			ImagePanel
+		wide				36
+		tall				36
+		visible				0
+		image				"ui/icon_mic_active"
+		scaleImage			1
+		zpos				900
+
+		pin_to_sibling				voiceMic1
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		BOTTOM_RIGHT
+	}
+	voiceName2
+	{
+		ControlName			Label
+		wide				450
+		tall				36
+		visible				0
+		font				Default_21_ShadowGlow
+		textAlignment		east
+		textinsetx			13
+		zpos				900
+
+		pin_to_sibling				voiceMic2
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		TOP_LEFT
+	}
+
+	voiceMic3
+	{
+		ControlName			ImagePanel
+		wide				36
+		tall				36
+		visible				0
+		image				"ui/icon_mic_active"
+		scaleImage			1
+		zpos				900
+
+		pin_to_sibling				voiceMic2
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		BOTTOM_RIGHT
+	}
+	voiceName3
+	{
+		ControlName			Label
+		wide				450
+		tall				36
+		visible				0
+		font				Default_21_ShadowGlow
+		textAlignment		east
+		textinsetx			13
+		zpos				900
+
+		pin_to_sibling				voiceMic3
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		TOP_LEFT
+	}
+
+	voiceMic4
+	{
+		ControlName			ImagePanel
+		wide				36
+		tall				36
+		visible				0
+		image				"ui/icon_mic_active"
+		scaleImage			1
+		zpos				900
+
+		pin_to_sibling				voiceMic3
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		BOTTOM_RIGHT
+	}
+	voiceName4
+	{
+		ControlName			Label
+		wide				450
+		tall				36
+		visible				0
+		font				Default_21_ShadowGlow
+		textAlignment		east
+		textinsetx			13
+		zpos				900
+
+		pin_to_sibling				voiceMic4
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		TOP_LEFT
+	}
+}

--- a/Northstar.Client/mod/resource/ui/hudvoice.res
+++ b/Northstar.Client/mod/resource/ui/hudvoice.res
@@ -164,4 +164,125 @@
 		pin_corner_to_sibling		TOP_RIGHT
 		pin_to_sibling_corner		TOP_LEFT
 	}
+
+	voiceMic5
+	{
+		ControlName			ImagePanel
+		wide				36
+		tall				36
+		visible				0
+		image				"ui/icon_mic_active"
+		scaleImage			1
+		zpos				900
+
+		pin_to_sibling				voiceMic4
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		BOTTOM_RIGHT
+	}
+	voiceName5
+	{
+		ControlName			Label
+		wide				450
+		tall				36
+		visible				0
+		font				Default_21_ShadowGlow
+		textAlignment		east
+		textinsetx			13
+		zpos				900
+
+		pin_to_sibling				voiceMic5
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		TOP_LEFT
+	}
+
+	voiceMic6
+	{
+		ControlName			ImagePanel
+		wide				36
+		tall				36
+		visible				0
+		image				"ui/icon_mic_active"
+		scaleImage			1
+		zpos				900
+
+		pin_to_sibling				voiceMic5
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		BOTTOM_RIGHT
+	}
+	voiceName6
+	{
+		ControlName			Label
+		wide				450
+		tall				36
+		visible				0
+		font				Default_21_ShadowGlow
+		textAlignment		east
+		textinsetx			13
+		zpos				900
+
+		pin_to_sibling				voiceMic6
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		TOP_LEFT
+	}
+
+	voiceMic7
+	{
+		ControlName			ImagePanel
+		wide				36
+		tall				36
+		visible				0
+		image				"ui/icon_mic_active"
+		scaleImage			1
+		zpos				900
+
+		pin_to_sibling				voiceMic6
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		BOTTOM_RIGHT
+	}
+	voiceName7
+	{
+		ControlName			Label
+		wide				450
+		tall				36
+		visible				0
+		font				Default_21_ShadowGlow
+		textAlignment		east
+		textinsetx			13
+		zpos				900
+
+		pin_to_sibling				voiceMic7
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		TOP_LEFT
+	}
+
+	voiceMic8
+	{
+		ControlName			ImagePanel
+		wide				36
+		tall				36
+		visible				0
+		image				"ui/icon_mic_active"
+		scaleImage			1
+		zpos				900
+
+		pin_to_sibling				voiceMic7
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		BOTTOM_RIGHT
+	}
+	voiceName8
+	{
+		ControlName			Label
+		wide				450
+		tall				36
+		visible				0
+		font				Default_21_ShadowGlow
+		textAlignment		east
+		textinsetx			13
+		zpos				900
+
+		pin_to_sibling				voiceMic8
+		pin_corner_to_sibling		TOP_RIGHT
+		pin_to_sibling_corner		TOP_LEFT
+	}
+
 }

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_voice_hud.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_voice_hud.gnut
@@ -1,0 +1,76 @@
+untyped
+
+
+global function InitVoiceHUD
+global function UpdateVoiceHUD
+
+
+const VOICEHUD_MAX = 5
+
+
+function InitVoiceHUD( entity player )
+{
+	player.cv.voiceHUDArray <- []
+	local elemPrefix
+	local elemIndex
+
+	for ( int index = 0; index < VOICEHUD_MAX; index++ )
+	{
+		elemPrefix = "voice"
+		elemIndex = string( index )
+
+		local Table = {
+			mic = HudElement( elemPrefix + "Mic" + elemIndex )
+			name = HudElement( elemPrefix + "Name" + elemIndex )
+		}
+
+		player.cv.voiceHUDArray.append( Table )
+
+		Table.name.Hide()
+		Table.mic.Hide()
+
+		VisGroup_AddElement( clGlobal.menuVisGroup, Table.mic )
+		VisGroup_AddElement( clGlobal.menuVisGroup, Table.name )
+	}
+}
+
+
+function UpdateVoiceHUD()
+{
+	entity localPlayer = GetLocalClientPlayer()
+
+	// Verify init was called first
+	if ( !( "voiceHUDArray" in localPlayer.cv ) )
+		return
+
+	int index = 0
+	if ( !clGlobal.showingScoreboard && !clGlobal.isMenuOpen )
+	{
+		array<entity> teamPlayers = GetPlayerArrayOfTeam( localPlayer.GetTeam() )
+		if ( teamPlayers.len() > 1 )
+		{
+			foreach ( teamPlayer in teamPlayers )
+			{
+				if ( teamPlayer.IsTalking() && !teamPlayer.IsMuted() )
+				{
+					localPlayer.cv.voiceHUDArray[index].mic.Show()
+
+					localPlayer.cv.voiceHUDArray[index].name.SetText( teamPlayer.GetPlayerNameWithClanTag() )
+					localPlayer.cv.voiceHUDArray[index].name.Show()
+
+					index++
+
+					// Already showing max, can't do anything else
+					if ( index >= VOICEHUD_MAX )
+						return
+				}
+			}
+		}
+	}
+
+	for ( ; index < VOICEHUD_MAX; index++ )
+	{
+		localPlayer.cv.voiceHUDArray[index].name.Hide()
+		localPlayer.cv.voiceHUDArray[index].mic.Hide()
+	}
+}

--- a/Northstar.Client/mod/scripts/vscripts/client/cl_voice_hud.gnut
+++ b/Northstar.Client/mod/scripts/vscripts/client/cl_voice_hud.gnut
@@ -5,8 +5,9 @@ global function InitVoiceHUD
 global function UpdateVoiceHUD
 
 
-const VOICEHUD_MAX = 5
-
+const VOICEHUD_MAX = 9
+const VOICEHUD_COLOR_FRIENDLY = [FRIENDLY_R, FRIENDLY_G, FRIENDLY_B, 255]
+const VOICEHUD_COLOR_ENEMY = [ENEMY_R, ENEMY_G, ENEMY_B, 255]
 
 function InitVoiceHUD( entity player )
 {
@@ -47,6 +48,12 @@ function UpdateVoiceHUD()
 	if ( !clGlobal.showingScoreboard && !clGlobal.isMenuOpen )
 	{
 		array<entity> teamPlayers = GetPlayerArrayOfTeam( localPlayer.GetTeam() )
+
+		bool allTalkEnabled = GetConVarBool( "sv_alltalk" )
+
+		if ( allTalkEnabled )
+			teamPlayers = GetPlayerArray()
+
 		if ( teamPlayers.len() > 1 )
 		{
 			foreach ( teamPlayer in teamPlayers )
@@ -57,6 +64,27 @@ function UpdateVoiceHUD()
 
 					localPlayer.cv.voiceHUDArray[index].name.SetText( teamPlayer.GetPlayerNameWithClanTag() )
 					localPlayer.cv.voiceHUDArray[index].name.Show()
+
+					if ( allTalkEnabled )
+					{
+						// The name hud element doesnt wanna change colors for some reason
+						// But its fine i think
+						if ( teamPlayer.GetTeam() == localPlayer.GetTeam() )
+						{
+							localPlayer.cv.voiceHUDArray[index].mic.SetColor( VOICEHUD_COLOR_FRIENDLY )
+							localPlayer.cv.voiceHUDArray[index].name.SetColor( VOICEHUD_COLOR_FRIENDLY )
+						}
+						else
+						{
+							localPlayer.cv.voiceHUDArray[index].mic.SetColor( VOICEHUD_COLOR_ENEMY )
+							localPlayer.cv.voiceHUDArray[index].name.SetColor( VOICEHUD_COLOR_ENEMY )
+						}
+					}
+					else
+					{
+						localPlayer.cv.voiceHUDArray[index].mic.ReturnToBaseColor()
+						localPlayer.cv.voiceHUDArray[index].name.ReturnToBaseColor()
+					}
 
 					index++
 


### PR DESCRIPTION
This makes a few changes to the voice chat hud element:

- If the server is using alltalk:
   - Players from the enemy team now actually show up on the hud
   - The voice chat icon will change colors depending on the player's team. I also wanted the name to change colors, but it just doesn't do that for some reason (it's probably fine like this tbh)

- Increased the max ammount of slots from 5 to 9 (mostly due to the alltalk changes)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/15f6ff7e-2d79-472b-af6a-558433b530c7" />

Adds two vanilla files:

`hudvoice.res` from englishclient_frontend
`cl_voice_hud.gnut` from englishclient_mp_common