### PR TITLE
Hide the "RuiButton" text from the color slider menu

### DIFF
--- a/Northstar.Client/mod/resource/ui/menus/colorsliders.menu
+++ b/Northstar.Client/mod/resource/ui/menus/colorsliders.menu
@@ -22,7 +22,7 @@ resource/ui/menus/colorsliders.menu
 		{
 			ControlName				RuiButton
 			rui                     "ui/basic_image.rpak"
-
+			labelText				""
 			wide					%100
 			tall					%100
 			bgcolor_override		"0 0 0 255"


### PR DESCRIPTION
This PR hides the "RuiButton" text from the color slider menu when open. 