### PR TITLE
Fix `GameTime_PlayingTime()`

### DIFF
--- a/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
@@ -4080,15 +4080,15 @@ int function GameTime_TimeLeftSeconds()
 	if ( IsRoundBased() )
 	{
 		if ( GetGameState() > eGameState.SuddenDeath )
-			return int( expect float( GetServerVar( "roundEndTime" ) ) - expect float( GetServerVar( "roundStartTime" ) ) )
+			return floor( expect float( GetServerVar( "roundEndTime" ) ) - expect float( GetServerVar( "roundStartTime" ) ) ).tointeger()
 
-		return int( expect float( GetServerVar( "roundEndTime" ) ) - Time() )
+		return floor( expect float( GetServerVar( "roundEndTime" ) ) - Time() ).tointeger()
 	}
 
 	if ( GetGameState() > eGameState.SuddenDeath )
-		return int( expect float( GetServerVar( "gameEndTime" ) ) - expect float( GetServerVar( "gameStartTime" ) ) )
+		return floor( expect float( GetServerVar( "gameEndTime" ) ) - expect float( GetServerVar( "gameStartTime" ) ) ).tointeger()
 
-	return int( expect float( GetServerVar( "gameEndTime" ) ) - Time() )
+	return floor( expect float( GetServerVar( "gameEndTime" ) ) - Time() ).tointeger()
 }
 
 // WARN: this function includes WaitingForPlayers and Prematch duration!

--- a/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
@@ -4016,10 +4016,11 @@ int function GameTime_TimeLimitSeconds()
 	}
 	else
 	{
-		if ( IsSuddenDeathGameMode() && GetGameState() == eGameState.SuddenDeath )
-			return ( GetTimeLimit_ForGameMode() * 60.0 ).tointeger() + ( GetSuddenDeathTimeLimit_ForGameMode() * 60.0 ).tointeger()
-		else
-			return ( GetTimeLimit_ForGameMode() * 60.0 ).tointeger()
+		// handled by GetTimeLimit_ForGameMode()
+		// if ( IsSuddenDeathGameMode() && GetGameState() == eGameState.SuddenDeath )
+		// 	return ( GetTimeLimit_ForGameMode() * 60.0 ).tointeger() + ( GetSuddenDeathTimeLimit_ForGameMode() * 60.0 ).tointeger()
+		// else
+		return ( GetTimeLimit_ForGameMode() * 60.0 ).tointeger()
 	}
 	unreachable
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
@@ -4045,10 +4045,11 @@ int function GameTime_TimeLeftMinutes()
 {
 	if ( GetGameState() == eGameState.WaitingForPlayers )
 		return 0
+
 	if ( GetGameState() == eGameState.Prematch )
 		return int( ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) / 60.0 )
 
-	return floor( GameTime_PlayingTime() / 60 ).tointeger()
+	return floor( ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) / 60 ).tointeger()
 }
 
 int function GameTime_TimeLeftSeconds()
@@ -4056,7 +4057,7 @@ int function GameTime_TimeLeftSeconds()
 	if ( GetGameState() == eGameState.Prematch )
 		return int( expect float( GetServerVar( "gameStartTime" ) ) - Time() )
 
-	return GameTime_PlayingTime().tointeger()
+	return int( expect float( GetServerVar( "gameEndTime" ) ) - Time() )
 }
 
 // WARN: this function includes WaitingForPlayers and Prematch duration!
@@ -4074,7 +4075,13 @@ int function GameTime_Minutes()
 // this function only counts the time limit during eGameState.Playing
 float function GameTime_PlayingTime()
 {
+	return GameTime_PlayingTimeSince( Time() )
+}
+
+float function GameTime_PlayingTimeSince( float sinceTime )
+{
 	int gameState = GetGameState()
+
 	if ( gameState < eGameState.Playing )
 		return 0
 
@@ -4083,15 +4090,16 @@ float function GameTime_PlayingTime()
 		if ( gameState > eGameState.SuddenDeath )
 			return ( expect float( GetServerVar( "roundEndTime" ) ) - expect float( GetServerVar( "roundStartTime" ) ) )
 		else
-			return floor( expect float( GetServerVar( "roundEndTime" ) ) - Time() )
+			return sinceTime - expect float( GetServerVar( "roundStartTime" ) )
 	}
 	else
 	{
 		if ( gameState > eGameState.SuddenDeath )
 			return ( expect float( GetServerVar( "gameEndTime" ) ) - expect float( GetServerVar( "gameStartTime" ) ) )
 		else
-			return floor( expect float( GetServerVar( "gameEndTime" ) ) - Time() )
+			return sinceTime - expect float( GetServerVar( "gameStartTime" ) )
 	}
+
 	unreachable
 }
 

--- a/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
@@ -4046,27 +4046,7 @@ int function GameTime_TimeLeftMinutes()
 	if ( GetGameState() == eGameState.Prematch )
 		return int( ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) / 60.0 )
 
-	if ( GetGameState() < eGameState.Playing )
-		return 0
-
-	float playingTime = 0.0
-
-	if ( IsRoundBased() )
-	{
-		if ( GetGameState() > eGameState.SuddenDeath )
-			playingTime = expect float( GetServerVar( "roundEndTime" ) ) - expect float( GetServerVar( "roundStartTime" ) )
-		else
-			playingTime = expect float( GetServerVar( "roundEndTime" ) ) - Time()
-	}
-	else
-	{
-		if ( GetGameState() > eGameState.SuddenDeath )
-			playingTime = expect float( GetServerVar( "gameEndTime" ) ) - expect float( GetServerVar( "gameStartTime" ) )
-		else
-			playingTime = expect float( GetServerVar( "gameEndTime" ) ) - Time()
-	}
-
-	return floor( playingTime / 60 ).tointeger()
+	return floor( GameTime_TimeLimitMinutes() - GameTime_PlayingTime() / 60 ).tointeger()
 }
 
 int function GameTime_TimeLeftSeconds()
@@ -4074,21 +4054,7 @@ int function GameTime_TimeLeftSeconds()
 	if ( GetGameState() == eGameState.Prematch )
 		return int( expect float( GetServerVar( "gameStartTime" ) ) - Time() )
 
-	if ( GetGameState() < eGameState.Playing )
-		return 0
-
-	if ( IsRoundBased() )
-	{
-		if ( GetGameState() > eGameState.SuddenDeath )
-			return floor( expect float( GetServerVar( "roundEndTime" ) ) - expect float( GetServerVar( "roundStartTime" ) ) ).tointeger()
-
-		return floor( expect float( GetServerVar( "roundEndTime" ) ) - Time() ).tointeger()
-	}
-
-	if ( GetGameState() > eGameState.SuddenDeath )
-		return floor( expect float( GetServerVar( "gameEndTime" ) ) - expect float( GetServerVar( "gameStartTime" ) ) ).tointeger()
-
-	return floor( expect float( GetServerVar( "gameEndTime" ) ) - Time() ).tointeger()
+	return floor( GameTime_TimeLimitSeconds() - GameTime_PlayingTime() ).tointeger()
 }
 
 // WARN: this function includes WaitingForPlayers and Prematch duration!

--- a/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
@@ -4049,13 +4049,41 @@ int function GameTime_TimeLeftMinutes()
 	if ( GetGameState() == eGameState.Prematch )
 		return int( ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) / 60.0 )
 
-	return floor( ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) / 60 ).tointeger()
+	float playingTime = 0.0
+
+	if ( IsRoundBased() )
+	{
+		if ( GetGameState() > eGameState.SuddenDeath )
+			playingTime = expect float( GetServerVar( "roundEndTime" ) ) - expect float( GetServerVar( "roundStartTime" ) )
+		else
+			playingTime = expect float( GetServerVar( "roundEndTime" ) ) - Time()
+	}
+	else
+	{
+		if ( GetGameState() > eGameState.SuddenDeath )
+			playingTime = expect float( GetServerVar( "gameEndTime" ) ) - expect float( GetServerVar( "gameStartTime" ) )
+		else
+			playingTime = expect float( GetServerVar( "gameEndTime" ) ) - Time()
+	}
+
+	return floor( ( playingTime - Time() ) / 60 ).tointeger()
 }
 
 int function GameTime_TimeLeftSeconds()
 {
 	if ( GetGameState() == eGameState.Prematch )
 		return int( expect float( GetServerVar( "gameStartTime" ) ) - Time() )
+
+	if ( IsRoundBased() )
+	{
+		if ( GetGameState() > eGameState.SuddenDeath )
+			return int( expect float( GetServerVar( "roundEndTime" ) ) - expect float( GetServerVar( "roundStartTime" ) ) )
+
+		return int( expect float( GetServerVar( "roundEndTime" ) ) - Time() )
+	}
+
+	if ( GetGameState() > eGameState.SuddenDeath )
+		return int( expect float( GetServerVar( "gameEndTime" ) ) - expect float( GetServerVar( "gameStartTime" ) ) )
 
 	return int( expect float( GetServerVar( "gameEndTime" ) ) - Time() )
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/_utility.gnut
@@ -4043,11 +4043,11 @@ int function GameTime_TimeLimitMinutes()
 
 int function GameTime_TimeLeftMinutes()
 {
-	if ( GetGameState() == eGameState.WaitingForPlayers )
-		return 0
-
 	if ( GetGameState() == eGameState.Prematch )
 		return int( ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) / 60.0 )
+
+	if ( GetGameState() < eGameState.Playing )
+		return 0
 
 	float playingTime = 0.0
 
@@ -4066,13 +4066,16 @@ int function GameTime_TimeLeftMinutes()
 			playingTime = expect float( GetServerVar( "gameEndTime" ) ) - Time()
 	}
 
-	return floor( ( playingTime - Time() ) / 60 ).tointeger()
+	return floor( playingTime / 60 ).tointeger()
 }
 
 int function GameTime_TimeLeftSeconds()
 {
 	if ( GetGameState() == eGameState.Prematch )
 		return int( expect float( GetServerVar( "gameStartTime" ) ) - Time() )
+
+	if ( GetGameState() < eGameState.Playing )
+		return 0
 
 	if ( IsRoundBased() )
 	{

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -410,11 +410,11 @@ void function StartGameWithoutClassicMP()
 		if ( IsAlive( player ) )
 			player.Die()
 
+	WaitFrame() // wait for callbacks to finish
+
 	// need these otherwise game will complain
 	SetServerVar( "gameStartTime", Time() )
 	SetServerVar( "roundStartTime", Time() )
-
-	WaitFrame() // wait for callbacks to finish
 
 	foreach ( entity player in GetPlayerArray() )
 	{

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -103,13 +103,13 @@ void function PIN_GameStart()
 
 void function GameEndTimeVarChanged()
 {
-	if ( GetGameState() > eGameState.SuddenDeath )
+	if ( GetGameState() <= eGameState.SuddenDeath )
 		file.timeLimitOverride = ( ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) ) / 60.0
 }
 
 void function RoundEndTimeVarChanged()
 {
-	if ( GetGameState() > eGameState.SuddenDeath )
+	if ( GetGameState() <= eGameState.SuddenDeath )
 		file.timeLimitOverride =
 			( ( expect float( GetServerVar( "roundEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "roundStartTime" ) ) - Time() ) ) / 60.0
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -94,13 +94,14 @@ void function PIN_GameStart()
 void function GameEndTimeVarChanged()
 {
 	if ( GetGameState() <= eGameState.SuddenDeath )
-		file.timeLimitOverride = ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) / 60.0
+		file.timeLimitOverride = ( ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) ) / 60.0
 }
 
 void function RoundEndTimeVarChanged()
 {
 	if ( GetGameState() <= eGameState.SuddenDeath )
-		file.timeLimitOverride = ( expect float( GetServerVar( "roundEndTime" ) ) - Time() ) / 60.0
+		file.timeLimitOverride =
+			( ( expect float( GetServerVar( "roundEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "roundStartTime" ) ) - Time() ) ) / 60.0
 }
 
 void function GameState_EntitiesDidLoad()
@@ -414,11 +415,11 @@ void function GameStateEnter_Prematch()
 	if ( IsRoundBased() )
 		timeLimit = int( GameMode_GetRoundTimeLimit( GAMETYPE ) * 60 )
 
-	SetServerVar( "gameEndTime", Time() + timeLimit + ClassicMP_GetIntroLength() )
-	SetServerVar( "roundEndTime", Time() + timeLimit + ClassicMP_GetIntroLength() )
-
 	if ( !GetClassicMPMode() && !ClassicMP_ShouldTryIntroAndEpilogueWithoutClassicMP() )
 		thread StartGameWithoutClassicMP()
+
+	SetServerVar( "gameEndTime", Time() + timeLimit + ClassicMP_GetIntroLength() )
+	SetServerVar( "roundEndTime", Time() + timeLimit + ClassicMP_GetIntroLength() )
 
 	// Initialise any spectators. Hopefully they are all initialised already in CodeCallback_OnClientConnectionCompleted
 	// (_base_gametype_mp.gnut) but for modes like LTS this doesn't seem to happen late enough to work properly.
@@ -435,11 +436,11 @@ void function StartGameWithoutClassicMP()
 		if ( IsAlive( player ) )
 			player.Die()
 
-	WaitFrame() // wait for callbacks to finish
-
 	// need these otherwise game will complain
 	SetServerVar( "gameStartTime", Time() )
 	SetServerVar( "roundStartTime", Time() )
+
+	WaitFrame() // wait for callbacks to finish
 
 	foreach ( entity player in GetPlayerArray() )
 	{

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -25,7 +25,6 @@ global function GameState_SetTimeLimitOverride
 global function IsRoundBasedGameOver
 global function ShouldRunEvac
 global function GiveTitanToPlayer
-global function GetTimeLimit_ForGameMode
 
 struct
 {
@@ -1085,25 +1084,6 @@ bool function ShouldRunEvac()
 
 void function GiveTitanToPlayer( entity player )
 {
-}
-
-float function GetTimeLimit_ForGameMode()
-{
-	#if DEV
-		if ( level.devForcedTimeLimit )
-		{
-			level.devForcedTimeLimit = 0
-			return 0.1
-		}
-	#endif
-
-	if ( GameState_GetTimeLimitOverride() >= 0 )
-		return GameState_GetTimeLimitOverride()
-
-	if ( !GameMode_IsDefined( GAMETYPE ) )
-		return GetCurrentPlaylistVarFloat( "timelimit", 10 )
-
-	return GameMode_GetTimeLimit( GAMETYPE ).tofloat() // not a float for some reason?
 }
 
 void function DialoguePlayNormal()

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -1057,7 +1057,6 @@ float function GetTimeLimit_ForGameMode()
 	#if DEV
 		if ( level.devForcedTimeLimit )
 		{
-			// Make it needed to be called multiple times for RoundBasedGameModes
 			level.devForcedTimeLimit = 0
 			return 0.1
 		}
@@ -1069,7 +1068,7 @@ float function GetTimeLimit_ForGameMode()
 	if ( !GameMode_IsDefined( GAMETYPE ) )
 		return GetCurrentPlaylistVarFloat( "timelimit", 10 )
 
-	return GameMode_GetRoundTimeLimit( GAMETYPE )
+	return GameMode_GetTimeLimit( GAMETYPE ).tofloat() // not a float for some reason?
 }
 
 void function DialoguePlayNormal()

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -103,13 +103,13 @@ void function PIN_GameStart()
 
 void function GameEndTimeVarChanged()
 {
-	if ( GetGameState() != eGameState.WinnerDetermined ) // WinnerDetermined always sets it to Time()
+	if ( GetGameState() > eGameState.SuddenDeath )
 		file.timeLimitOverride = ( ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) ) / 60.0
 }
 
 void function RoundEndTimeVarChanged()
 {
-	if ( GetGameState() != eGameState.WinnerDetermined ) // WinnerDetermined always sets it to Time()
+	if ( GetGameState() > eGameState.SuddenDeath )
 		file.timeLimitOverride =
 			( ( expect float( GetServerVar( "roundEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "roundStartTime" ) ) - Time() ) ) / 60.0
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -81,7 +81,17 @@ void function PIN_GameStart()
 	SetServerVar( "switchedSides", 0 )
 	SetServerVar( "winningTeam", -1 )
 
+	AddCallback_GameStateEnter( eGameState.WaitingForCustomStart, GameStateEnter_WaitingForCustomStart )
+	AddCallback_GameStateEnter( eGameState.WaitingForPlayers, GameStateEnter_WaitingForPlayers )
 	AddCallback_OnClientConnected( WaitingForPlayers_ClientConnected )
+
+	AddCallback_GameStateEnter( eGameState.PickLoadout, GameStateEnter_PickLoadout )
+	AddCallback_GameStateEnter( eGameState.Prematch, GameStateEnter_Prematch )
+	AddCallback_GameStateEnter( eGameState.Playing, GameStateEnter_Playing )
+	AddCallback_GameStateEnter( eGameState.WinnerDetermined, GameStateEnter_WinnerDetermined )
+	AddCallback_GameStateEnter( eGameState.SwitchingSides, GameStateEnter_SwitchingSides )
+	AddCallback_GameStateEnter( eGameState.SuddenDeath, GameStateEnter_SuddenDeath )
+	AddCallback_GameStateEnter( eGameState.Postmatch, GameStateEnter_Postmatch )
 
 	AddCallback_OnPlayerKilled( OnPlayerKilled )
 	AddDeathCallback( "npc_titan", OnTitanKilled )
@@ -92,15 +102,22 @@ void function PIN_GameStart()
 
 void function GameEndTimeVarChanged()
 {
-	if ( GetGameState() <= eGameState.SuddenDeath )
-		file.timeLimitOverride = ( ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) ) / 60.0
+	if ( GetGameState() > eGameState.SuddenDeath )
+		return
+
+	float startTime = GetServerVar( "gameStartTime" ) != null ? ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) : 0.0
+
+	file.timeLimitOverride = ( ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) - startTime ) / 60.0
 }
 
 void function RoundEndTimeVarChanged()
 {
-	if ( GetGameState() <= eGameState.SuddenDeath )
-		file.timeLimitOverride =
-			( ( expect float( GetServerVar( "roundEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "roundStartTime" ) ) - Time() ) ) / 60.0
+	if ( GetGameState() > eGameState.SuddenDeath )
+		return
+
+	float startTime = GetServerVar( "roundStartTime" ) != null ? ( expect float( GetServerVar( "roundStartTime" ) ) - Time() ) : 0.0
+
+	file.timeLimitOverride = ( ( expect float( GetServerVar( "roundEndTime" ) ) - Time() ) - startTime ) / 60.0
 }
 
 void function GameState_EntitiesDidLoad()
@@ -162,48 +179,6 @@ void function SetGameState( int newState )
 	// added in AddCallback_GameStateEnter
 	foreach ( callbackFunc in svGlobal.gameStateEnterCallbacks[ newState ] )
 		callbackFunc()
-
-	switch ( newState )
-	{
-		case eGameState.WaitingForCustomStart:
-			GameStateEnter_WaitingForCustomStart()
-			break
-
-		case eGameState.WaitingForPlayers:
-			GameStateEnter_WaitingForPlayers()
-			break
-
-		case eGameState.PickLoadout:
-			GameStateEnter_PickLoadout()
-			break
-
-		case eGameState.Prematch:
-			GameStateEnter_Prematch()
-			break
-
-		case eGameState.Playing:
-			GameStateEnter_Playing()
-			break
-
-		case eGameState.SuddenDeath:
-			GameStateEnter_SuddenDeath()
-			break
-
-		case eGameState.WinnerDetermined:
-			GameStateEnter_WinnerDetermined()
-			break
-
-		case eGameState.SwitchingSides:
-			GameStateEnter_SwitchingSides()
-			break
-
-		case eGameState.Epilogue:
-			break
-
-		case eGameState.Postmatch:
-			GameStateEnter_Postmatch()
-			break
-	}
 }
 
 void function AddTeamScore( int team, int amount )
@@ -414,11 +389,11 @@ void function GameStateEnter_Prematch()
 	if ( IsRoundBased() )
 		timeLimit = int( GameMode_GetRoundTimeLimit( GAMETYPE ) * 60 )
 
-	if ( !GetClassicMPMode() && !ClassicMP_ShouldTryIntroAndEpilogueWithoutClassicMP() )
-		thread StartGameWithoutClassicMP()
-
 	SetServerVar( "gameEndTime", Time() + timeLimit + ClassicMP_GetIntroLength() )
 	SetServerVar( "roundEndTime", Time() + timeLimit + ClassicMP_GetIntroLength() )
+
+	if ( !GetClassicMPMode() && !ClassicMP_ShouldTryIntroAndEpilogueWithoutClassicMP() )
+		thread StartGameWithoutClassicMP()
 
 	// Initialise any spectators. Hopefully they are all initialised already in CodeCallback_OnClientConnectionCompleted
 	// (_base_gametype_mp.gnut) but for modes like LTS this doesn't seem to happen late enough to work properly.

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -73,6 +73,7 @@ struct
 void function PIN_GameStart()
 {
 	RegisterServerVarChangeCallback( "gameEndTime", GameEndTimeVarChanged )
+	RegisterServerVarChangeCallback( "roundEndTime", RoundEndTimeVarChanged )
 	// todo: using the pin telemetry function here, weird and was done veeery early on before i knew how this all worked, should use a different one
 
 	// called from InitGameState
@@ -102,7 +103,15 @@ void function PIN_GameStart()
 
 void function GameEndTimeVarChanged()
 {
-	file.timeLimitOverride = ( ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) ) / 60.0
+	if ( GetGameState() != eGameState.WinnerDetermined ) // WinnerDetermined always sets it to Time()
+		file.timeLimitOverride = ( ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) ) / 60.0
+}
+
+void function RoundEndTimeVarChanged()
+{
+	if ( GetGameState() != eGameState.WinnerDetermined ) // WinnerDetermined always sets it to Time()
+		file.timeLimitOverride =
+			( ( expect float( GetServerVar( "roundEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "roundStartTime" ) ) - Time() ) ) / 60.0
 }
 
 void function GameState_EntitiesDidLoad()

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -82,8 +82,6 @@ void function PIN_GameStart()
 	SetServerVar( "switchedSides", 0 )
 	SetServerVar( "winningTeam", -1 )
 
-	AddCallback_GameStateEnter( eGameState.WaitingForCustomStart, GameStateEnter_WaitingForCustomStart )
-	AddCallback_GameStateEnter( eGameState.WaitingForPlayers, GameStateEnter_WaitingForPlayers )
 	AddCallback_OnClientConnected( WaitingForPlayers_ClientConnected )
 
 	AddCallback_OnPlayerKilled( OnPlayerKilled )
@@ -96,14 +94,13 @@ void function PIN_GameStart()
 void function GameEndTimeVarChanged()
 {
 	if ( GetGameState() <= eGameState.SuddenDeath )
-		file.timeLimitOverride = ( ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) ) / 60.0
+		file.timeLimitOverride = ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) / 60.0
 }
 
 void function RoundEndTimeVarChanged()
 {
 	if ( GetGameState() <= eGameState.SuddenDeath )
-		file.timeLimitOverride =
-			( ( expect float( GetServerVar( "roundEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "roundStartTime" ) ) - Time() ) ) / 60.0
+		file.timeLimitOverride = ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) / 60.0
 }
 
 void function GameState_EntitiesDidLoad()
@@ -414,8 +411,11 @@ void function GameStateEnter_Prematch()
 	if ( file.switchSidesBased )
 		timeLimit /= 2 // endtime is half of total per side
 
+	if ( IsRoundBased() )
+		timeLimit = int( GameMode_GetRoundTimeLimit( GAMETYPE ) * 60 )
+
 	SetServerVar( "gameEndTime", Time() + timeLimit + ClassicMP_GetIntroLength() )
-	SetServerVar( "roundEndTime", Time() + ClassicMP_GetIntroLength() + GameMode_GetRoundTimeLimit( GAMETYPE ) * 60 )
+	SetServerVar( "roundEndTime", Time() + timeLimit + ClassicMP_GetIntroLength() )
 
 	if ( !GetClassicMPMode() && !ClassicMP_ShouldTryIntroAndEpilogueWithoutClassicMP() )
 		thread StartGameWithoutClassicMP()

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -21,6 +21,7 @@ global function AddTeamScore
 global function GetWinningTeamWithFFASupport
 
 global function GameState_GetTimeLimitOverride
+global function GameState_SetTimeLimitOverride
 global function IsRoundBasedGameOver
 global function ShouldRunEvac
 global function GiveTitanToPlayer
@@ -58,6 +59,7 @@ struct
 
 	array<void functionref()> roundEndCleanupCallbacks
 	bool functionref( entity victim, entity attacker, var damageInfo, bool isRoundEnd ) shouldTryUseProjectileReplayCallback
+	float timeLimitOverride = -1
 } file
 
 /*
@@ -70,6 +72,7 @@ struct
 
 void function PIN_GameStart()
 {
+	RegisterServerVarChangeCallback( "gameEndTime", GameEndTimeVarChanged )
 	// todo: using the pin telemetry function here, weird and was done veeery early on before i knew how this all worked, should use a different one
 
 	// called from InitGameState
@@ -95,6 +98,11 @@ void function PIN_GameStart()
 	AddCallback_EntityChangedTeam( "player", OnPlayerChangedTeam )
 
 	RegisterSignal( "CleanUpEntitiesForRoundEnd" )
+}
+
+void function GameEndTimeVarChanged()
+{
+	file.timeLimitOverride = ( ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) - ( expect float( GetServerVar( "gameStartTime" ) ) - Time() ) ) / 60.0
 }
 
 void function GameState_EntitiesDidLoad()
@@ -1013,7 +1021,12 @@ int function GetWinningTeamWithFFASupport()
 
 float function GameState_GetTimeLimitOverride()
 {
-	return 100
+	return file.timeLimitOverride
+}
+
+void function GameState_SetTimeLimitOverride( float timeLimitOverride )
+{
+	file.timeLimitOverride = timeLimitOverride
 }
 
 bool function IsRoundBasedGameOver()
@@ -1032,11 +1045,22 @@ void function GiveTitanToPlayer( entity player )
 
 float function GetTimeLimit_ForGameMode()
 {
-	string mode = GameRules_GetGameMode()
-	string playlistString = "timelimit"
+	#if DEV
+		if ( level.devForcedTimeLimit )
+		{
+			// Make it needed to be called multiple times for RoundBasedGameModes
+			level.devForcedTimeLimit = 0
+			return 0.1
+		}
+	#endif
 
-	// default to 10 mins, because that seems reasonable
-	return GetCurrentPlaylistVarFloat( playlistString, 10 )
+	if ( GameState_GetTimeLimitOverride() >= 0 )
+		return GameState_GetTimeLimitOverride()
+
+	if ( !GameMode_IsDefined( GAMETYPE ) )
+		return GetCurrentPlaylistVarFloat( "timelimit", 10 )
+
+	return GameMode_GetRoundTimeLimit( GAMETYPE )
 }
 
 void function DialoguePlayNormal()

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -86,14 +86,6 @@ void function PIN_GameStart()
 	AddCallback_GameStateEnter( eGameState.WaitingForPlayers, GameStateEnter_WaitingForPlayers )
 	AddCallback_OnClientConnected( WaitingForPlayers_ClientConnected )
 
-	AddCallback_GameStateEnter( eGameState.PickLoadout, GameStateEnter_PickLoadout )
-	AddCallback_GameStateEnter( eGameState.Prematch, GameStateEnter_Prematch )
-	AddCallback_GameStateEnter( eGameState.Playing, GameStateEnter_Playing )
-	AddCallback_GameStateEnter( eGameState.WinnerDetermined, GameStateEnter_WinnerDetermined )
-	AddCallback_GameStateEnter( eGameState.SwitchingSides, GameStateEnter_SwitchingSides )
-	AddCallback_GameStateEnter( eGameState.SuddenDeath, GameStateEnter_SuddenDeath )
-	AddCallback_GameStateEnter( eGameState.Postmatch, GameStateEnter_Postmatch )
-
 	AddCallback_OnPlayerKilled( OnPlayerKilled )
 	AddDeathCallback( "npc_titan", OnTitanKilled )
 	AddCallback_EntityChangedTeam( "player", OnPlayerChangedTeam )
@@ -173,6 +165,48 @@ void function SetGameState( int newState )
 	// added in AddCallback_GameStateEnter
 	foreach ( callbackFunc in svGlobal.gameStateEnterCallbacks[ newState ] )
 		callbackFunc()
+
+	switch ( newState )
+	{
+		case eGameState.WaitingForCustomStart:
+			GameStateEnter_WaitingForCustomStart()
+			break
+
+		case eGameState.WaitingForPlayers:
+			GameStateEnter_WaitingForPlayers()
+			break
+
+		case eGameState.PickLoadout:
+			GameStateEnter_PickLoadout()
+			break
+
+		case eGameState.Prematch:
+			GameStateEnter_Prematch()
+			break
+
+		case eGameState.Playing:
+			GameStateEnter_Playing()
+			break
+
+		case eGameState.SuddenDeath:
+			GameStateEnter_SuddenDeath()
+			break
+
+		case eGameState.WinnerDetermined:
+			GameStateEnter_WinnerDetermined()
+			break
+
+		case eGameState.SwitchingSides:
+			GameStateEnter_SwitchingSides()
+			break
+
+		case eGameState.Epilogue:
+			break
+
+		case eGameState.Postmatch:
+			GameStateEnter_Postmatch()
+			break
+	}
 }
 
 void function AddTeamScore( int team, int amount )

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_gamestate_mp.nut
@@ -100,7 +100,7 @@ void function GameEndTimeVarChanged()
 void function RoundEndTimeVarChanged()
 {
 	if ( GetGameState() <= eGameState.SuddenDeath )
-		file.timeLimitOverride = ( expect float( GetServerVar( "gameEndTime" ) ) - Time() ) / 60.0
+		file.timeLimitOverride = ( expect float( GetServerVar( "roundEndTime" ) ) - Time() ) / 60.0
 }
 
 void function GameState_EntitiesDidLoad()

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_utility_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_utility_mp.gnut
@@ -1,4 +1,4 @@
-globalize_all_funcitons
+globalize_all_functions
 
 void function Utility_MP_Init()
 {

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_utility_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_utility_mp.gnut
@@ -1,6 +1,4 @@
-global function Utility_MP_Init
-global function ClientCommand_OnDevnetBugScreenshot
-global function SafeForTitanFall
+globalize_all_funcitons
 
 void function Utility_MP_Init()
 {
@@ -14,4 +12,22 @@ bool function ClientCommand_OnDevnetBugScreenshot( entity player, array<string> 
 bool function SafeForTitanFall( vector dropPoint )
 {
 	return true
+}
+
+float function GetTimeLimit_ForGameMode()
+{
+	#if DEV
+		if ( level.devForcedTimeLimit )
+			return 0.1
+	#endif
+
+	if ( GameState_GetTimeLimitOverride() >= 0 )
+		return GameState_GetTimeLimitOverride()
+
+	float timeLimit = GetCurrentPlaylistVarFloat( "timelimit", -1 )
+
+	if ( timeLimit == -1 )
+		timeLimit = float( GameMode_GetTimeLimit( GAMETYPE ) ) // not a float for some reason?
+
+	return timeLimit
 }

--- a/Northstar.CustomServers/mod/scripts/vscripts/mp/_utility_mp.gnut
+++ b/Northstar.CustomServers/mod/scripts/vscripts/mp/_utility_mp.gnut
@@ -1,4 +1,7 @@
-globalize_all_functions
+global function Utility_MP_Init
+global function ClientCommand_OnDevnetBugScreenshot
+global function SafeForTitanFall
+global function GetTimeLimit_ForGameMode
 
 void function Utility_MP_Init()
 {


### PR DESCRIPTION
Fixes `GameTime_PlayingTime()` being reversed

Fixes https://github.com/R2Northstar/NorthstarMods/blob/f2a6cdd14a71cb4b681b9d1f6c5aa8a6c5fd73ea/Northstar.CustomServers/mod/scripts/vscripts/mp/_base_gametype.gnut#L1174-L1192 and https://github.com/R2Northstar/NorthstarMods/blob/f2a6cdd14a71cb4b681b9d1f6c5aa8a6c5fd73ea/Northstar.CustomServers/mod/scripts/vscripts/titan/_replacement_titans.gnut#L407-L467

Correct (pr)
<img width="873" height="943" alt="image" src="https://github.com/user-attachments/assets/53a87e24-e8be-4c20-8a14-e516aa8f1270" />

Incorrect (current)
<img width="1020" height="964" alt="image" src="https://github.com/user-attachments/assets/a6dc00a4-3c99-4f5a-9048-f5ae0d457b4f" />
