### PR TITLE
Downloadable mod icon

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -1535,6 +1535,24 @@ array<string> function GetModVersions( string modName )
 	return versions
 }
 
+bool function IsModInstalled( string modName, string modVersion )
+{
+	array<string> versions = GetModVersions( modName )
+	if ( versions.len() == 0 ) {
+		return false
+	}
+
+	foreach( string version in versions )
+	{
+		if ( version == modVersion )
+		{
+			return true
+		}
+	}
+
+	return false
+}
+
 // escapes localisation by replacing # with ^FFFFFFFF#
 string function EscapeLocalisation( string input )
 {

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -1094,7 +1094,8 @@ string function FillInServerModsLabel( array<RequiredModInfo> mods )
 
 	foreach ( RequiredModInfo mod in mods )
 	{
-		ret += format( "  %s v%s\n", mod.name, mod.version )
+		string template = NSIsModDownloadable(mod.name, mod.version) ? "  %s v%s ^00ff0000(↓)^FFFFFFFF\n" : "  %s v%s\n"
+		ret += format( template, mod.name, mod.version )
 	}
 
 	return ret

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -1097,7 +1097,20 @@ string function FillInServerModsLabel( array<RequiredModInfo> mods )
 
 	foreach ( RequiredModInfo mod in mods )
 	{
-		string template = NSIsModDownloadable(mod.name, mod.version) ? "  %s v%s ^00ff0000(↓)^FFFFFFFF\n" : "  %s v%s\n"
+		string template = ""
+
+		// Display nothing if the mod is installed locally
+		if ( IsCoreMod(mod.name) || IsModInstalled(mod.name, mod.version))
+		{
+			template = "  %s v%s\n"
+		}
+
+		// Display a green checkmark if it can be downloaded, a red cross if not
+		else
+		{
+			template = NSIsModDownloadable(mod.name, mod.version) ? "  %s v%s ^00ff0000(↓)^FFFFFFFF\n" : "  %s v%s ^ff000000(x)^FFFFFFFF\n"
+		}
+
 		ret += format( template, mod.name, mod.version )
 	}
 

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -293,6 +293,9 @@ void function InitServerBrowserMenu()
 
 	// UI was cut off on some aspect ratios; not perfect
 	UpdateServerInfoBasedOnRes()
+
+	// Retrieve list of verified mods
+	thread NSFetchVerifiedModsManifesto()
 }
 
 // //////////////////////////

--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_ns_serverbrowser.nut
@@ -1100,15 +1100,14 @@ string function FillInServerModsLabel( array<RequiredModInfo> mods )
 		string template = ""
 
 		// Display nothing if the mod is installed locally
-		if ( IsCoreMod(mod.name) || IsModInstalled(mod.name, mod.version))
+		if ( IsCoreMod( mod.name ) || IsModInstalled( mod.name, mod.version ) )
 		{
 			template = "  %s v%s\n"
 		}
-
 		// Display a green checkmark if it can be downloaded, a red cross if not
 		else
 		{
-			template = NSIsModDownloadable(mod.name, mod.version) ? "  %s v%s ^00ff0000(↓)^FFFFFFFF\n" : "  %s v%s ^ff000000(x)^FFFFFFFF\n"
+			template = NSIsModDownloadable( mod.name, mod.version ) ? "  %s v%s ^00ff0000(↓)^FFFFFFFF\n" : "  %s v%s ^ff000000(x)^FFFFFFFF\n"
 		}
 
 		ret += format( template, mod.name, mod.version )
@@ -1551,11 +1550,12 @@ array<string> function GetModVersions( string modName )
 bool function IsModInstalled( string modName, string modVersion )
 {
 	array<string> versions = GetModVersions( modName )
-	if ( versions.len() == 0 ) {
+	if ( versions.len() == 0 )
+	{
 		return false
 	}
 
-	foreach( string version in versions )
+	foreach ( string version in versions )
 	{
 		if ( version == modVersion )
 		{


### PR DESCRIPTION
This PR makes approved mods more visible in the server browser:
- mods already installed (or ns core mods) are displayed as usual;
- mods which can be downloaded to join a server appear with a green checkmark;
- those which cannot be downloaded are displayed with a red cross.

<img width="524" height="511" alt="image" src="https://github.com/user-attachments/assets/eeb2441f-9b47-412a-9fb3-363cae2cda36" />

<img width="524" height="596" alt="image" src="https://github.com/user-attachments/assets/c16743bb-fe3a-453f-a8db-2bbc22938120" />


---

Part of [#883](https://github.com/R2Northstar/NorthstarLauncher/issues/883):

> Verified mods should be shown differently in the server browser UI, think funny checkmark or something