### PR TITLE
Add console shortcuts for some script functions

### DIFF
--- a/Northstar.Custom/mod.json
+++ b/Northstar.Custom/mod.json
@@ -468,6 +468,10 @@
 		  "ServerCallback": {
 				"Before": "Server_CustomScoreboardColumns_Init"
 		  }
+		},
+		{
+			"Path": "sh_console_shortcuts.nut",
+			"RunOn": "CLIENT || SERVER || UI"
 		}
 	],
 

--- a/Northstar.Custom/mod/scripts/vscripts/sh_console_shortcuts.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/sh_console_shortcuts.nut
@@ -1,4 +1,3 @@
-
 #if !UI
 	global function gwep // GetActiveWeapon
 #endif

--- a/Northstar.Custom/mod/scripts/vscripts/sh_console_shortcuts.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/sh_console_shortcuts.nut
@@ -21,18 +21,18 @@
 #if !SERVER
 	entity function glc()
 	{
-	    #if UI
+		#if UI
 			return GetUIPlayer()
-	    #else
+		#else
 			return GetLocalClientPlayer()
 		#endif
 	}
 
 	entity function glv()
 	{
-	    #if UI
+		#if UI
 			return GetUIPlayer()
-	    #else
+		#else
 			return GetLocalViewPlayer()
 		#endif
 	}

--- a/Northstar.Custom/mod/scripts/vscripts/sh_console_shortcuts.nut
+++ b/Northstar.Custom/mod/scripts/vscripts/sh_console_shortcuts.nut
@@ -1,0 +1,39 @@
+
+#if !UI
+	global function gwep // GetActiveWeapon
+#endif
+
+#if !SERVER
+	global function glc // GetLocalClientPlayer
+	global function glv // GetLocalViewPlayer
+#endif
+
+#if !UI
+	entity function gwep( entity ent )
+	{
+		if ( !IsValid( ent ) )
+			return null
+
+		return ent.GetActiveWeapon()
+	}
+#endif
+
+#if !SERVER
+	entity function glc()
+	{
+	    #if UI
+			return GetUIPlayer()
+	    #else
+			return GetLocalClientPlayer()
+		#endif
+	}
+
+	entity function glv()
+	{
+	    #if UI
+			return GetUIPlayer()
+	    #else
+			return GetLocalViewPlayer()
+		#endif
+	}
+#endif

--- a/Northstar.CustomServers/mod/scripts/vscripts/_utility_shared.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_utility_shared.nut
@@ -88,14 +88,12 @@ void function Utility_Shared_Init()
 	#document( "ArrayWithin", "Remove ents from array that are out of range" )
 }
 
-#if DEV
-	// short cut for the console
-	// script gp()[0].Die( gp()[1] )
-	array<entity> function gp()
-	{
-		return GetPlayerArray()
-	}
-#endif
+// short cut for the console
+// script gp()[0].Die( gp()[1] )
+array<entity> function gp()
+{
+	return GetPlayerArray()
+}
 
 void function InitWeaponScripts()
 {


### PR DESCRIPTION
`gp` is a shortcut for `GetPlayerArray` meant for the console that was added in tf1 and its still found on tf2, but hidden behind dev mode. I just removed the dev mode checks and added similar functions to a couple other useful ones, so people don't have to type in the full thing every time. Nothing too crazy, just a small convenient thing to have

glc -> `GetLocalClientPlayer` (`GetUiPlayer` in UI vm)
glv -> `GetLocalViewPlayer` (`GetUiPlayer` in UI vm)
gwep -> `GetActiveWeapon`