### PR TITLE
feat: Custom map label

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -110,11 +110,20 @@ bool function FloatsEqual( float arg1, float arg2, float epsilon )
 ////////////////////////////
 // Custom map handling
 ////////////////////////////
+
+/**
+ * A map name is deemed raw if it is not localized (happens if the map
+ * is not an original Titanfall2 map, or is not localized by its mod).
+ */
 bool function IsMapNameRaw( string mapname )
 {
 	return mapname == Localize( mapname )
 }
 
+/**
+ * Formats a map name in a human readable way.
+ * (e.g. inputting "#mp_chroma_null_surf" returns "Chroma Null Surf" )
+ */
 string function GetCustomMapDisplayName( string mapname )
 {
 	// Remove "#mp_" prefix
@@ -146,6 +155,11 @@ string function GetCustomMapDisplayName( string mapname )
 	return res
 }
 
+/**
+ * Supersedes the default {GetMapDisplayName} function, to the addition of returning a
+ * nicely formatted map name if it couldn't be properly localized by the game (happens
+ * with maps that are not original sp or mp maps).
+ */
 string function GetMapBrowserName( string mapname )
 {
 	string localized = GetMapDisplayName( mapname )

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -10,7 +10,7 @@ global function RemoveConnectToServerCallback
 // Stop peeking
 
 const int BUTTONS_PER_PAGE = 15 // Number of servers we show
-const float DOUBLE_CLICK_TIME_MS = 0.4 // Max time between clicks for double click registering 
+const float DOUBLE_CLICK_TIME_MS = 0.4 // Max time between clicks for double click registering
 
 // Stores mouse delta used for scroll bar
 struct {
@@ -77,14 +77,14 @@ struct {
 	int serverButtonFocusedID = 0
 	bool shouldFocus = true
 	bool cancelConnection = false
-	
+
 	// filtered array of servers
 	array<serverStruct> serversArrayFiltered
 
 	array<ServerInfo> filteredServers
 	ServerInfo& focusedServer
 	ServerInfo& lastSelectedServer
-	
+
 	// UI references
 	array<var> serverButtons
 	array<var> serversName
@@ -102,10 +102,58 @@ struct {
 bool function FloatsEqual( float arg1, float arg2, float epsilon )
 {
 	if ( fabs( arg1 - arg2 ) < epsilon ) return true
-	
+
 	return false
 }
 
+
+////////////////////////////
+// Custom map handling
+////////////////////////////
+bool function IsMapNameRaw( string mapname )
+{
+	return mapname == Localize( mapname )
+}
+
+string function GetCustomMapDisplayName( string mapname )
+{
+	// Remove "#mp_" prefix
+	string res = mapname.slice(4)
+
+	// Remove underscores
+	res = StringReplace( res, "_", " ", true )
+
+	// Uppercase first letter
+	res = res.slice(0, 1).toupper() + res.slice(1)
+
+	// Uppercase each word
+	/// Early exit
+	if ( ! res.find(" ") )
+	{
+		return res
+	}
+
+	/// Uppercasing
+	for ( int i = 0; i < res.len(); i++ )
+	{
+		string c = res.slice(i, i+1 )
+		if ( c != " " )
+			continue
+
+		res = res.slice(0, i + 1) + res.slice(i + 1, i + 2).toupper() + res.slice(i + 2)
+	}
+
+	return res
+}
+
+string function GetMapBrowserName( string mapname )
+{
+	string localized = GetMapDisplayName( mapname )
+
+	if ( IsMapNameRaw( localized ) )
+		return GetCustomMapDisplayName( localized )
+	return localized
+}
 
 ////////////////////////////
 // Init
@@ -127,7 +175,7 @@ void function UpdatePrivateMatchModesAndMaps()
 
 		filterArguments.filterMaps.append( map )
 
-		string localized = GetMapDisplayName( map )
+		string localized = GetMapBrowserName( map )
 		Hud_DialogList_AddListItem( Hud_GetChild( file.menu, "SwtBtnSelectMap" ) , localized, string( enum_ + 1 ) )
 	}
 
@@ -487,7 +535,7 @@ void function OnHitDummyTop( var button )
 		file.scrollOffset = 0
 		Hud_SetFocused(Hud_GetChild(file.menu, "BtnServerNameTab"))
 	}
-	else 
+	else
 	{
 		// only update if list position changed
 		UpdateShownPage()
@@ -531,7 +579,7 @@ void function OnDownArrowSelected( var button )
 	{
 		file.scrollOffset = file.filteredServers.len() - BUTTONS_PER_PAGE
 	}
-	
+
 	UpdateShownPage()
 	UpdateListSliderPosition( file.filteredServers.len() )
 }
@@ -544,7 +592,7 @@ void function OnUpArrowSelected( var button )
 	{
 		file.scrollOffset = 0
 	}
-	
+
 	UpdateShownPage()
 	UpdateListSliderPosition( file.filteredServers.len() )
 }
@@ -552,41 +600,41 @@ void function OnUpArrowSelected( var button )
 ////////////////////////
 // Key Callbacks
 ////////////////////////
-void function OnEnterPressed( arg ) 
+void function OnEnterPressed( arg )
 {
 	// only trigger if a server is focused
-	if ( IsServerButtonFocused() ) 
+	if ( IsServerButtonFocused() )
 	{
 		OnServerSelected(0)
 	}
 }
 
-void function OnKeyRPressed( arg ) 
+void function OnKeyRPressed( arg )
 {
-	if ( !IsSearchBarFocused() ) 
+	if ( !IsSearchBarFocused() )
 	{
 		RefreshServers(0);
 	}
 }
 
-bool function IsServerButtonFocused() 
+bool function IsServerButtonFocused()
 {
 	var focusedElement = GetFocus()
 	if ( focusedElement == null )
 		return false
-	
+
 	var name = Hud_GetHudName( focusedElement )
 
-	foreach ( element in GetElementsByClassname( file.menu, "ServerButton" ) ) 
+	foreach ( element in GetElementsByClassname( file.menu, "ServerButton" ) )
 	{
-		if ( element == focusedElement ) 
+		if ( element == focusedElement )
 			return true
 	}
 
 	return false
 }
 
-bool function IsSearchBarFocused() 
+bool function IsSearchBarFocused()
 {
 	return Hud_GetChild( file.menu, "BtnServerSearch" ) == GetFocus()
 }
@@ -833,25 +881,25 @@ void function FilterServerList()
 		// Filters
 		if ( filterArguments.hideEmpty && server.playerCount == 0 )
 			continue;
-		
+
 		if ( filterArguments.hideFull && server.playerCount == server.maxPlayerCount )
 			continue;
-		
+
 		if ( filterArguments.hideProtected && server.requiresPassword )
 			continue;
-		
+
 		if ( filterArguments.filterMap != "SWITCH_ANY" && filterArguments.filterMap != server.map )
 			continue;
-		
+
 		if ( filterArguments.filterGamemode != "SWITCH_ANY" && filterArguments.filterGamemode != GetGameModeDisplayName(server.playlist) )
 			continue;
-	
+
 		// Search
 		if ( filterArguments.useSearch )
-		{	
+		{
 			array<string> sName
 			sName.append( StripColorCodes( RemoveNewlines( server.name.tolower() ) ) )
-			sName.append( Localize( GetMapDisplayName( server.map ) ).tolower() )
+			sName.append( Localize( GetMapBrowserName( server.map ) ).tolower() )
 			sName.append( server.map.tolower() )
 			sName.append( server.playlist.tolower() )
 			sName.append( Localize( server.playlist ).tolower() )
@@ -859,21 +907,21 @@ void function FilterServerList()
 			sName.append( server.region.tolower() )
 
 			string sTerm = filterArguments.searchTerm.tolower()
-			
+
 			bool found = false
 			for( int j = 0; j < sName.len(); j++ )
 			{
 				if ( sName[j].find( sTerm ) != null )
 					found = true
 			}
-			
+
 			if ( !found )
 				continue;
 		}
 
 		file.filteredServers.append( server )
 	}
-	
+
 	// Update player and server count
 	string totalPlayersStr = string( totalPlayers ) + ( totalPlayers == 1 ? " " : ""  ) + ( totalPlayers < 10 ? " " : ""  )
 	string serverCountStr = string( serverCount ) + ( serverCount == 1 ? " " : "" ) + ( serverCount < 10 ? " " : ""  )
@@ -909,7 +957,7 @@ void function UpdateShownPage()
 		Hud_SetVisible( file.serversProtected[ i ], server.requiresPassword )
 		Hud_SetText( file.serversName[ i ], EscapeLocalisationAndRemoveNewlines( server.name ) )
 		Hud_SetText( file.playerCountLabels[ i ], format( "%i/%i", server.playerCount, server.maxPlayerCount ) )
-		Hud_SetText( file.serversMap[ i ], GetMapDisplayName( server.map ) )
+		Hud_SetText( file.serversMap[ i ], GetMapBrowserName( server.map ) )
 		Hud_SetText( file.serversGamemode[ i ], GetGameModeDisplayName( server.playlist ) )
 		Hud_SetText( file.serversRegion[ i ], server.region )
 	}
@@ -928,7 +976,7 @@ void function OnServerButtonFocused( var button )
 {
 	if ( file.scrollOffset < 0 )
 		file.scrollOffset = 0
-	
+
 	int scriptID = int ( Hud_GetScriptID( button ) )
 	file.serverButtonFocusedID = scriptID
 	if ( file.filteredServers.len() > 0 )
@@ -995,7 +1043,7 @@ void function DisplayFocusedServerInfo( int scriptID )
 	Hud_SetVisible( Hud_GetChild( menu, "NextMapBack" ), true )
 	RuiSetImage( Hud_GetRui( Hud_GetChild( menu, "NextMapImage" ) ), "basicImage", GetMapImageForMapName( map ) )
 	Hud_SetVisible( Hud_GetChild( menu, "NextMapName" ), true )
-	Hud_SetText( Hud_GetChild( menu, "NextMapName" ), GetMapDisplayName( map ) )
+	Hud_SetText( Hud_GetChild( menu, "NextMapName" ), GetMapBrowserName( map ) )
 	Hud_SetVisible( Hud_GetChild( menu, "ServerName" ), true )
 	Hud_SetText( Hud_GetChild( menu, "ServerName" ), EscapeLocalisationAndRemoveNewlines( server.name ) )
 
@@ -1121,7 +1169,7 @@ void function OnServerSelected_Threaded( string password = "" )
 			}
 		}
 	}
-	
+
 	// If yes, we fetch the verified mods manifesto, to check whether uninstalled
 	// mods can be installed through auto-download
 	if ( uninstalledModFound && autoDownloadAllowed )

--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
@@ -396,7 +396,7 @@ string function GetMapDisplayNameAllCaps( string mapname )
 string function GetMapDisplayName( string mapname )
 {
 	if ( IsMapCustom(mapname) ) {
-		return "todo"
+		return GetCustomMapDisplayName(mapname)
 	}
 
 	return "#" + mapname
@@ -410,6 +410,37 @@ string function GetCampaignMapDisplayName( string mapname )
 string function GetMapDisplayDesc( string mapname )
 {
 	return "#" + mapname + "_CLASSIC_DESC"
+}
+
+string function GetCustomMapDisplayName( string mapname )
+{
+	// Remove "mp_" prefix
+	string res = mapname.slice(3)
+
+	// Remove underscores
+	res = StringReplace( res, "_", " ", true )
+
+	// Uppercase first letter
+	res = res.slice(0, 1).toupper() + res.slice(1)
+
+	// Uppercase each word
+	/// Early exit
+	if ( ! res.find(" ") )
+	{
+		return res
+	}
+
+	/// Uppercasing
+	for ( int i = 0; i < res.len(); i++ )
+	{
+		string c = res.slice(i, i+1 )
+		if ( c != " " )
+			continue
+
+		res = res.slice(0, i + 1) + res.slice(i + 1, i + 2).toupper() + res.slice(i + 2)
+	}
+
+	return res
 }
 
 /// Sends a string message to player

--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
@@ -21,6 +21,56 @@ struct
 	bool devUnlockedSPMissions
 } file
 
+const array<string> officialMaps = [
+	"mp_lobby",
+
+	"mp_forwardbase_kodai",
+	"mp_grave",
+	"mp_homestead",
+	"mp_thaw",
+	"mp_black_water_canal",
+	"mp_eden",
+	"mp_drydock",
+	"mp_crashsite3",
+	"mp_complex3",
+	"mp_angel_city",
+	"mp_colony02",
+	"mp_glitch",
+	"mp_lf_stacks",
+	"mp_lf_meadow",
+	"mp_lf_deck",
+	"mp_lf_traffic",
+	"mp_coliseum",
+	"mp_coliseum_column",
+	"mp_relic02",
+	"mp_wargames",
+	"mp_rise",
+	"mp_lf_township",
+	"mp_lf_uma",
+
+	// sp maps
+	"sp_training",
+	"sp_crashsite",
+	"sp_sewers1",
+	"sp_boomtown_start",
+	"sp_hub_timeshift",
+	"sp_beacon",
+	"sp_tday",
+	"sp_s2s",
+	"sp_skyway_v1",
+
+	// mp converted variants
+	"mp_training",
+	"mp_crashsite",
+	"mp_sewers1",
+	"mp_boomtown_start",
+	"mp_hub_timeshift",
+	"mp_beacon",
+	"mp_tday",
+	"mp_s2s",
+	"mp_skyway_v1"
+]
+
 void function ShUtilityAll_Init()
 {
 	#document( "DistanceAlongVector", "" )
@@ -333,6 +383,11 @@ string function GetTeamShortName( int team )
 	return ""
 }
 
+bool function IsMapCustom( string mapname )
+{
+	return !officialMaps.contains( mapname )
+}
+
 string function GetMapDisplayNameAllCaps( string mapname )
 {
 	return "#" + mapname + "_ALLCAPS"
@@ -340,6 +395,10 @@ string function GetMapDisplayNameAllCaps( string mapname )
 
 string function GetMapDisplayName( string mapname )
 {
+	if ( IsMapCustom(mapname) ) {
+		return "todo"
+	}
+
 	return "#" + mapname
 }
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
@@ -21,7 +21,6 @@ struct
 	bool devUnlockedSPMissions
 } file
 
-
 void function ShUtilityAll_Init()
 {
 	#document( "DistanceAlongVector", "" )

--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
@@ -334,19 +334,6 @@ string function GetTeamShortName( int team )
 	return ""
 }
 
-bool function IsMapCustom( string mapname )
-{
-	// SP map
-	foreach( int i, table data in LEVEL_UNLOCKS_COUNT )
-	{
-		if ( data.level == mapname )
-			return false
-	}
-
-	// MP map
-	return ! GetPrivateMatchMaps().contains( mapname )
-}
-
 string function GetMapDisplayNameAllCaps( string mapname )
 {
 	return "#" + mapname + "_ALLCAPS"
@@ -354,10 +341,6 @@ string function GetMapDisplayNameAllCaps( string mapname )
 
 string function GetMapDisplayName( string mapname )
 {
-	if ( IsMapCustom(mapname) ) {
-		return GetCustomMapDisplayName(mapname)
-	}
-
 	return "#" + mapname
 }
 
@@ -369,37 +352,6 @@ string function GetCampaignMapDisplayName( string mapname )
 string function GetMapDisplayDesc( string mapname )
 {
 	return "#" + mapname + "_CLASSIC_DESC"
-}
-
-string function GetCustomMapDisplayName( string mapname )
-{
-	// Remove "mp_" prefix
-	string res = mapname.slice(3)
-
-	// Remove underscores
-	res = StringReplace( res, "_", " ", true )
-
-	// Uppercase first letter
-	res = res.slice(0, 1).toupper() + res.slice(1)
-
-	// Uppercase each word
-	/// Early exit
-	if ( ! res.find(" ") )
-	{
-		return res
-	}
-
-	/// Uppercasing
-	for ( int i = 0; i < res.len(); i++ )
-	{
-		string c = res.slice(i, i+1 )
-		if ( c != " " )
-			continue
-
-		res = res.slice(0, i + 1) + res.slice(i + 1, i + 2).toupper() + res.slice(i + 2)
-	}
-
-	return res
 }
 
 /// Sends a string message to player

--- a/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/sh_utility_all.gnut
@@ -21,55 +21,6 @@ struct
 	bool devUnlockedSPMissions
 } file
 
-const array<string> officialMaps = [
-	"mp_lobby",
-
-	"mp_forwardbase_kodai",
-	"mp_grave",
-	"mp_homestead",
-	"mp_thaw",
-	"mp_black_water_canal",
-	"mp_eden",
-	"mp_drydock",
-	"mp_crashsite3",
-	"mp_complex3",
-	"mp_angel_city",
-	"mp_colony02",
-	"mp_glitch",
-	"mp_lf_stacks",
-	"mp_lf_meadow",
-	"mp_lf_deck",
-	"mp_lf_traffic",
-	"mp_coliseum",
-	"mp_coliseum_column",
-	"mp_relic02",
-	"mp_wargames",
-	"mp_rise",
-	"mp_lf_township",
-	"mp_lf_uma",
-
-	// sp maps
-	"sp_training",
-	"sp_crashsite",
-	"sp_sewers1",
-	"sp_boomtown_start",
-	"sp_hub_timeshift",
-	"sp_beacon",
-	"sp_tday",
-	"sp_s2s",
-	"sp_skyway_v1",
-
-	// mp converted variants
-	"mp_training",
-	"mp_crashsite",
-	"mp_sewers1",
-	"mp_boomtown_start",
-	"mp_hub_timeshift",
-	"mp_beacon",
-	"mp_tday",
-	"mp_s2s",
-	"mp_skyway_v1"
-]
 
 void function ShUtilityAll_Init()
 {
@@ -385,7 +336,15 @@ string function GetTeamShortName( int team )
 
 bool function IsMapCustom( string mapname )
 {
-	return !officialMaps.contains( mapname )
+	// SP map
+	foreach( int i, table data in LEVEL_UNLOCKS_COUNT )
+	{
+		if ( data.level == mapname )
+			return false
+	}
+
+	// MP map
+	return ! GetPrivateMatchMaps().contains( mapname )
 }
 
 string function GetMapDisplayNameAllCaps( string mapname )


### PR DESCRIPTION
Since we're starting to have custom maps, this PR formats map names so that they're not displayed as "#mp_[...]".
This PR tools the `GetMapDisplayName` method, which now detects custom maps and formats their name accordingly.

#### Without PR

<img width="972" height="525" alt="image" src="https://github.com/user-attachments/assets/b2d49260-ac15-4dc6-941d-1463c4642535" />

#### With PR

<img width="972" height="525" alt="image" src="https://github.com/user-attachments/assets/b3c4180f-8bb1-4d42-86fc-444df088951f" />

---

I implemented this in `CustomServers`, maybe this should be in `Client`? idk