### PR TITLE
fix: Assign a background image to mp_lobby

### DIFF
--- a/Northstar.Client/mod/scripts/vscripts/ui/menu_private_match.nut
+++ b/Northstar.Client/mod/scripts/vscripts/ui/menu_private_match.nut
@@ -67,6 +67,8 @@ struct
 } file
 
 const table<asset> mapImages = {
+	mp_lobby = $"rui/menu/main_menu/spotlight_13",
+
 	mp_forwardbase_kodai = $"loadscreens/mp_forwardbase_kodai_lobby",
 	mp_grave = $"loadscreens/mp_grave_lobby",
 	mp_homestead = $"loadscreens/mp_homestead_lobby",


### PR DESCRIPTION
Currently, when a server is in the lobby, no background image is displayed in the server browser.

#### Without this PR

<img width="525" height="442" alt="image" src="https://github.com/user-attachments/assets/42b94f0b-97a3-4a45-8d5f-f843277270f8" />

#### With this PR

<img width="525" height="442" alt="image" src="https://github.com/user-attachments/assets/370bf9d3-8db3-4479-9aaa-e7b280c0e2ee" />

