### PR TITLE
Update .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
 # git config --global blame.ignoreRevsFile .git-blame-ignore-revs
 
 # sqformat commit
-69fe45d039aabbba195c0e6aa38a0f705e482e34
+ebf89c805e96de91bc4d069cfa38aafb0ae34f32


### PR DESCRIPTION
Commit hash changed when merging into main, need to update the ignore revs.

Current commit: https://github.com/R2Northstar/NorthstarMods/commit/ebf89c805e96de91bc4d069cfa38aafb0ae34f32